### PR TITLE
Add resource docs pages and improve dashboard labels

### DIFF
--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import {
+  ArrowLeftIcon,
+  ArrowTopRightOnSquareIcon,
+  CircleStackIcon,
+  ClipboardDocumentIcon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+
+function CodeBlock({ code }: { code: string }) {
+  const copy = () => {
+    navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  };
+  return (
+    <div className="relative group">
+      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={copy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+        title="Copy"
+      >
+        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
+      </button>
+    </div>
+  );
+}
+
+const sdkExamples = {
+  node: `// npm install @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, GetCommand, QueryCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+const ddb = DynamoDBDocumentClient.from(client);
+
+// Put an item
+await ddb.send(new PutCommand({
+  TableName: "my-table",
+  Item: { id: "user-1", name: "Alice", email: "alice@example.com" },
+}));
+
+// Get an item
+const { Item } = await ddb.send(new GetCommand({
+  TableName: "my-table",
+  Key: { id: "user-1" },
+}));
+console.log(Item);
+
+// Query items (requires index or partition key)
+const { Items } = await ddb.send(new QueryCommand({
+  TableName: "my-table",
+  KeyConditionExpression: "id = :id",
+  ExpressionAttributeValues: { ":id": "user-1" },
+}));
+
+// Delete an item
+await ddb.send(new DeleteCommand({
+  TableName: "my-table",
+  Key: { id: "user-1" },
+}));`,
+  python: `# pip install boto3
+import boto3
+
+ddb = boto3.resource(
+    "dynamodb",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+table = ddb.Table("my-table")
+
+# Put an item
+table.put_item(Item={"id": "user-1", "name": "Alice", "email": "alice@example.com"})
+
+# Get an item
+response = table.get_item(Key={"id": "user-1"})
+item = response.get("Item")
+print(item)
+
+# Query items
+response = table.query(
+    KeyConditionExpression=boto3.dynamodb.conditions.Key("id").eq("user-1")
+)
+print(response["Items"])
+
+# Delete an item
+table.delete_item(Key={"id": "user-1"})`,
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# List tables
+awslocal dynamodb list-tables
+
+# Describe a table
+awslocal dynamodb describe-table --table-name my-table
+
+# Put an item
+awslocal dynamodb put-item \\
+  --table-name my-table \\
+  --item '{"id":{"S":"user-1"},"name":{"S":"Alice"}}'
+
+# Get an item
+awslocal dynamodb get-item \\
+  --table-name my-table \\
+  --key '{"id":{"S":"user-1"}}'
+
+# Scan a table (returns all items)
+awslocal dynamodb scan --table-name my-table
+
+# Delete an item
+awslocal dynamodb delete-item \\
+  --table-name my-table \\
+  --key '{"id":{"S":"user-1"}}'`,
+};
+
+const externalResources = [
+  {
+    name: "AWS DynamoDB Documentation",
+    url: "https://docs.aws.amazon.com/dynamodb/",
+    description: "Official AWS DynamoDB documentation — data modeling, API reference, and best practices.",
+  },
+  {
+    name: "DynamoDB SDK v3 (Node.js)",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/dynamodb/",
+    description: "DynamoDBClient API reference for the AWS SDK v3.",
+  },
+  {
+    name: "boto3 DynamoDB Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html",
+    description: "Complete boto3 DynamoDB client and resource reference for Python.",
+  },
+  {
+    name: "LocalStack DynamoDB Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_dynamodb/",
+    description: "Which DynamoDB API operations are supported by LocalStack.",
+  },
+];
+
+export default function DynamoDBDocPage() {
+  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-center space-x-4">
+              <Link
+                href="/"
+                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+                Dashboard
+              </Link>
+              <div className="flex items-center space-x-3">
+                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">DynamoDB Tables</h1>
+                  <p className="text-xs text-gray-500">Local NoSQL database via LocalStack</p>
+                </div>
+              </div>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+            >
+              <CircleStackIcon className="h-4 w-4 mr-1.5" />
+              Manage Tables
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About DynamoDB</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>Amazon DynamoDB</strong> via LocalStack — a fully managed,
+            serverless, key-value NoSQL database. DynamoDB is optimized for high-performance applications
+            at any scale, with single-digit millisecond performance.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Use the dashboard to create and browse tables, or connect directly via the AWS SDK using
+            the local endpoint <code className="bg-gray-100 px-1 rounded font-mono text-xs">http://localhost:4566</code>.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Put, get, query, and delete items using any AWS SDK.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setActiveTab(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
+          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
+          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import RedisModal from "@/components/RedisModal";
+import {
+  ArrowLeftIcon,
+  ArrowTopRightOnSquareIcon,
+  ClipboardDocumentIcon,
+  ServerIcon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+
+function CodeBlock({ code }: { code: string }) {
+  const copy = () => {
+    navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  };
+  return (
+    <div className="relative group">
+      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={copy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+        title="Copy"
+      >
+        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
+      </button>
+    </div>
+  );
+}
+
+const clientExamples = {
+  node: `// npm install ioredis
+const Redis = require("ioredis");
+
+const redis = new Redis({
+  host: "localhost",
+  port: 6380,
+});
+
+// Set a key
+await redis.set("greeting", "hello world");
+await redis.set("counter", 42, "EX", 3600); // expires in 1 hour
+
+// Get a key
+const value = await redis.get("greeting");
+console.log(value); // "hello world"
+
+// Delete a key
+await redis.del("greeting");
+
+redis.quit();`,
+  python: `# pip install redis
+import redis
+
+client = redis.Redis(host="localhost", port=6380, decode_responses=True)
+
+# Set a key
+client.set("greeting", "hello world")
+client.setex("counter", 3600, 42)  # expires in 1 hour
+
+# Get a key
+value = client.get("greeting")
+print(value)  # "hello world"
+
+# Delete a key
+client.delete("greeting")
+
+client.close()`,
+  cli: `# Connect to Redis via CLI
+redis-cli -h localhost -p 6380
+
+# Basic commands
+SET greeting "hello world"
+GET greeting
+DEL greeting
+
+# With expiry
+SET session:abc123 "user_data" EX 3600
+
+# List all keys
+KEYS *
+
+# Flush the database (dev only)
+FLUSHALL`,
+};
+
+const externalResources = [
+  {
+    name: "Redis Documentation",
+    url: "https://redis.io/docs/",
+    description: "Official Redis documentation — commands, data types, and configuration.",
+  },
+  {
+    name: "ioredis (Node.js)",
+    url: "https://github.com/redis/ioredis",
+    description: "Robust, full-featured Redis client for Node.js with promise support.",
+  },
+  {
+    name: "redis-py (Python)",
+    url: "https://redis-py.readthedocs.io/",
+    description: "The official Python interface to the Redis key-value store.",
+  },
+  {
+    name: "Redis CLI Reference",
+    url: "https://redis.io/docs/manual/cli/",
+    description: "Complete redis-cli usage guide with examples.",
+  },
+];
+
+export default function RedisDocPage() {
+  const [showModal, setShowModal] = useState(false);
+  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-center space-x-4">
+              <Link
+                href="/"
+                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+                Dashboard
+              </Link>
+              <div className="flex items-center space-x-3">
+                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">Redis Cache</h1>
+                  <p className="text-xs text-gray-500">Local in-memory cache for development</p>
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => setShowModal(true)}
+              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+            >
+              <ServerIcon className="h-4 w-4 mr-1.5" />
+              Manage Cache
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Redis</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit includes <strong>Redis 7</strong> — a fast, in-memory data structure store
+            used as a cache, session store, and message broker. It runs alongside LocalStack so your
+            application can use caching locally without any external infrastructure.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            The <strong>Cache</strong> card on your dashboard reflects the live Redis state.
+            Click <em>Open</em> on that card to browse keys, check memory usage, and run commands.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Host machine</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Docker network</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Host</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">localhost</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">localcloud-redis</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Port</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">6380</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">6379</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Password</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-400 italic" colSpan={2}>none required</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">TLS</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900" colSpan={2}>Off</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Client Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Client Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Connect to Redis from your application using any Redis-compatible client.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "Redis CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setActiveTab(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "node" && (
+            <div>
+              <p className="text-sm text-gray-500 mb-2">
+                Node.js — <code className="bg-gray-100 px-1 rounded">npm install ioredis</code>
+              </p>
+              <CodeBlock code={clientExamples.node} />
+            </div>
+          )}
+          {activeTab === "python" && (
+            <div>
+              <p className="text-sm text-gray-500 mb-2">
+                Python — <code className="bg-gray-100 px-1 rounded">pip install redis</code>
+              </p>
+              <CodeBlock code={clientExamples.python} />
+            </div>
+          )}
+          {activeTab === "cli" && (
+            <div>
+              <p className="text-sm text-gray-500 mb-2">
+                Connect directly using <code className="bg-gray-100 px-1 rounded">redis-cli</code> on port 6380.
+              </p>
+              <CodeBlock code={clientExamples.cli} />
+            </div>
+          )}
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+
+      {showModal && <RedisModal onClose={() => setShowModal(false)} />}
+    </main>
+  );
+}

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import {
+  ArrowLeftIcon,
+  ArrowTopRightOnSquareIcon,
+  ClipboardDocumentIcon,
+  FolderIcon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+
+function CodeBlock({ code }: { code: string }) {
+  const copy = () => {
+    navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  };
+  return (
+    <div className="relative group">
+      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={copy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+        title="Copy"
+      >
+        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
+      </button>
+    </div>
+  );
+}
+
+const sdkExamples = {
+  node: `// npm install @aws-sdk/client-s3
+import { S3Client, CreateBucketCommand, PutObjectCommand, GetObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  forcePathStyle: true,
+});
+
+// Create a bucket
+await s3.send(new CreateBucketCommand({ Bucket: "my-bucket" }));
+
+// Upload an object
+await s3.send(new PutObjectCommand({
+  Bucket: "my-bucket",
+  Key: "hello.txt",
+  Body: "Hello, LocalStack!",
+  ContentType: "text/plain",
+}));
+
+// Download an object
+const { Body } = await s3.send(new GetObjectCommand({
+  Bucket: "my-bucket",
+  Key: "hello.txt",
+}));
+const text = await Body.transformToString();
+console.log(text);
+
+// List objects
+const { Contents } = await s3.send(new ListObjectsV2Command({ Bucket: "my-bucket" }));
+Contents?.forEach((obj) => console.log(obj.Key));`,
+  python: `# pip install boto3
+import boto3
+
+s3 = boto3.client(
+    "s3",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a bucket
+s3.create_bucket(Bucket="my-bucket")
+
+# Upload a file
+s3.upload_file("local_file.txt", "my-bucket", "remote_file.txt")
+
+# Upload from string
+s3.put_object(Bucket="my-bucket", Key="hello.txt", Body=b"Hello, LocalStack!")
+
+# Download a file
+s3.download_file("my-bucket", "remote_file.txt", "downloaded.txt")
+
+# List objects
+response = s3.list_objects_v2(Bucket="my-bucket")
+for obj in response.get("Contents", []):
+    print(obj["Key"])`,
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+# Or set an alias
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a bucket
+awslocal s3 mb s3://my-bucket
+
+# Upload a file
+awslocal s3 cp local_file.txt s3://my-bucket/remote_file.txt
+
+# List buckets
+awslocal s3 ls
+
+# List objects in a bucket
+awslocal s3 ls s3://my-bucket/
+
+# Download a file
+awslocal s3 cp s3://my-bucket/remote_file.txt downloaded.txt
+
+# Delete an object
+awslocal s3 rm s3://my-bucket/remote_file.txt
+
+# Delete a bucket (must be empty first)
+awslocal s3 rb s3://my-bucket`,
+};
+
+const externalResources = [
+  {
+    name: "AWS S3 Documentation",
+    url: "https://docs.aws.amazon.com/s3/",
+    description: "Official AWS S3 documentation — concepts, API reference, and best practices.",
+  },
+  {
+    name: "AWS SDK for JavaScript v3",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/s3/",
+    description: "S3Client API reference for the AWS SDK v3 (Node.js / browser).",
+  },
+  {
+    name: "boto3 S3 Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html",
+    description: "Complete boto3 S3 client reference for Python.",
+  },
+  {
+    name: "LocalStack S3 Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_s3/",
+    description: "Which S3 API operations are supported by LocalStack.",
+  },
+];
+
+export default function S3DocPage() {
+  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-center space-x-4">
+              <Link
+                href="/"
+                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+                Dashboard
+              </Link>
+              <div className="flex items-center space-x-3">
+                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">S3 Buckets</h1>
+                  <p className="text-xs text-gray-500">Local object storage via LocalStack</p>
+                </div>
+              </div>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+            >
+              <FolderIcon className="h-4 w-4 mr-1.5" />
+              Manage Buckets
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About S3</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>Amazon S3</strong> (Simple Storage Service) via LocalStack.
+            S3 is an object storage service that lets you store and retrieve any amount of data — files,
+            images, backups, static assets, and more.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Your local S3 endpoint is <code className="bg-gray-100 px-1 rounded font-mono text-xs">http://localhost:4566</code>.
+            Use the same AWS SDK code you would in production — just point the endpoint at LocalStack.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Path Style</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">enabled (required)</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Create buckets, upload objects, and list contents using any AWS SDK.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setActiveTab(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
+          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
+          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+import {
+  ArrowLeftIcon,
+  ArrowTopRightOnSquareIcon,
+  ClipboardDocumentIcon,
+  KeyIcon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+
+function CodeBlock({ code }: { code: string }) {
+  const copy = () => {
+    navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  };
+  return (
+    <div className="relative group">
+      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
+        <code>{code}</code>
+      </pre>
+      <button
+        onClick={copy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
+        title="Copy"
+      >
+        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
+      </button>
+    </div>
+  );
+}
+
+const sdkExamples = {
+  node: `// npm install @aws-sdk/client-secrets-manager
+import {
+  SecretsManagerClient,
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  UpdateSecretCommand,
+  DeleteSecretCommand,
+  ListSecretsCommand,
+} from "@aws-sdk/client-secrets-manager";
+
+const sm = new SecretsManagerClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a secret
+await sm.send(new CreateSecretCommand({
+  Name: "my-app/database-password",
+  SecretString: JSON.stringify({ password: "s3cr3t!" }),
+  Description: "Database password for my-app",
+}));
+
+// Get a secret value
+const { SecretString } = await sm.send(new GetSecretValueCommand({
+  SecretId: "my-app/database-password",
+}));
+const secret = JSON.parse(SecretString);
+console.log(secret.password);
+
+// Update a secret
+await sm.send(new UpdateSecretCommand({
+  SecretId: "my-app/database-password",
+  SecretString: JSON.stringify({ password: "new-s3cr3t!" }),
+}));
+
+// List secrets
+const { SecretList } = await sm.send(new ListSecretsCommand({}));
+SecretList?.forEach((s) => console.log(s.Name, s.ARN));
+
+// Delete a secret (ForceDeleteWithoutRecovery skips the 30-day window)
+await sm.send(new DeleteSecretCommand({
+  SecretId: "my-app/database-password",
+  ForceDeleteWithoutRecovery: true,
+}));`,
+  python: `# pip install boto3
+import boto3, json
+
+sm = boto3.client(
+    "secretsmanager",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a secret
+sm.create_secret(
+    Name="my-app/database-password",
+    SecretString=json.dumps({"password": "s3cr3t!"}),
+    Description="Database password for my-app",
+)
+
+# Get a secret value
+response = sm.get_secret_value(SecretId="my-app/database-password")
+secret = json.loads(response["SecretString"])
+print(secret["password"])
+
+# Update a secret
+sm.update_secret(
+    SecretId="my-app/database-password",
+    SecretString=json.dumps({"password": "new-s3cr3t!"}),
+)
+
+# List secrets
+response = sm.list_secrets()
+for s in response.get("SecretList", []):
+    print(s["Name"], s["ARN"])
+
+# Delete a secret immediately
+sm.delete_secret(
+    SecretId="my-app/database-password",
+    ForceDeleteWithoutRecovery=True,
+)`,
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a secret
+awslocal secretsmanager create-secret \\
+  --name "my-app/database-password" \\
+  --secret-string '{"password":"s3cr3t!"}' \\
+  --description "Database password for my-app"
+
+# Get a secret value
+awslocal secretsmanager get-secret-value \\
+  --secret-id "my-app/database-password"
+
+# Update a secret
+awslocal secretsmanager update-secret \\
+  --secret-id "my-app/database-password" \\
+  --secret-string '{"password":"new-s3cr3t!"}'
+
+# List secrets
+awslocal secretsmanager list-secrets
+
+# Delete a secret immediately
+awslocal secretsmanager delete-secret \\
+  --secret-id "my-app/database-password" \\
+  --force-delete-without-recovery`,
+};
+
+const externalResources = [
+  {
+    name: "AWS Secrets Manager Documentation",
+    url: "https://docs.aws.amazon.com/secretsmanager/",
+    description: "Official AWS Secrets Manager docs — rotation, policies, and API reference.",
+  },
+  {
+    name: "Secrets Manager SDK v3 (Node.js)",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/secrets-manager/",
+    description: "SecretsManagerClient API reference for the AWS SDK v3.",
+  },
+  {
+    name: "boto3 Secrets Manager Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html",
+    description: "Complete boto3 Secrets Manager client reference for Python.",
+  },
+  {
+    name: "LocalStack Secrets Manager Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_secretsmanager/",
+    description: "Which Secrets Manager API operations are supported by LocalStack.",
+  },
+];
+
+export default function SecretsDocPage() {
+  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-center space-x-4">
+              <Link
+                href="/"
+                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+                Dashboard
+              </Link>
+              <div className="flex items-center space-x-3">
+                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+                <div>
+                  <h1 className="text-xl font-bold text-gray-900">Secrets Manager</h1>
+                  <p className="text-xs text-gray-500">Local secret storage via LocalStack</p>
+                </div>
+              </div>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+            >
+              <KeyIcon className="h-4 w-4 mr-1.5" />
+              Manage Secrets
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Secrets Manager</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>AWS Secrets Manager</strong> via LocalStack — a service that
+            helps you protect access to your applications, services, and IT resources. You can store
+            database credentials, API keys, OAuth tokens, and other sensitive configuration values.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Secrets are accessed programmatically at runtime, so your application code never contains
+            hard-coded credentials. Use the dashboard to create and inspect secrets, or connect via the
+            AWS SDK at <code className="bg-gray-100 px-1 rounded font-mono text-xs">http://localhost:4566</code>.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Create, read, update, and delete secrets using any AWS SDK.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => setActiveTab(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-blue-600 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
+          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
+          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -462,7 +462,7 @@ export default function Dashboard() {
               redis.status === "running" ? "bg-green-500" :
               redis.status === "stopped" ? "bg-red-500" : "bg-gray-400"
             }`} />
-            <span className="text-sm font-medium text-gray-700">Cache</span>
+            <span className="text-sm font-medium text-gray-700">Redis</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
               redis.status === "running" ? "bg-green-100 text-green-800" :
               redis.status === "stopped" ? "bg-red-100 text-red-800" :
@@ -483,7 +483,7 @@ export default function Dashboard() {
             <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
               mailpit.status === "healthy" ? "bg-green-500" : "bg-gray-400"
             }`} />
-            <span className="text-sm font-medium text-gray-700">Inbox</span>
+            <span className="text-sm font-medium text-gray-700">Mailpit</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
               mailpit.status === "healthy" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"
             }`}>

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -360,22 +360,64 @@ export default function Dashboard() {
                   <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`} />
                 </button>
                 {showDocsMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    {/* LocalStack */}
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
                     <Link
                       href="/localstack"
                       onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
                       <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
-                      LocalStack Integration
+                      LocalStack
+                    </Link>
+
+                    {/* AWS Resources */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
+                    <Link
+                      href="/s3"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <FolderIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      S3 Buckets
+                    </Link>
+                    <Link
+                      href="/dynamodb"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      DynamoDB
+                    </Link>
+                    <Link
+                      href="/secrets"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Secrets Manager
+                    </Link>
+
+                    {/* Services */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Services</p>
+                    <Link
+                      href="/redis"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Redis Cache
                     </Link>
                     <Link
                       href="/mailpit"
                       onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
                       <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Mailpit Integration
+                      Inbox
                     </Link>
                   </div>
                 )}
@@ -420,7 +462,7 @@ export default function Dashboard() {
               redis.status === "running" ? "bg-green-500" :
               redis.status === "stopped" ? "bg-red-500" : "bg-gray-400"
             }`} />
-            <span className="text-sm font-medium text-gray-700">Redis</span>
+            <span className="text-sm font-medium text-gray-700">Cache</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
               redis.status === "running" ? "bg-green-100 text-green-800" :
               redis.status === "stopped" ? "bg-red-100 text-red-800" :
@@ -441,7 +483,7 @@ export default function Dashboard() {
             <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
               mailpit.status === "healthy" ? "bg-green-500" : "bg-gray-400"
             }`} />
-            <span className="text-sm font-medium text-gray-700">Mailpit</span>
+            <span className="text-sm font-medium text-gray-700">Inbox</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
               mailpit.status === "healthy" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"
             }`}>

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -305,7 +305,9 @@ export default function ResourceList({
                     </h4>
                     <p className="text-xs text-gray-500 capitalize truncate">
                       {resource.type === "mailpit"
-                        ? "Mailpit Integration"
+                        ? "Inbox"
+                        : resource.type === "cache"
+                        ? "Redis"
                         : `${resource.type} • ${resource.project}`}
                     </p>
                   </div>

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -305,7 +305,7 @@ export default function ResourceList({
                     </h4>
                     <p className="text-xs text-gray-500 capitalize truncate">
                       {resource.type === "mailpit"
-                        ? "Inbox"
+                        ? "Mailpit"
                         : resource.type === "cache"
                         ? "Redis"
                         : `${resource.type} • ${resource.project}`}


### PR DESCRIPTION
- Add documentation pages for Redis, S3, DynamoDB, and Secrets Manager,
  each with connection settings, SDK examples (Node.js, Python, CLI),
  and external resource links
- Expand Docs dropdown with categorised links to all new and existing pages
- Rename "Mailpit" to "Inbox" in the status bar and resource list subtitle
- Rename "Redis" to "Cache" in the status bar
- Remove project name from the Cache resource subtitle (now shows "Redis")

https://claude.ai/code/session_0115DNiLhBs11FnkMc5zwG6Z