### PR TITLE
Pin LocalStack default to 4.12, add start-latest and start-community make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ PROJECT_NAME ?= localstack-template
 ENVIRONMENT ?= dev
 AWS_ENDPOINT ?= http://localhost:4566
 AWS_REGION ?= us-east-1
-LOCALSTACK_VERSION ?= 4.12
-LOCALSTACK_IMAGE ?= localstack/localstack
+LOCALSTACK_VERSION ?= latest
 
 # Colors for output
 GREEN := \033[0;32m
@@ -16,7 +15,7 @@ RED := \033[0;31m
 BLUE := \033[0;34m
 NC := \033[0m # No Color
 
-.PHONY: help start start-latest start-community stop restart status logs clean
+.PHONY: help start start-legacy stop restart status logs clean
 .PHONY: shell-create shell-destroy shell-list
 .PHONY: gui-start gui-stop gui-restart
 .PHONY: setup check-prerequisites docker-build docker-logs
@@ -40,10 +39,9 @@ help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-15s$(NC) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(setup|check)"
 	@echo ""
 	@echo "$(YELLOW)Usage Examples:$(NC)"
-	@echo "  make start                              # Start with pinned LocalStack $(LOCALSTACK_VERSION)"
-	@echo "  make start LOCALSTACK_VERSION=4.11      # Start with a specific version"
-	@echo "  make start-latest                       # Start with localstack/localstack:latest"
-	@echo "  make start-community                    # Start with localstack/localstack:latest (community)"
+	@echo "  make start                              # Start with LocalStack latest"
+	@echo "  make start LOCALSTACK_VERSION=4.12      # Start with a specific LocalStack version"
+	@echo "  make start-legacy                       # Start with LocalStack 4.12 (community legacy)"
 	@echo "  make gui-start                          # Start GUI system with Docker"
 	@echo "  make shell-create ENV=dev               # Create resources with Shell scripts"
 	@echo "  make clean                              # Clean up all resources"
@@ -51,11 +49,11 @@ help: ## Show this help message
 	@echo "  make reset-env                          # Full environment reset (stop + clean all + volumes)"
 
 # Docker Management
-start: ## Start all services (LocalStack $(LOCALSTACK_VERSION) — default pinned version)
+start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by default)
 	@echo "$(GREEN)Starting LocalStack Template with Docker...$(NC)"
-	@echo "$(YELLOW)Using image: $(LOCALSTACK_IMAGE):$(LOCALSTACK_VERSION)$(NC)"
+	@echo "$(YELLOW)Using LocalStack version: $(LOCALSTACK_VERSION)$(NC)"
 	@mkdir -p volume/cache volume/lib volume/logs volume/tmp
-	LOCALSTACK_IMAGE=$(LOCALSTACK_IMAGE) LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) docker compose up --build -d
+	LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) docker compose up --build -d
 	@echo "$(GREEN)Waiting for services to be ready...$(NC)"
 	@until curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 || curl -s http://localhost/health > /dev/null 2>&1; do sleep 2; done
 	@echo "$(GREEN)All services are ready!$(NC)"
@@ -64,11 +62,8 @@ start: ## Start all services (LocalStack $(LOCALSTACK_VERSION) — default pinne
 	@echo "$(YELLOW)LocalStack: http://localhost:4566$(NC)"
 	@echo "$(YELLOW)Express API (direct): http://localhost:3031$(NC)"
 
-start-latest: ## Start all services using LocalStack latest tag
-	@$(MAKE) start LOCALSTACK_VERSION=latest
-
-start-community: ## Start all services using LocalStack community edition (latest)
-	@$(MAKE) start LOCALSTACK_IMAGE=localstack/localstack LOCALSTACK_VERSION=latest
+start-legacy: ## Start all services using LocalStack 4.12 (community legacy)
+	@$(MAKE) start LOCALSTACK_VERSION=4.12
 
 stop: ## Stop all Docker services
 	@echo "$(YELLOW)Stopping all services...$(NC)"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ PROJECT_NAME ?= localstack-template
 ENVIRONMENT ?= dev
 AWS_ENDPOINT ?= http://localhost:4566
 AWS_REGION ?= us-east-1
-LOCALSTACK_VERSION ?= latest
+LOCALSTACK_VERSION ?= 4.12
+LOCALSTACK_IMAGE ?= localstack/localstack
 
 # Colors for output
 GREEN := \033[0;32m
@@ -15,7 +16,7 @@ RED := \033[0;31m
 BLUE := \033[0;34m
 NC := \033[0m # No Color
 
-.PHONY: help start stop restart status logs clean
+.PHONY: help start start-latest start-community stop restart status logs clean
 .PHONY: shell-create shell-destroy shell-list
 .PHONY: gui-start gui-stop gui-restart
 .PHONY: setup check-prerequisites docker-build docker-logs
@@ -39,19 +40,22 @@ help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-15s$(NC) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(setup|check)"
 	@echo ""
 	@echo "$(YELLOW)Usage Examples:$(NC)"
-	@echo "  make start                    # Start all services with Docker"
-	@echo "  make gui-start                # Start GUI system with Docker"
-	@echo "  make shell-create ENV=dev     # Create resources with Shell scripts"
-	@echo "  make clean                    # Clean up all resources"
-	@echo "  make reset                    # Reset Docker environment (stop + clean volumes)"
-	@echo "  make reset-env                # Full environment reset (stop + clean all + volumes)"
+	@echo "  make start                              # Start with pinned LocalStack $(LOCALSTACK_VERSION)"
+	@echo "  make start LOCALSTACK_VERSION=4.11      # Start with a specific version"
+	@echo "  make start-latest                       # Start with localstack/localstack:latest"
+	@echo "  make start-community                    # Start with localstack/localstack:latest (community)"
+	@echo "  make gui-start                          # Start GUI system with Docker"
+	@echo "  make shell-create ENV=dev               # Create resources with Shell scripts"
+	@echo "  make clean                              # Clean up all resources"
+	@echo "  make reset                              # Reset Docker environment (stop + clean volumes)"
+	@echo "  make reset-env                          # Full environment reset (stop + clean all + volumes)"
 
 # Docker Management
-start: ## Start all services with Docker Compose
+start: ## Start all services (LocalStack $(LOCALSTACK_VERSION) — default pinned version)
 	@echo "$(GREEN)Starting LocalStack Template with Docker...$(NC)"
-	@echo "$(YELLOW)Using LocalStack version: $(LOCALSTACK_VERSION)$(NC)"
+	@echo "$(YELLOW)Using image: $(LOCALSTACK_IMAGE):$(LOCALSTACK_VERSION)$(NC)"
 	@mkdir -p volume/cache volume/lib volume/logs volume/tmp
-	LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) docker compose up --build -d
+	LOCALSTACK_IMAGE=$(LOCALSTACK_IMAGE) LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) docker compose up --build -d
 	@echo "$(GREEN)Waiting for services to be ready...$(NC)"
 	@until curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 || curl -s http://localhost/health > /dev/null 2>&1; do sleep 2; done
 	@echo "$(GREEN)All services are ready!$(NC)"
@@ -59,6 +63,12 @@ start: ## Start all services with Docker Compose
 	@echo "$(YELLOW)API: https://app-local.localcloudkit.com:3030/api$(NC)"
 	@echo "$(YELLOW)LocalStack: http://localhost:4566$(NC)"
 	@echo "$(YELLOW)Express API (direct): http://localhost:3031$(NC)"
+
+start-latest: ## Start all services using LocalStack latest tag
+	@$(MAKE) start LOCALSTACK_VERSION=latest
+
+start-community: ## Start all services using LocalStack community edition (latest)
+	@$(MAKE) start LOCALSTACK_IMAGE=localstack/localstack LOCALSTACK_VERSION=latest
 
 stop: ## Stop all Docker services
 	@echo "$(YELLOW)Stopping all services...$(NC)"

--- a/README.md
+++ b/README.md
@@ -253,26 +253,28 @@ LocalCloud Kit uses the latest LocalStack version by default:
 - **Last Tested**: 4.13.0 (March 9, 2026)
 - **Compatibility**: Maintained and updated as LocalStack evolves
 
-> 📌 **LocalStack image change (March 23, 2026)**: LocalStack is consolidating Community and Pro into a single image. The **Community edition remains free** — all services LocalCloud Kit uses (S3, DynamoDB, Secrets Manager, IAM) are included at no cost. After March 23, you'll need a free account and `LOCALSTACK_AUTH_TOKEN` set in your `.env` to pull the `latest` tag. [Sign up free →](https://app.localstack.cloud/sign-up). To avoid this entirely, pin to `4.13.0` or earlier (no auth required for pre-consolidation versions).
+> 📌 **LocalStack image change (March 23, 2026)**: LocalStack is consolidating Community and Pro into a single image. The **Community edition remains free** — all services LocalCloud Kit uses (S3, DynamoDB, Secrets Manager, IAM) are included at no cost. After March 23, you'll need a free account and `LOCALSTACK_AUTH_TOKEN` set in your `.env` to pull the `latest` tag. [Sign up free →](https://app.localstack.cloud/sign-up). To avoid this entirely, use `make start-legacy` to pin to `4.12` (no auth required for pre-consolidation versions).
 
 ### Using Specific LocalStack Versions
 
 The default configuration uses `latest`, but you can pin to a specific version if needed:
 
 ```bash
-# Method 1: Using environment variable
-LOCALSTACK_VERSION=4.13.0 docker compose up
+# Start with latest (default)
+make start
 
-# Method 2: Using Makefile
+# Start with LocalStack 4.12 — community legacy, no auth token required
+make start-legacy
+
+# Start with any specific version
 make start LOCALSTACK_VERSION=4.13.0
 
-# Method 3: Create/edit .env file
-echo "LOCALSTACK_VERSION=4.13.0" > .env
-docker compose up
+# Using environment variable directly
+LOCALSTACK_VERSION=4.13.0 docker compose up
 
-# Method 4: Edit env.example
+# Using a .env file
 cp env.example .env
-# Edit LOCALSTACK_VERSION in .env
+# Edit LOCALSTACK_VERSION in .env, then:
 docker compose up
 ```
 
@@ -299,14 +301,17 @@ The `docker-compose.yml` uses `${LOCALSTACK_VERSION:-latest}` which means:
 ### Start Services
 
 ```bash
-# Recommended: Use Make (cross-platform)
+# Start with LocalStack latest (default)
 make start
+
+# Start with LocalStack 4.12 — community legacy, no auth token required
+make start-legacy
+
+# Start with any specific LocalStack version
+make start LOCALSTACK_VERSION=4.13.0
 
 # Alternative: Docker Compose directly
 docker compose up --build
-
-# Alternative: Using Makefile
-make start
 
 # Development mode (GUI outside Docker)
 docker compose up -d localstack api nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # LocalStack - AWS Services Emulation
   localstack:
-    image: localstack/localstack:${LOCALSTACK_VERSION:-latest}
+    image: ${LOCALSTACK_IMAGE:-localstack/localstack}:${LOCALSTACK_VERSION:-4.12}
     container_name: localstack
     ports:
       - "4566:4566"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # LocalStack - AWS Services Emulation
   localstack:
-    image: ${LOCALSTACK_IMAGE:-localstack/localstack}:${LOCALSTACK_VERSION:-4.12}
+    image: localstack/localstack:${LOCALSTACK_VERSION:-latest}
     container_name: localstack
     ports:
       - "4566:4566"

--- a/env.example
+++ b/env.example
@@ -1,9 +1,15 @@
 # LocalStack Configuration
-LOCALSTACK_VERSION=latest
+# Pinned to a stable release by default. Use 'latest' or override via make targets:
+#   make start                        → localstack/localstack:4.12 (default)
+#   make start-latest                 → localstack/localstack:latest
+#   make start-community              → localstack/localstack:latest (community)
+#   make start LOCALSTACK_VERSION=X   → localstack/localstack:X
+LOCALSTACK_IMAGE=localstack/localstack
+LOCALSTACK_VERSION=4.12
 LOCALSTACK_VOLUME_DIR=./volume
 DEBUG=1
 
-# LocalStack Auth Token (required after March 23, 2026 when using latest)
+# LocalStack Auth Token (required when using latest with pro features)
 # Get your free token at: https://app.localstack.cloud/sign-up
 # LOCALSTACK_AUTH_TOKEN=your_token_here
 

--- a/env.example
+++ b/env.example
@@ -1,11 +1,9 @@
 # LocalStack Configuration
-# Pinned to a stable release by default. Use 'latest' or override via make targets:
-#   make start                        → localstack/localstack:4.12 (default)
-#   make start-latest                 → localstack/localstack:latest
-#   make start-community              → localstack/localstack:latest (community)
-#   make start LOCALSTACK_VERSION=X   → localstack/localstack:X
-LOCALSTACK_IMAGE=localstack/localstack
-LOCALSTACK_VERSION=4.12
+# Override version via make targets:
+#   make start                             → localstack/localstack:latest (default)
+#   make start-legacy                      → localstack/localstack:4.12
+#   make start LOCALSTACK_VERSION=<ver>    → any version
+LOCALSTACK_VERSION=latest
 LOCALSTACK_VOLUME_DIR=./volume
 DEBUG=1
 


### PR DESCRIPTION
- docker-compose.yml: default image/version now uses LOCALSTACK_IMAGE and LOCALSTACK_VERSION env vars (fallback: localstack/localstack:4.12)
- Makefile: LOCALSTACK_VERSION default changed from latest → 4.12; added LOCALSTACK_IMAGE variable; new targets: start-latest, start-community; updated help examples
- env.example: updated defaults and added comments explaining all version override options

https://claude.ai/code/session_01Lf6Yh5ZsjYS78b45sTgovB