### PR TITLE
Add user profiles, preferences, projects, and saved resource configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **ThemeableCodeBlock**: Reusable code block component with highlight.js syntax highlighting and theme selector for SDK samples across S3, DynamoDB, Secrets, Redis, Mailpit, and LocalStack doc pages
+
 ### Changed
+- **ConnectionGuide**: Respects profile highlight_theme preference for SDK code examples
 - **docker-compose.yml**: Updated Traefik image from `traefik:v3.0` to `traefik:v3` (floating latest v3 — currently v3.6.10)
 - **README**: Updated LocalStack last-tested version from 4.9 to 4.13.0 (March 9, 2026); added notice about LocalStack's upcoming authentication requirement (March 23, 2026) with link to free plan signup
+
+### Fixed
+- **SecretsManagerViewer**: Sub-modals (Create, Edit, Delete) no longer close when focusing inputs — added stopPropagation to prevent backdrop click bubbling
+- **Dashboard**: Fixed projectName self-reference that caused TypeScript build error (fallback to config.projectName)
 
 ## [0.8.0] - 2026-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,23 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Added
 - **ThemeableCodeBlock**: Reusable code block component with highlight.js syntax highlighting and theme selector for SDK samples across S3, DynamoDB, Secrets, Redis, Mailpit, and LocalStack doc pages
+- **DashboardSkeleton**: Skeleton loading component with animated pulse placeholders for the dashboard header, services bar, and resource list
+- **GET /api/dashboard**: Batched backend endpoint that aggregates LocalStack status, project config, Mailpit stats, resources, and Redis status in a single round-trip
 
 ### Changed
 - **ConnectionGuide**: Respects profile highlight_theme preference for SDK code examples
 - **docker-compose.yml**: Updated Traefik image from `traefik:v3.0` to `traefik:v3` (floating latest v3 — currently v3.6.10)
 - **README**: Updated LocalStack last-tested version from 4.9 to 4.13.0 (March 9, 2026); added notice about LocalStack's upcoming authentication requirement (March 23, 2026) with link to free plan signup
+- **Dashboard**: Replaced full-screen spinner with DashboardSkeleton during initial load; data is lazy-loaded only when visiting the dashboard
+- **useServicesData**: Refactored to use the new batched `/api/dashboard` endpoint (single API call instead of multiple parallel requests)
+- **ResourceList**: Cache resource label changed from "Redis Cache" to "Cache" (type remains "Redis" in the subtitle)
+- **DynamoDBViewer**: Tighter row padding (`px-3 py-2`), auto-sizing columns (`table-auto`), inline JSON expand button with `ArrowsPointingOutIcon`, and fixed vertical + horizontal scroll in the items table
 
 ### Fixed
 - **SecretsManagerViewer**: Sub-modals (Create, Edit, Delete) no longer close when focusing inputs — added stopPropagation to prevent backdrop click bubbling
 - **Dashboard**: Fixed projectName self-reference that caused TypeScript build error (fallback to config.projectName)
+- **DynamoDBAddItemModal**: Empty attributes are now filtered before submission — prevents partial items from being saved to DynamoDB
+- **DynamoDBAddItemModal**: Form state (keys, attributes, errors) is reset each time the modal is opened so stale data from a previous submission is not shown
 
 ## [0.8.0] - 2026-03-09
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,8 +4,8 @@ FROM node:22-alpine
 # Set the working directory
 WORKDIR /app
 
-# Install AWS CLI v2, jq, and redis-cli
-RUN apk add --no-cache curl jq aws-cli redis
+# Install AWS CLI v2, jq, redis-cli, and native build tools (required for better-sqlite3)
+RUN apk add --no-cache curl jq aws-cli redis python3 make g++
 
 # Copy package files
 COPY localcloud-api/package*.json ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - /app/node_modules
       - ./logs:/app/logs
       - ./scripts:/app/scripts
+      - localcloud-data:/app/data
     depends_on:
       - localstack
     networks:
@@ -133,3 +134,4 @@ networks:
 
 volumes:
   localstack_data:
+  localcloud-data:

--- a/localcloud-api/db.js
+++ b/localcloud-api/db.js
@@ -1,11 +1,14 @@
-const Database = require("better-sqlite3");
-const path = require("path");
-const fs = require("fs");
+import Database from "better-sqlite3";
+import { existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
 
-const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, "data");
-if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
-const db = new Database(path.join(DATA_DIR, "localcloud.db"));
+const DATA_DIR = process.env.DATA_DIR || join(__dirname, "data");
+if (!existsSync(DATA_DIR)) mkdirSync(DATA_DIR, { recursive: true });
+
+const db = new Database(join(DATA_DIR, "localcloud.db"));
 db.pragma("journal_mode = WAL");
 
 db.exec(`
@@ -61,4 +64,4 @@ if (!profile) {
   ).run(defaultProject.id);
 }
 
-module.exports = db;
+export default db;

--- a/localcloud-api/db.js
+++ b/localcloud-api/db.js
@@ -1,0 +1,64 @@
+const Database = require("better-sqlite3");
+const path = require("path");
+const fs = require("fs");
+
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, "data");
+if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
+
+const db = new Database(path.join(DATA_DIR, "localcloud.db"));
+db.pragma("journal_mode = WAL");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS projects (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    name        TEXT NOT NULL UNIQUE,
+    label       TEXT NOT NULL,
+    description TEXT,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS user_profile (
+    id                 INTEGER PRIMARY KEY DEFAULT 1,
+    preferred_language TEXT NOT NULL DEFAULT 'typescript',
+    highlight_theme    TEXT NOT NULL DEFAULT 'github-dark',
+    display_name       TEXT DEFAULT 'Developer',
+    active_project_id  INTEGER REFERENCES projects(id) ON DELETE SET NULL,
+    created_at         DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at         DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+
+  CREATE TABLE IF NOT EXISTS saved_configs (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id    INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name          TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    config_json   TEXT NOT NULL,
+    created_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+  );
+`);
+
+// Seed default project
+let defaultProject = db
+  .prepare("SELECT id FROM projects WHERE name = ?")
+  .get("default");
+if (!defaultProject) {
+  const result = db
+    .prepare(
+      "INSERT INTO projects (name, label, description) VALUES (?, ?, ?)"
+    )
+    .run("default", "Default", "Default project");
+  defaultProject = { id: result.lastInsertRowid };
+}
+
+// Seed profile row (id = 1)
+const profile = db
+  .prepare("SELECT id FROM user_profile WHERE id = 1")
+  .get();
+if (!profile) {
+  db.prepare(
+    "INSERT INTO user_profile (id, active_project_id) VALUES (1, ?)"
+  ).run(defaultProject.id);
+}
+
+module.exports = db;

--- a/localcloud-api/package-lock.json
+++ b/localcloud-api/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "localcloud-api",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "localcloud-api",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.1692.0",
         "axios": "^1.6.0",
+        "better-sqlite3": "^9.4.3",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "mammoth": "^1.9.1",
@@ -210,6 +211,17 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -220,6 +232,64 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -374,6 +444,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -502,6 +578,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -541,6 +641,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dingbat-to-unicode": {
@@ -585,6 +694,15 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -705,6 +823,15 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -754,6 +881,12 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -853,6 +986,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -895,6 +1034,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -1021,6 +1166,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -1315,6 +1466,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1346,6 +1509,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1369,12 +1538,30 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-cron": {
@@ -1495,6 +1682,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -1554,6 +1750,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -1581,6 +1804,16 @@
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "1.3.2",
@@ -1630,6 +1863,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -1720,7 +1968,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1870,6 +2117,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/simple-swizzle": {
@@ -2035,6 +2327,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -2045,6 +2346,48 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/text-hex": {
@@ -2087,6 +2430,18 @@
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -2259,6 +2614,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.17.1",

--- a/localcloud-api/package.json
+++ b/localcloud-api/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0",
   "description": "LocalCloud Kit API Server",
   "main": "server.js",
+  "type": "module",
   "engines": {
     "node": ">=22.0.0"
   },

--- a/localcloud-api/package.json
+++ b/localcloud-api/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "aws-sdk": "^2.1692.0",
     "axios": "^1.6.0",
+    "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "mammoth": "^1.9.1",

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -57,13 +57,9 @@ let localstackStatus = {
 const internalEndpoint = "http://localstack:4566";
 // User-friendly endpoint for GUI display
 const userEndpoint = "http://localhost:4566";
+const awsRegion = process.env.AWS_DEFAULT_REGION || "us-east-1";
 
-// Default project configuration (hardcoded for local development)
-let projectConfig = {
-  projectName: "localstack-dev",
-  awsEndpoint: "http://localstack:4566",
-  awsRegion: "us-east-1",
-};
+const db = require("./db");
 
 // Configure multer for file uploads
 const upload = multer({
@@ -313,7 +309,7 @@ async function createSingleResource(projectName, resourceType, config = {}) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -373,7 +369,7 @@ async function destroyResources(request) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -407,7 +403,7 @@ async function destroySingleResource(projectName, resourceType, resourceName) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -441,7 +437,7 @@ async function listResources(projectName) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -486,7 +482,7 @@ async function listAllBuckets(projectName) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -542,7 +538,7 @@ async function listBucketContents(projectName, bucketName) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -594,7 +590,7 @@ async function listDynamoDBTables(projectName) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -643,7 +639,7 @@ async function scanDynamoDBTable(projectName, tableName, limit = 100) {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -694,7 +690,7 @@ async function queryDynamoDBTable(
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -727,13 +723,13 @@ async function queryDynamoDBTable(
 
 async function getDynamoDBTableSchema(projectName, tableName) {
   try {
-    let command = `aws dynamodb describe-table --table-name "${tableName}" --endpoint-url "${internalEndpoint}" --region "${projectConfig.awsRegion}"`;
+    let command = `aws dynamodb describe-table --table-name "${tableName}" --endpoint-url "${internalEndpoint}" --region "${awsRegion}"`;
 
     const { stdout, stderr } = await execAsync(command, {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -875,15 +871,135 @@ app.get("/resources/status", async (req, res) => {
 
 // Configuration Management
 app.get("/config/project", (req, res) => {
-  // Return user-friendly endpoint for GUI display
-  const userFriendlyConfig = {
-    ...projectConfig,
-    awsEndpoint: userEndpoint,
-  };
+  const row = db
+    .prepare(
+      `SELECT p.name as projectName
+       FROM user_profile u
+       LEFT JOIN projects p ON u.active_project_id = p.id
+       WHERE u.id = 1`
+    )
+    .get();
   res.json({
     success: true,
-    data: userFriendlyConfig,
+    data: {
+      projectName: row?.projectName || "default",
+      awsEndpoint: userEndpoint,
+      awsRegion,
+    },
   });
+});
+
+// Profile
+app.get("/profile", (req, res) => {
+  const profile = db
+    .prepare(
+      `SELECT u.*, p.name as active_project_name, p.label as active_project_label
+       FROM user_profile u
+       LEFT JOIN projects p ON u.active_project_id = p.id
+       WHERE u.id = 1`
+    )
+    .get();
+  res.json({ success: true, data: profile });
+});
+
+app.put("/profile", (req, res) => {
+  const { preferred_language, highlight_theme, display_name, active_project_id } = req.body;
+  const sets = [];
+  const vals = [];
+  if (preferred_language !== undefined) { sets.push("preferred_language = ?"); vals.push(preferred_language); }
+  if (highlight_theme !== undefined) { sets.push("highlight_theme = ?"); vals.push(highlight_theme); }
+  if (display_name !== undefined) { sets.push("display_name = ?"); vals.push(display_name); }
+  if (active_project_id !== undefined) { sets.push("active_project_id = ?"); vals.push(active_project_id); }
+  if (sets.length === 0) return res.status(400).json({ success: false, error: "No fields to update" });
+  sets.push("updated_at = CURRENT_TIMESTAMP");
+  db.prepare(`UPDATE user_profile SET ${sets.join(", ")} WHERE id = 1`).run(...vals);
+  const profile = db
+    .prepare(
+      `SELECT u.*, p.name as active_project_name, p.label as active_project_label
+       FROM user_profile u
+       LEFT JOIN projects p ON u.active_project_id = p.id
+       WHERE u.id = 1`
+    )
+    .get();
+  res.json({ success: true, data: profile });
+});
+
+// Projects
+app.get("/projects", (req, res) => {
+  const projects = db.prepare("SELECT * FROM projects ORDER BY created_at ASC").all();
+  res.json({ success: true, data: projects });
+});
+
+app.post("/projects", (req, res) => {
+  const { name, label, description } = req.body;
+  if (!name || !label) return res.status(400).json({ success: false, error: "name and label are required" });
+  try {
+    const result = db
+      .prepare("INSERT INTO projects (name, label, description) VALUES (?, ?, ?)")
+      .run(name, label, description || null);
+    const project = db.prepare("SELECT * FROM projects WHERE id = ?").get(result.lastInsertRowid);
+    res.json({ success: true, data: project });
+  } catch {
+    res.status(400).json({ success: false, error: "Project name already exists" });
+  }
+});
+
+app.put("/projects/:id", (req, res) => {
+  const { label, description } = req.body;
+  db.prepare("UPDATE projects SET label = COALESCE(?, label), description = COALESCE(?, description) WHERE id = ?")
+    .run(label || null, description !== undefined ? description : null, req.params.id);
+  const project = db.prepare("SELECT * FROM projects WHERE id = ?").get(req.params.id);
+  if (!project) return res.status(404).json({ success: false, error: "Project not found" });
+  res.json({ success: true, data: project });
+});
+
+app.delete("/projects/:id", (req, res) => {
+  const profile = db.prepare("SELECT active_project_id FROM user_profile WHERE id = 1").get();
+  if (profile?.active_project_id == req.params.id) {
+    return res.status(400).json({ success: false, error: "Cannot delete the active project. Switch projects first." });
+  }
+  db.prepare("DELETE FROM projects WHERE id = ?").run(req.params.id);
+  res.json({ success: true });
+});
+
+// Saved Configs
+app.get("/saved-configs", (req, res) => {
+  const { project_id, type } = req.query;
+  let query = "SELECT * FROM saved_configs WHERE 1=1";
+  const params = [];
+  if (project_id) { query += " AND project_id = ?"; params.push(project_id); }
+  if (type) { query += " AND resource_type = ?"; params.push(type); }
+  query += " ORDER BY created_at DESC";
+  const rows = db.prepare(query).all(...params);
+  const configs = rows.map((r) => ({ ...r, config: JSON.parse(r.config_json) }));
+  res.json({ success: true, data: configs });
+});
+
+app.post("/saved-configs", (req, res) => {
+  const { project_id, name, resource_type, config } = req.body;
+  if (!project_id || !name || !resource_type || !config) {
+    return res.status(400).json({ success: false, error: "project_id, name, resource_type, and config are required" });
+  }
+  const result = db
+    .prepare("INSERT INTO saved_configs (project_id, name, resource_type, config_json) VALUES (?, ?, ?, ?)")
+    .run(project_id, name, resource_type, JSON.stringify(config));
+  const row = db.prepare("SELECT * FROM saved_configs WHERE id = ?").get(result.lastInsertRowid);
+  res.json({ success: true, data: { ...row, config: JSON.parse(row.config_json) } });
+});
+
+app.put("/saved-configs/:id", (req, res) => {
+  const { name, config } = req.body;
+  db.prepare(
+    "UPDATE saved_configs SET name = COALESCE(?, name), config_json = COALESCE(?, config_json), updated_at = CURRENT_TIMESTAMP WHERE id = ?"
+  ).run(name || null, config ? JSON.stringify(config) : null, req.params.id);
+  const row = db.prepare("SELECT * FROM saved_configs WHERE id = ?").get(req.params.id);
+  if (!row) return res.status(404).json({ success: false, error: "Saved config not found" });
+  res.json({ success: true, data: { ...row, config: JSON.parse(row.config_json) } });
+});
+
+app.delete("/saved-configs/:id", (req, res) => {
+  db.prepare("DELETE FROM saved_configs WHERE id = ?").run(req.params.id);
+  res.json({ success: true });
 });
 
 app.get("/config/templates", (req, res) => {
@@ -964,7 +1080,7 @@ app.get("/s3/bucket/:bucketName/object/*", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1061,7 +1177,7 @@ app.post(
         env: {
           ...process.env,
           AWS_ENDPOINT_URL: internalEndpoint,
-          AWS_DEFAULT_REGION: projectConfig.awsRegion,
+          AWS_DEFAULT_REGION: awsRegion,
         },
       });
 
@@ -1144,7 +1260,7 @@ app.post("/s3/bucket/:bucketName/upload", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1190,7 +1306,7 @@ app.delete("/s3/bucket/:bucketName/object/*", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1293,7 +1409,7 @@ app.post("/dynamodb/table/:tableName/item", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
     if (stderr) {
@@ -1339,7 +1455,7 @@ app.delete("/dynamodb/table/:tableName/item", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1501,7 +1617,7 @@ app.get("/secrets", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1560,7 +1676,7 @@ app.post("/secrets", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1622,7 +1738,7 @@ app.get("/secrets/:secretName", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1671,7 +1787,7 @@ app.put("/secrets/:secretName", async (req, res) => {
     }
 
     // For updating, we'll use the AWS CLI directly since we need to handle updates
-    let command = `aws --endpoint-url=${internalEndpoint} --region=${projectConfig.awsRegion} secretsmanager update-secret --secret-id "${secretName}" --secret-string "${secretValue}"`;
+    let command = `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} secretsmanager update-secret --secret-id "${secretName}" --secret-string "${secretValue}"`;
 
     if (description) {
       command += ` --description "${description}"`;
@@ -1685,7 +1801,7 @@ app.put("/secrets/:secretName", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 
@@ -1699,13 +1815,13 @@ app.put("/secrets/:secretName", async (req, res) => {
         .map(([key, value]) => `Key=${key},Value=${value}`)
         .join(" ");
 
-      const tagCommand = `aws --endpoint-url=${internalEndpoint} --region=${projectConfig.awsRegion} secretsmanager tag-resource --secret-id "${secretName}" --tags ${tagString}`;
+      const tagCommand = `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} secretsmanager tag-resource --secret-id "${secretName}" --tags ${tagString}`;
 
       await execAsync(tagCommand, {
         env: {
           ...process.env,
           AWS_ENDPOINT_URL: internalEndpoint,
-          AWS_DEFAULT_REGION: projectConfig.awsRegion,
+          AWS_DEFAULT_REGION: awsRegion,
         },
       });
     }
@@ -1751,7 +1867,7 @@ app.delete("/secrets/:secretName", async (req, res) => {
       env: {
         ...process.env,
         AWS_ENDPOINT_URL: internalEndpoint,
-        AWS_DEFAULT_REGION: projectConfig.awsRegion,
+        AWS_DEFAULT_REGION: awsRegion,
       },
     });
 

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -778,6 +778,99 @@ app.get("/health", (req, res) => {
   });
 });
 
+// Batched dashboard data (single round-trip for dashboard load)
+app.get("/dashboard", async (req, res) => {
+  try {
+    const projectConfigRow = db
+      .prepare(
+        `SELECT p.name as projectName
+         FROM user_profile u
+         LEFT JOIN projects p ON u.active_project_id = p.id
+         WHERE u.id = 1`
+      )
+      .get();
+    const projectConfig = {
+      projectName: projectConfigRow?.projectName || "default",
+      awsEndpoint: userEndpoint,
+      awsRegion,
+    };
+
+    const localstackStatusForDashboard = {
+      ...localstackStatus,
+      endpoint: userEndpoint,
+    };
+
+    const MAILPIT_URL =
+      process.env.MAILPIT_INTERNAL_URL || "http://mailpit:8025";
+
+    const [mailpitResult, resources, cacheResult] = await Promise.all([
+      axios
+        .get(`${MAILPIT_URL}/api/v1/info`, { timeout: 3000 })
+        .then((r) => ({
+          total: r.data.Messages ?? 0,
+          unread: r.data.Unread ?? 0,
+          status: "healthy",
+        }))
+        .catch(() => ({ total: 0, unread: 0, status: "unavailable" })),
+      listResources(projectConfig.projectName),
+      execAsync(`/bin/sh ${path.join("/app/scripts/shell", "list_cache.sh")}`)
+        .then(({ stdout }) => JSON.parse(stdout))
+        .catch(() => ({ status: "unknown", info: null })),
+    ]);
+
+    const redisStatus =
+      cacheResult.status === "running" ? "running" : "stopped";
+    const resourcesWithExtras = [...resources];
+    resourcesWithExtras.push({
+      id: "cache-redis",
+      name: "Redis Cache",
+      type: "cache",
+      status: redisStatus === "running" ? "active" : "error",
+      environment: "local",
+      project: projectConfig.projectName,
+      createdAt: new Date().toISOString(),
+      details: {
+        info: cacheResult.info,
+        status: cacheResult.status,
+      },
+    });
+    resourcesWithExtras.push({
+      id: "mailpit-inbox",
+      name: "Inbox",
+      type: "mailpit",
+      status: mailpitResult.status === "healthy" ? "active" : "error",
+      environment: "local",
+      project: projectConfig.projectName,
+      createdAt: new Date().toISOString(),
+      details: {
+        total: mailpitResult.total,
+        unread: mailpitResult.unread,
+        status: mailpitResult.status,
+      },
+    });
+
+    res.json({
+      success: true,
+      data: {
+        localstackStatus: localstackStatusForDashboard,
+        projectConfig,
+        mailpit: mailpitResult,
+        resources: resourcesWithExtras,
+        redis: {
+          status: redisStatus,
+          info: cacheResult.info,
+        },
+      },
+    });
+  } catch (err) {
+    addLog("error", `Dashboard aggregation failed: ${err.message}`, "api");
+    res.status(500).json({
+      success: false,
+      error: err.message || "Failed to load dashboard data",
+    });
+  }
+});
+
 // LocalStack Management
 app.get("/localstack/status", (req, res) => {
   // Return user-friendly endpoint for GUI display

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -1,22 +1,22 @@
-const express = require("express");
-const cors = require("cors");
-const { exec } = require("child_process");
-const { promisify } = require("util");
-const axios = require("axios");
-const winston = require("winston");
-const cron = require("node-cron");
-const http = require("http");
-const socketIo = require("socket.io");
-const path = require("path");
-const fs = require("fs");
-const multer = require("multer");
-const nodemailer = require("nodemailer");
+import express from "express";
+import cors from "cors";
+import { exec } from "child_process";
+import { promisify } from "util";
+import axios from "axios";
+import winston from "winston";
+import cron from "node-cron";
+import http from "http";
+import { Server as SocketIOServer } from "socket.io";
+import path from "path";
+import fs from "fs";
+import multer from "multer";
+import nodemailer from "nodemailer";
 
 const execAsync = promisify(exec);
 
 const app = express();
 const server = http.createServer(app);
-const io = socketIo(server, {
+const io = new SocketIOServer(server, {
   cors: {
     origin: process.env.SOCKET_IO_ORIGIN || "https://app-local.localcloudkit.com:3030",
     methods: ["GET", "POST"],
@@ -59,7 +59,7 @@ const internalEndpoint = "http://localstack:4566";
 const userEndpoint = "http://localhost:4566";
 const awsRegion = process.env.AWS_DEFAULT_REGION || "us-east-1";
 
-const db = require("./db");
+import db from "./db.js";
 
 // Configure multer for file uploads
 const upload = multer({

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { usePreferences } from "@/context/PreferencesContext";
+import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
 function CodeBlock({ code }: { code: string }) {
@@ -32,7 +33,53 @@ function CodeBlock({ code }: { code: string }) {
   );
 }
 
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
 const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  GetCommand,
+  QueryCommand,
+  DeleteCommand,
+} from "@aws-sdk/lib-dynamodb";
+
+const client = new DynamoDBClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+const ddb = DynamoDBDocumentClient.from(client);
+
+// Put an item
+await ddb.send(new PutCommand({
+  TableName: "my-table",
+  Item: { id: "user-1", name: "Alice", email: "alice@example.com" },
+}));
+
+// Get an item
+const { Item } = await ddb.send(new GetCommand({
+  TableName: "my-table",
+  Key: { id: "user-1" },
+}));
+console.log(Item as Record<string, unknown>);
+
+// Query items
+const { Items } = await ddb.send(new QueryCommand({
+  TableName: "my-table",
+  KeyConditionExpression: "id = :id",
+  ExpressionAttributeValues: { ":id": "user-1" },
+}));
+console.log(Items);
+
+// Delete an item
+await ddb.send(new DeleteCommand({
+  TableName: "my-table",
+  Key: { id: "user-1" },
+}));`,
   node: `// npm install @aws-sdk/client-dynamodb @aws-sdk/lib-dynamodb
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, PutCommand, GetCommand, QueryCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
@@ -154,7 +201,20 @@ const externalResources = [
 ];
 
 export default function DynamoDBDocPage() {
-  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
@@ -249,13 +309,14 @@ export default function DynamoDBDocPage() {
           </p>
           <div className="flex space-x-1 mb-4 border-b border-gray-200">
             {([
+              { key: "typescript" as const, label: "TypeScript" },
               { key: "node" as const, label: "Node.js" },
               { key: "python" as const, label: "Python" },
               { key: "cli" as const, label: "AWS CLI" },
             ]).map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => handleTabChange(key)}
                 className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
                   activeTab === key
                     ? "border-blue-600 text-blue-600"
@@ -266,6 +327,7 @@ export default function DynamoDBDocPage() {
               </button>
             ))}
           </div>
+          {activeTab === "typescript" && <CodeBlock code={sdkExamples.typescript} />}
           {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
           {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
           {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -4,34 +4,12 @@ import {
   ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   CircleStackIcon,
-  ClipboardDocumentIcon,
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
-import { toast } from "react-hot-toast";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
 type PageTab = (typeof PAGE_TABS)[number];
@@ -327,10 +305,18 @@ export default function DynamoDBDocPage() {
               </button>
             ))}
           </div>
-          {activeTab === "typescript" && <CodeBlock code={sdkExamples.typescript} />}
-          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
-          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
-          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="node" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="cli" />
+          )}
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/app/layout.tsx
+++ b/localcloud-gui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
+import { PreferencesProvider } from "@/context/PreferencesContext";
 
 export const metadata: Metadata = {
   title: "LocalCloud Kit",
@@ -14,7 +15,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased font-sans">{children}</body>
+      <body className="antialiased font-sans">
+        <PreferencesProvider>{children}</PreferencesProvider>
+      </body>
     </html>
   );
 }

--- a/localcloud-gui/src/app/localstack/page.tsx
+++ b/localcloud-gui/src/app/localstack/page.tsx
@@ -2,32 +2,11 @@
 
 import { useLocalStackStatus } from "@/hooks/useLocalStackStatus";
 import StatusCard from "@/components/StatusCard";
-import { ArrowLeftIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import { toast } from "react-hot-toast";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 export default function LocalStackIntegrationPage() {
   const { status, projectConfig, loading } = useLocalStackStatus();
@@ -194,9 +173,9 @@ alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
               </button>
             ))}
           </div>
-          {activeTab === "node" && <CodeBlock code={nodeExample} />}
-          {activeTab === "python" && <CodeBlock code={pythonExample} />}
-          {activeTab === "cli" && <CodeBlock code={cliExample} />}
+          {activeTab === "node" && <ThemeableCodeBlock code={nodeExample} language="node" />}
+          {activeTab === "python" && <ThemeableCodeBlock code={pythonExample} language="python" />}
+          {activeTab === "cli" && <ThemeableCodeBlock code={cliExample} language="cli" />}
         </section>
 
         {/* Quick Commands */}
@@ -205,15 +184,15 @@ alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
           <div className="space-y-3">
             <div>
               <p className="text-sm text-gray-600 mb-1.5">Start LocalStack</p>
-              <CodeBlock code="docker compose up -d localstack" />
+              <ThemeableCodeBlock code="docker compose up -d localstack" language="cli" showThemeSelector={false} />
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-1.5">Stop LocalStack</p>
-              <CodeBlock code="docker compose stop localstack" />
+              <ThemeableCodeBlock code="docker compose stop localstack" language="cli" showThemeSelector={false} />
             </div>
             <div>
               <p className="text-sm text-gray-600 mb-1.5">Check health</p>
-              <CodeBlock code={`curl ${projectConfig.awsEndpoint}/_localstack/health`} />
+              <ThemeableCodeBlock code={`curl ${projectConfig.awsEndpoint}/_localstack/health`} language="cli" showThemeSelector={false} />
             </div>
           </div>
         </section>

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -4,37 +4,15 @@ import MailpitModal from "@/components/MailpitModal";
 import {
   ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
   InboxIcon,
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import { toast } from "react-hot-toast";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 const MAILPIT_UI_URL = "https://mailpit.localcloudkit.com:3030";
 const MAILPIT_UI_DIRECT = "http://localhost:8025";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
 
 const frameworkExamples = {
   nodemailer: `// npm install nodemailer
@@ -308,31 +286,31 @@ export default function MailpitIntegrationPage() {
           {activeFrameworkTab === "nodemailer" && (
             <div>
               <p className="text-sm text-gray-500 mb-2">Node.js — <code className="bg-gray-100 px-1 rounded">npm install nodemailer</code></p>
-              <CodeBlock code={frameworkExamples.nodemailer} />
+              <ThemeableCodeBlock code={frameworkExamples.nodemailer} language="nodemailer" />
             </div>
           )}
           {activeFrameworkTab === "sendgrid" && (
             <div>
               <p className="text-sm text-gray-500 mb-2">Use Nodemailer as a local transport swap — no SendGrid API key needed in dev.</p>
-              <CodeBlock code={frameworkExamples.sendgrid} />
+              <ThemeableCodeBlock code={frameworkExamples.sendgrid} language="sendgrid" />
             </div>
           )}
           {activeFrameworkTab === "laravel" && (
             <div>
               <p className="text-sm text-gray-500 mb-2">Set the mail driver in <code className="bg-gray-100 px-1 rounded">.env</code> and use the Mail facade normally.</p>
-              <CodeBlock code={frameworkExamples.laravel} />
+              <ThemeableCodeBlock code={frameworkExamples.laravel} language="laravel" />
             </div>
           )}
           {activeFrameworkTab === "django" && (
             <div>
               <p className="text-sm text-gray-500 mb-2">Configure <code className="bg-gray-100 px-1 rounded">settings.py</code> and use Django's built-in <code className="bg-gray-100 px-1 rounded">send_mail</code>.</p>
-              <CodeBlock code={frameworkExamples.django} />
+              <ThemeableCodeBlock code={frameworkExamples.django} language="django" />
             </div>
           )}
           {activeFrameworkTab === "flask" && (
             <div>
               <p className="text-sm text-gray-500 mb-2"><code className="bg-gray-100 px-1 rounded">pip install Flask-Mail</code> — configure once, send anywhere in your app.</p>
-              <CodeBlock code={frameworkExamples.flask} />
+              <ThemeableCodeBlock code={frameworkExamples.flask} language="flask" />
             </div>
           )}
         </section>

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { usePreferences } from "@/context/PreferencesContext";
+import { projectsApi, savedConfigsApi } from "@/services/api";
+import { HighlightTheme, PreferredLanguage, Project } from "@/types";
+import {
+  ArrowLeftIcon,
+  CircleStackIcon,
+  FolderIcon,
+  KeyIcon,
+  PlusIcon,
+  TrashIcon,
+  UserCircleIcon,
+} from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+import { Toaster } from "react-hot-toast";
+
+const LANGUAGES: { value: PreferredLanguage; label: string }[] = [
+  { value: "typescript", label: "TypeScript" },
+  { value: "node", label: "JavaScript (Node)" },
+  { value: "python", label: "Python" },
+  { value: "go", label: "Go" },
+  { value: "java", label: "Java" },
+  { value: "cli", label: "AWS CLI" },
+];
+
+const THEMES: { value: HighlightTheme; label: string }[] = [
+  { value: "github-dark", label: "GitHub Dark" },
+  { value: "github", label: "GitHub Light" },
+  { value: "github-dark-dimmed", label: "GitHub Dark Dimmed" },
+  { value: "atom-one-dark", label: "Atom One Dark" },
+  { value: "atom-one-light", label: "Atom One Light" },
+];
+
+const RESOURCE_ICONS: Record<string, React.ReactNode> = {
+  s3: <FolderIcon className="h-4 w-4 text-yellow-600" />,
+  dynamodb: <CircleStackIcon className="h-4 w-4 text-indigo-600" />,
+  secrets: <KeyIcon className="h-4 w-4 text-green-600" />,
+};
+
+export default function ProfilePage() {
+  const {
+    profile,
+    projects,
+    savedConfigs,
+    updateProfile,
+    createProject,
+    deleteProject,
+    deleteSavedConfig,
+  } = usePreferences();
+
+  const [newProjectLabel, setNewProjectLabel] = useState("");
+  const [newProjectDesc, setNewProjectDesc] = useState("");
+  const [showNewProject, setShowNewProject] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+      </div>
+    );
+  }
+
+  const handleLanguageChange = async (lang: PreferredLanguage) => {
+    try {
+      await updateProfile({ preferred_language: lang });
+      toast.success("Language preference saved");
+    } catch {
+      toast.error("Failed to save preference");
+    }
+  };
+
+  const handleThemeChange = async (theme: HighlightTheme) => {
+    try {
+      await updateProfile({ highlight_theme: theme });
+      toast.success("Theme preference saved");
+    } catch {
+      toast.error("Failed to save preference");
+    }
+  };
+
+  const handleDisplayNameSave = async (name: string) => {
+    try {
+      await updateProfile({ display_name: name });
+      toast.success("Display name saved");
+    } catch {
+      toast.error("Failed to save display name");
+    }
+  };
+
+  const handleCreateProject = async () => {
+    if (!newProjectLabel.trim()) return;
+    setSaving(true);
+    try {
+      const name = newProjectLabel.trim().toLowerCase().replace(/[^a-z0-9-]/g, "-");
+      await createProject(name, newProjectLabel.trim(), newProjectDesc.trim() || undefined);
+      setNewProjectLabel("");
+      setNewProjectDesc("");
+      setShowNewProject(false);
+      toast.success("Project created");
+    } catch {
+      toast.error("Failed to create project (name may already exist)");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDeleteProject = async (project: Project) => {
+    if (project.id === profile.active_project_id) {
+      toast.error("Switch to a different project before deleting this one");
+      return;
+    }
+    if (!confirm(`Delete project "${project.label}" and all its saved configs?`)) return;
+    try {
+      await deleteProject(project.id);
+      toast.success("Project deleted");
+    } catch {
+      toast.error("Failed to delete project");
+    }
+  };
+
+  const handleSwitchProject = async (id: number) => {
+    try {
+      await updateProfile({ active_project_id: id });
+      toast.success("Active project updated");
+    } catch {
+      toast.error("Failed to switch project");
+    }
+  };
+
+  const handleDeleteConfig = async (id: number) => {
+    try {
+      await deleteSavedConfig(id);
+      toast.success("Config deleted");
+    } catch {
+      toast.error("Failed to delete config");
+    }
+  };
+
+  const activeProjectConfigs = savedConfigs.filter(
+    (c) => c.project_id === profile.active_project_id
+  );
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <Toaster position="top-right" />
+
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-center space-x-3">
+              <Link
+                href="/"
+                className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+              >
+                <ArrowLeftIcon className="h-5 w-5" />
+              </Link>
+              <UserCircleIcon className="h-7 w-7 text-blue-600" />
+              <h1 className="text-xl font-bold text-gray-900">Profile & Preferences</h1>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+
+        {/* Preferences Card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-5">Preferences</h2>
+
+          <div className="space-y-5">
+            {/* Display Name */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Display Name</label>
+              <div className="flex items-center space-x-3">
+                <input
+                  type="text"
+                  defaultValue={profile.display_name}
+                  onBlur={(e) => {
+                    if (e.target.value !== profile.display_name) {
+                      handleDisplayNameSave(e.target.value);
+                    }
+                  }}
+                  className="w-64 px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                />
+              </div>
+            </div>
+
+            {/* Language Preference */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Preferred Code Language
+                <span className="ml-2 text-xs text-gray-400 font-normal">Used as default in SDK examples</span>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {LANGUAGES.map(({ value, label }) => (
+                  <button
+                    key={value}
+                    onClick={() => handleLanguageChange(value)}
+                    className={`px-4 py-2 rounded-md text-sm font-medium border transition-colors ${
+                      profile.preferred_language === value
+                        ? "bg-blue-600 text-white border-blue-600"
+                        : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Highlight Theme */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Code Highlight Theme
+                <span className="ml-2 text-xs text-gray-400 font-normal">Used in file viewer and code samples</span>
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {THEMES.map(({ value, label }) => (
+                  <button
+                    key={value}
+                    onClick={() => handleThemeChange(value)}
+                    className={`px-4 py-2 rounded-md text-sm font-medium border transition-colors ${
+                      profile.highlight_theme === value
+                        ? "bg-blue-600 text-white border-blue-600"
+                        : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Projects Card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <div className="flex items-center justify-between mb-5">
+            <h2 className="text-lg font-semibold text-gray-900">Projects</h2>
+            <button
+              onClick={() => setShowNewProject((v) => !v)}
+              className="flex items-center px-3 py-1.5 text-sm font-medium text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 transition-colors"
+            >
+              <PlusIcon className="h-4 w-4 mr-1" />
+              New Project
+            </button>
+          </div>
+
+          {showNewProject && (
+            <div className="mb-5 p-4 bg-blue-50 rounded-lg border border-blue-200 space-y-3">
+              <input
+                type="text"
+                placeholder="Project name (e.g. E-Commerce App)"
+                value={newProjectLabel}
+                onChange={(e) => setNewProjectLabel(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+                autoFocus
+              />
+              <input
+                type="text"
+                placeholder="Description (optional)"
+                value={newProjectDesc}
+                onChange={(e) => setNewProjectDesc(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+              />
+              <div className="flex space-x-2">
+                <button
+                  onClick={handleCreateProject}
+                  disabled={!newProjectLabel.trim() || saving}
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {saving ? "Creating..." : "Create"}
+                </button>
+                <button
+                  onClick={() => setShowNewProject(false)}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-2">
+            {projects.map((project) => {
+              const isActive = project.id === profile.active_project_id;
+              const configCount = savedConfigs.filter((c) => c.project_id === project.id).length;
+              return (
+                <div
+                  key={project.id}
+                  className={`flex items-center justify-between px-4 py-3 rounded-lg border transition-colors ${
+                    isActive
+                      ? "bg-blue-50 border-blue-200"
+                      : "bg-gray-50 border-gray-200 hover:border-gray-300"
+                  }`}
+                >
+                  <div className="flex items-center space-x-3">
+                    <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${isActive ? "bg-blue-500" : "bg-gray-300"}`} />
+                    <div>
+                      <p className={`text-sm font-medium ${isActive ? "text-blue-900" : "text-gray-900"}`}>
+                        {project.label}
+                        {isActive && <span className="ml-2 text-xs text-blue-600 font-normal">active</span>}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {project.description || `/${project.name}`} • {configCount} saved config{configCount !== 1 ? "s" : ""}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-2">
+                    {!isActive && (
+                      <button
+                        onClick={() => handleSwitchProject(project.id)}
+                        className="px-3 py-1 text-xs font-medium text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 transition-colors"
+                      >
+                        Switch
+                      </button>
+                    )}
+                    {project.name !== "default" && (
+                      <button
+                        onClick={() => handleDeleteProject(project)}
+                        className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                        title="Delete project"
+                      >
+                        <TrashIcon className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Saved Configs Card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Saved Configurations</h2>
+          <p className="text-sm text-gray-500 mb-5">
+            Scoped to active project: <span className="font-medium text-gray-700">{profile.active_project_label || "Default"}</span>
+          </p>
+
+          {activeProjectConfigs.length === 0 ? (
+            <p className="text-sm text-gray-400 italic">
+              No saved configs yet. Open a DynamoDB or S3 creation form and click &quot;Save config&quot; to add one.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {activeProjectConfigs.map((cfg) => (
+                <div
+                  key={cfg.id}
+                  className="flex items-center justify-between px-4 py-3 bg-gray-50 rounded-lg border border-gray-200"
+                >
+                  <div className="flex items-center space-x-3">
+                    <span>{RESOURCE_ICONS[cfg.resource_type] ?? null}</span>
+                    <div>
+                      <p className="text-sm font-medium text-gray-900">{cfg.name}</p>
+                      <p className="text-xs text-gray-500 capitalize">{cfg.resource_type}</p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleDeleteConfig(cfg.id)}
+                    className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
+                    title="Delete saved config"
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -9,7 +9,8 @@ import {
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { usePreferences } from "@/context/PreferencesContext";
+import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
 function CodeBlock({ code }: { code: string }) {
@@ -33,7 +34,30 @@ function CodeBlock({ code }: { code: string }) {
   );
 }
 
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
 const clientExamples = {
+  typescript: `// npm install ioredis
+import Redis from "ioredis";
+
+const redis = new Redis({
+  host: "localhost",
+  port: 6380,
+});
+
+// Set a key
+await redis.set("greeting", "hello world");
+await redis.set("counter", "42", "EX", 3600); // expires in 1 hour
+
+// Get a key
+const value: string | null = await redis.get("greeting");
+console.log(value); // "hello world"
+
+// Delete a key
+await redis.del("greeting");
+
+redis.quit();`,
   node: `// npm install ioredis
 const Redis = require("ioredis");
 
@@ -114,7 +138,20 @@ const externalResources = [
 
 export default function RedisDocPage() {
   const [showModal, setShowModal] = useState(false);
-  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
@@ -208,13 +245,14 @@ export default function RedisDocPage() {
           </p>
           <div className="flex space-x-1 mb-4 border-b border-gray-200">
             {([
+              { key: "typescript" as const, label: "TypeScript" },
               { key: "node" as const, label: "Node.js" },
               { key: "python" as const, label: "Python" },
               { key: "cli" as const, label: "Redis CLI" },
             ]).map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => handleTabChange(key)}
                 className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
                   activeTab === key
                     ? "border-blue-600 text-blue-600"
@@ -225,6 +263,14 @@ export default function RedisDocPage() {
               </button>
             ))}
           </div>
+          {activeTab === "typescript" && (
+            <div>
+              <p className="text-sm text-gray-500 mb-2">
+                TypeScript — <code className="bg-gray-100 px-1 rounded">npm install ioredis</code>
+              </p>
+              <CodeBlock code={clientExamples.typescript} />
+            </div>
+          )}
           {activeTab === "node" && (
             <div>
               <p className="text-sm text-gray-500 mb-2">

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -4,35 +4,13 @@ import RedisModal from "@/components/RedisModal";
 import {
   ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
-import { toast } from "react-hot-toast";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
 type PageTab = (typeof PAGE_TABS)[number];
@@ -268,7 +246,7 @@ export default function RedisDocPage() {
               <p className="text-sm text-gray-500 mb-2">
                 TypeScript — <code className="bg-gray-100 px-1 rounded">npm install ioredis</code>
               </p>
-              <CodeBlock code={clientExamples.typescript} />
+              <ThemeableCodeBlock code={clientExamples.typescript} language="typescript" />
             </div>
           )}
           {activeTab === "node" && (
@@ -276,7 +254,7 @@ export default function RedisDocPage() {
               <p className="text-sm text-gray-500 mb-2">
                 Node.js — <code className="bg-gray-100 px-1 rounded">npm install ioredis</code>
               </p>
-              <CodeBlock code={clientExamples.node} />
+              <ThemeableCodeBlock code={clientExamples.node} language="node" />
             </div>
           )}
           {activeTab === "python" && (
@@ -284,7 +262,7 @@ export default function RedisDocPage() {
               <p className="text-sm text-gray-500 mb-2">
                 Python — <code className="bg-gray-100 px-1 rounded">pip install redis</code>
               </p>
-              <CodeBlock code={clientExamples.python} />
+              <ThemeableCodeBlock code={clientExamples.python} language="python" />
             </div>
           )}
           {activeTab === "cli" && (
@@ -292,7 +270,7 @@ export default function RedisDocPage() {
               <p className="text-sm text-gray-500 mb-2">
                 Connect directly using <code className="bg-gray-100 px-1 rounded">redis-cli</code> on port 6380.
               </p>
-              <CodeBlock code={clientExamples.cli} />
+              <ThemeableCodeBlock code={clientExamples.cli} language="cli" />
             </div>
           )}
         </section>

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -3,35 +3,13 @@
 import {
   ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
   FolderIcon,
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
-import { toast } from "react-hot-toast";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
 type PageTab = (typeof PAGE_TABS)[number];
@@ -319,10 +297,18 @@ export default function S3DocPage() {
               </button>
             ))}
           </div>
-          {activeTab === "typescript" && <CodeBlock code={sdkExamples.typescript} />}
-          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
-          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
-          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="node" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="cli" />
+          )}
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -8,7 +8,8 @@ import {
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { usePreferences } from "@/context/PreferencesContext";
+import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
 function CodeBlock({ code }: { code: string }) {
@@ -32,7 +33,49 @@ function CodeBlock({ code }: { code: string }) {
   );
 }
 
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
 const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-s3
+import {
+  S3Client,
+  CreateBucketCommand,
+  PutObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  _Object,
+} from "@aws-sdk/client-s3";
+
+const s3 = new S3Client({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+  forcePathStyle: true,
+});
+
+// Create a bucket
+await s3.send(new CreateBucketCommand({ Bucket: "my-bucket" }));
+
+// Upload an object
+await s3.send(new PutObjectCommand({
+  Bucket: "my-bucket",
+  Key: "hello.txt",
+  Body: "Hello, LocalStack!",
+  ContentType: "text/plain",
+}));
+
+// Download an object
+const { Body } = await s3.send(new GetObjectCommand({
+  Bucket: "my-bucket",
+  Key: "hello.txt",
+}));
+const text = await Body!.transformToString();
+console.log(text);
+
+// List objects
+const { Contents } = await s3.send(new ListObjectsV2Command({ Bucket: "my-bucket" }));
+(Contents ?? []).forEach((obj: _Object) => console.log(obj.Key));`,
   node: `// npm install @aws-sdk/client-s3
 import { S3Client, CreateBucketCommand, PutObjectCommand, GetObjectCommand, ListObjectsV2Command } from "@aws-sdk/client-s3";
 
@@ -146,7 +189,20 @@ const externalResources = [
 ];
 
 export default function S3DocPage() {
-  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
@@ -245,13 +301,14 @@ export default function S3DocPage() {
           </p>
           <div className="flex space-x-1 mb-4 border-b border-gray-200">
             {([
+              { key: "typescript" as const, label: "TypeScript" },
               { key: "node" as const, label: "Node.js" },
               { key: "python" as const, label: "Python" },
               { key: "cli" as const, label: "AWS CLI" },
             ]).map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => handleTabChange(key)}
                 className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
                   activeTab === key
                     ? "border-blue-600 text-blue-600"
@@ -262,6 +319,7 @@ export default function S3DocPage() {
               </button>
             ))}
           </div>
+          {activeTab === "typescript" && <CodeBlock code={sdkExamples.typescript} />}
           {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
           {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
           {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -3,34 +3,12 @@
 import {
   ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
-import { toast } from "react-hot-toast";
-
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
 const sdkExamples = {
   node: `// npm install @aws-sdk/client-secrets-manager
@@ -285,9 +263,15 @@ export default function SecretsDocPage() {
               </button>
             ))}
           </div>
-          {activeTab === "node" && <CodeBlock code={sdkExamples.node} />}
-          {activeTab === "python" && <CodeBlock code={sdkExamples.python} />}
-          {activeTab === "cli" && <CodeBlock code={sdkExamples.cli} />}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="node" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="cli" />
+          )}
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/components/ConnectionGuide.tsx
+++ b/localcloud-gui/src/components/ConnectionGuide.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CodeBracketIcon, CommandLineIcon } from "@heroicons/react/24/outline";
-import { useEffect } from "react";
+import { usePreferences } from "@/context/PreferencesContext";
 import hljs from "highlight.js";
 
 // Import language support
@@ -27,6 +27,16 @@ const themeMap: Record<string, string> = {
   "hljs-github-dark-dimmed": "github-dark-dimmed.css",
   "hljs-solarized": "base16/solarized-light.css",
   "hljs-dark": "dark.css",
+};
+
+// Map profile highlight_theme (from PreferencesContext) to ConnectionGuide themeMap keys
+const profileThemeToConnectionTheme: Record<string, string> = {
+  github: "hljs",
+  "github-light": "hljs",
+  "github-dark": "hljs-github-dark",
+  "github-dark-dimmed": "hljs-github-dark-dimmed",
+  "atom-one-dark": "hljs-atom-dark",
+  "atom-one-light": "hljs-atom-light",
 };
 
 const CodeBlock = ({
@@ -551,9 +561,18 @@ const languageOptions = [
 ];
 
 export default function ConnectionGuide() {
+  const { profile } = usePreferences();
   const [activeTab, setActiveTab] = useState("setup");
   const [selectedLanguage, setSelectedLanguage] = useState("JavaScript");
-  const [selectedTheme, setSelectedTheme] = useState("hljs");
+  const profileTheme =
+    profile?.highlight_theme && profileThemeToConnectionTheme[profile.highlight_theme]
+      ? profileThemeToConnectionTheme[profile.highlight_theme]
+      : "hljs";
+  const [selectedTheme, setSelectedTheme] = useState(profileTheme);
+
+  useEffect(() => {
+    setSelectedTheme(profileTheme);
+  }, [profileTheme]);
 
   const tabs = [
     { id: "setup", name: "Basic Setup", icon: CodeBracketIcon },

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -46,7 +46,7 @@ export default function Dashboard() {
   const { profile, projects, updateProfile } = usePreferences();
 
   // Derive projectName: active project from preferences, fall back to config from API
-  const projectName = profile?.active_project_name || projectName;
+  const projectName = profile?.active_project_name || config.projectName;
 
   const [showDynamoDBConfig, setShowDynamoDBConfig] = useState(false);
   const [showS3Config, setShowS3Config] = useState(false);

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -29,6 +29,7 @@ import DynamoDBViewer from "./DynamoDBViewer";
 import LogViewer from "./LogViewer";
 import MailpitModal from "./MailpitModal";
 import RedisModal from "./RedisModal";
+import DashboardSkeleton from "./DashboardSkeleton";
 import S3ConfigModal from "./S3ConfigModal";
 import SecretsManagerViewer from "./SecretsManagerViewer";
 
@@ -247,25 +248,7 @@ export default function Dashboard() {
   };
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <div className="flex items-center justify-center space-x-3 mb-2">
-            <Image
-              src="/logo.svg"
-              alt="LocalCloud Kit"
-              width={32}
-              height={32}
-            />
-            <h2 className="text-xl font-bold text-gray-900">
-              LocalCloud Kit
-            </h2>
-          </div>
-          <p className="text-gray-600">Loading LocalCloud Kit...</p>
-        </div>
-      </div>
-    );
+    return <DashboardSkeleton />;
   }
 
   if (error) {

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
-import { resourceApi } from "@/services/api";
+import { projectsApi, resourceApi } from "@/services/api";
 import { DynamoDBTableConfig, S3BucketConfig } from "@/types";
 import {
   BookOpenIcon,
@@ -13,6 +14,7 @@ import {
   KeyIcon,
   ServerIcon,
   Squares2X2Icon,
+  UserCircleIcon,
 } from "@heroicons/react/24/outline";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
@@ -41,6 +43,10 @@ export default function Dashboard() {
   } = useServicesData();
 
   const { status: localstackStatus, projectConfig: config, resources } = localstack;
+  const { profile, projects, updateProfile } = usePreferences();
+
+  // Derive projectName: active project from preferences, fall back to config from API
+  const projectName = profile?.active_project_name || projectName;
 
   const [showDynamoDBConfig, setShowDynamoDBConfig] = useState(false);
   const [showS3Config, setShowS3Config] = useState(false);
@@ -62,8 +68,10 @@ export default function Dashboard() {
   // Dropdowns
   const [showToolsMenu, setShowToolsMenu] = useState(false);
   const [showDocsMenu, setShowDocsMenu] = useState(false);
+  const [showProjectMenu, setShowProjectMenu] = useState(false);
   const toolsMenuRef = useRef<HTMLDivElement>(null);
   const docsMenuRef = useRef<HTMLDivElement>(null);
+  const projectMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -73,10 +81,38 @@ export default function Dashboard() {
       if (docsMenuRef.current && !docsMenuRef.current.contains(e.target as Node)) {
         setShowDocsMenu(false);
       }
+      if (projectMenuRef.current && !projectMenuRef.current.contains(e.target as Node)) {
+        setShowProjectMenu(false);
+      }
     }
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  const handleSwitchProject = async (projectId: number) => {
+    try {
+      await updateProfile({ active_project_id: projectId });
+      setShowProjectMenu(false);
+      await loadInitialData();
+    } catch {
+      toast.error("Failed to switch project");
+    }
+  };
+
+  const handleCreateProject = async () => {
+    const label = prompt("Project name:");
+    if (!label) return;
+    const name = label.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+    try {
+      const project = await projectsApi.create(name, label);
+      await updateProfile({ active_project_id: project.id });
+      setShowProjectMenu(false);
+      await loadInitialData();
+      toast.success(`Project "${label}" created`);
+    } catch {
+      toast.error("Failed to create project");
+    }
+  };
 
 
   const handleCreateSingleResource = async (resourceType: string) => {
@@ -99,7 +135,7 @@ export default function Dashboard() {
     setCreateLoading(true);
     try {
       const response = await resourceApi.createSingle(
-        config.projectName,
+        projectName,
         resourceType
       );
       if (response.success) {
@@ -130,7 +166,7 @@ export default function Dashboard() {
     setCreateLoading(true);
     try {
       const response = await resourceApi.createSingleWithConfig(
-        config.projectName,
+        projectName,
         "dynamodb",
         { dynamodbConfig }
       );
@@ -159,7 +195,7 @@ export default function Dashboard() {
     setCreateLoading(true);
     try {
       const response = await resourceApi.createSingleWithConfig(
-        config.projectName,
+        projectName,
         "s3",
         { s3Config }
       );
@@ -188,7 +224,7 @@ export default function Dashboard() {
     setDestroyLoading(true);
     try {
       const response = await resourceApi.destroy({
-        projectName: config.projectName,
+        projectName: projectName,
         resourceIds: resourceIds,
       });
 
@@ -423,6 +459,60 @@ export default function Dashboard() {
                 )}
               </div>
 
+              {/* Project Switcher */}
+              <div className="relative" ref={projectMenuRef}>
+                <button
+                  onClick={() => { setShowProjectMenu((v) => !v); setShowToolsMenu(false); setShowDocsMenu(false); }}
+                  className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+                >
+                  <span className="h-2 w-2 rounded-full bg-blue-500 mr-2 flex-shrink-0" />
+                  {profile?.active_project_label || "Default"}
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showProjectMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showProjectMenu && (
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Projects</p>
+                    {projects.map((p) => (
+                      <button
+                        key={p.id}
+                        onClick={() => handleSwitchProject(p.id)}
+                        className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
+                          p.id === profile?.active_project_id
+                            ? "text-blue-700 bg-blue-50 font-medium"
+                            : "text-gray-700 hover:bg-gray-50"
+                        }`}
+                      >
+                        <span className={`h-2 w-2 rounded-full mr-3 flex-shrink-0 ${p.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
+                        {p.label}
+                      </button>
+                    ))}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <button
+                      onClick={handleCreateProject}
+                      className="flex items-center w-full px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors"
+                    >
+                      + New project
+                    </button>
+                    <Link
+                      href="/profile"
+                      onClick={() => setShowProjectMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      Manage projects...
+                    </Link>
+                  </div>
+                )}
+              </div>
+
+              {/* Profile icon */}
+              <Link
+                href="/profile"
+                className="p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                title="Profile & Preferences"
+              >
+                <UserCircleIcon className="h-6 w-6" />
+              </Link>
+
             </div>
           </div>
         </div>
@@ -512,7 +602,7 @@ export default function Dashboard() {
             <ResourceList
               resources={resources}
               onDestroy={handleDestroyResources}
-              projectName={config.projectName}
+              projectName={projectName}
               loading={destroyLoading}
               onRefresh={loadInitialData}
               onAddS3={() => handleCreateSingleResource("s3")}
@@ -537,33 +627,6 @@ export default function Dashboard() {
           </div>
         )}
 
-        {/* Configuration Summary */}
-        <div className="bg-white rounded-lg shadow-lg p-6 border border-gray-200">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
-            Current Configuration
-          </h3>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Project
-              </label>
-              <p className="mt-1 text-sm text-gray-900">{config.projectName}</p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                AWS Region
-              </label>
-              <p className="mt-1 text-sm text-gray-900">{config.awsRegion}</p>
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Endpoint
-              </label>
-              <p className="mt-1 text-sm text-gray-900">{config.awsEndpoint}</p>
-            </div>
-          </div>
-        </div>
-
         {/* Footer */}
         <div className="mt-8 text-center">
           <p className="text-xs text-gray-400">
@@ -579,7 +642,7 @@ export default function Dashboard() {
           isOpen={showDynamoDBConfig}
           onClose={() => setShowDynamoDBConfig(false)}
           onSubmit={handleCreateDynamoDBTable}
-          projectName={config.projectName}
+          projectName={projectName}
           loading={createLoading}
         />
       )}
@@ -589,7 +652,7 @@ export default function Dashboard() {
           isOpen={showS3Config}
           onClose={() => setShowS3Config(false)}
           onSubmit={handleCreateS3Bucket}
-          projectName={config.projectName}
+          projectName={projectName}
           loading={createLoading}
         />
       )}
@@ -605,7 +668,7 @@ export default function Dashboard() {
             setShowBuckets(false);
             setSelectedS3Bucket("");
           }}
-          projectName={config.projectName}
+          projectName={projectName}
           selectedBucketName={selectedS3Bucket}
         />
       )}
@@ -617,7 +680,7 @@ export default function Dashboard() {
             setShowDynamoDB(false);
             setSelectedDynamoDBTable("");
           }}
-          projectName={config.projectName}
+          projectName={projectName}
           selectedTableName={selectedDynamoDBTable}
         />
       )}
@@ -628,7 +691,7 @@ export default function Dashboard() {
           onClose={() => {
             setShowSecretsManager(false);
           }}
-          projectName={config.projectName}
+          projectName={projectName}
         />
       )}
 

--- a/localcloud-gui/src/components/DashboardSkeleton.tsx
+++ b/localcloud-gui/src/components/DashboardSkeleton.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+export default function DashboardSkeleton() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 animate-pulse">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <div className="flex items-center space-x-3">
+              <div className="h-10 w-10 rounded-lg bg-gray-200" />
+              <div className="space-y-2">
+                <div className="h-7 w-48 bg-gray-200 rounded" />
+                <div className="h-3 w-64 bg-gray-100 rounded" />
+              </div>
+            </div>
+            <div className="flex items-center space-x-3">
+              <div className="h-9 w-24 bg-gray-200 rounded-md" />
+              <div className="h-9 w-20 bg-gray-200 rounded-md" />
+              <div className="h-9 w-28 bg-gray-200 rounded-md" />
+              <div className="h-9 w-9 bg-gray-200 rounded-md" />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Services status bar */}
+        <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 flex items-center space-x-6">
+          <div className="flex items-center space-x-2">
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-200" />
+            <div className="h-4 w-20 bg-gray-200 rounded" />
+            <div className="h-5 w-16 bg-gray-100 rounded-full" />
+          </div>
+          <div className="h-4 w-px bg-gray-200" />
+          <div className="flex items-center space-x-2">
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-200" />
+            <div className="h-4 w-14 bg-gray-200 rounded" />
+            <div className="h-5 w-16 bg-gray-100 rounded-full" />
+          </div>
+          <div className="h-4 w-px bg-gray-200" />
+          <div className="flex items-center space-x-2">
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-200" />
+            <div className="h-4 w-16 bg-gray-200 rounded" />
+            <div className="h-5 w-20 bg-gray-100 rounded-full" />
+          </div>
+        </div>
+
+        {/* Resource list placeholder */}
+        <div className="mb-8 bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+            <div className="h-5 w-32 bg-gray-200 rounded" />
+            <div className="flex space-x-2">
+              <div className="h-9 w-24 bg-gray-200 rounded-md" />
+              <div className="h-9 w-28 bg-gray-200 rounded-md" />
+            </div>
+          </div>
+          <div className="p-6 space-y-4">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 p-4 border border-gray-200 rounded-lg"
+              >
+                <div className="h-10 w-10 rounded bg-gray-200 flex-shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-48 bg-gray-200 rounded" />
+                  <div className="h-3 w-32 bg-gray-100 rounded" />
+                </div>
+                <div className="h-8 w-20 bg-gray-100 rounded-md" />
+                <div className="h-8 w-8 bg-gray-100 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="mt-8 text-center">
+          <div className="h-3 w-64 bg-gray-100 rounded mx-auto" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
@@ -53,23 +53,51 @@ function validateAttributes(attrs: NestedAttribute[], path = ""): string | null 
   return null;
 }
 
+// Helper to determine if an attribute is effectively empty and should be skipped
+function isAttributeEmpty(attr: NestedAttribute): boolean {
+  if (attr.type === "S" || attr.type === "N") {
+    return !attr.value || attr.value === "";
+  }
+  if (attr.type === "BOOL") {
+    return attr.value === undefined;
+  }
+  if ((attr.type === "M" || attr.type === "L") && (!attr.children || attr.children.length === 0)) {
+    return true;
+  }
+  return false;
+}
+
 // Recursive builder for DynamoDB attribute
+// Returns undefined when the attribute is effectively empty so it can be dropped cleanly
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function buildDynamoDBAttribute(attr: NestedAttribute): any {
+  if (isAttributeEmpty(attr)) return undefined;
+
   if (attr.type === "S") return { S: attr.value ?? "" };
   if (attr.type === "N") return { N: attr.value ?? "" };
   if (attr.type === "BOOL") return { BOOL: attr.value === "true" };
+
   if (attr.type === "M" && attr.children) {
     const mapObj: Record<string, any> = {};
     for (const child of attr.children) {
       if (!child.key) continue;
-      mapObj[child.key] = buildDynamoDBAttribute(child);
+      const builtChild = buildDynamoDBAttribute(child);
+      if (builtChild !== undefined) {
+        mapObj[child.key] = builtChild;
+      }
     }
+    if (Object.keys(mapObj).length === 0) return undefined;
     return { M: mapObj };
   }
+
   if (attr.type === "L" && attr.children) {
-    return { L: attr.children.map(buildDynamoDBAttribute) };
+    const builtChildren = attr.children
+      .map((child) => buildDynamoDBAttribute(child))
+      .filter((child) => child !== undefined);
+    if (builtChildren.length === 0) return undefined;
+    return { L: builtChildren };
   }
+
   return undefined;
 }
 
@@ -200,6 +228,11 @@ function AttributeEditor({
           ))}
         </div>
       )}
+      {isAttributeEmpty(attr) && (
+        <p className="mt-1 text-xs text-amber-600">
+          This attribute is empty and will not be saved.
+        </p>
+      )}
     </div>
   );
 }
@@ -223,6 +256,15 @@ export default function DynamoDBAddItemModal({
       loadTableSchema();
     }
   }, [isOpen, tableName]);
+
+  // Reset form state each time the modal is opened so previous values don't persist
+  useEffect(() => {
+    if (isOpen) {
+      setKeyValues({});
+      setAttributes([]);
+      setError("");
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -303,10 +345,12 @@ export default function DynamoDBAddItemModal({
       item[key.AttributeName] = { S: keyValues[key.AttributeName] };
     });
 
-    // Add custom attributes
+    // Add custom attributes (skip empty ones)
     for (const attr of attributes) {
       if (!attr.key) continue;
-      item[attr.key] = buildDynamoDBAttribute(attr);
+      const built = buildDynamoDBAttribute(attr);
+      if (built === undefined) continue;
+      item[attr.key] = built;
     }
 
     onSubmit(item);

--- a/localcloud-gui/src/components/DynamoDBConfigModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBConfigModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { XMarkIcon, PlusIcon, TrashIcon, CircleStackIcon } from "@heroicons/react/24/outline";
 import { DynamoDBTableConfig, DynamoDBGSI } from "@/types";
+import SavedConfigPicker from "./SavedConfigPicker";
 
 interface DynamoDBConfigModalProps {
   isOpen: boolean;
@@ -41,6 +42,26 @@ export default function DynamoDBConfigModal({
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
+
+  const loadSavedConfig = (config: DynamoDBTableConfig) => {
+    setTableName(config.tableName || "");
+    setPartitionKey(config.partitionKey || "pk");
+    setSortKey(config.sortKey || "");
+    setBillingMode(config.billingMode || "PAY_PER_REQUEST");
+    setReadCapacity(config.readCapacity || 5);
+    setWriteCapacity(config.writeCapacity || 5);
+    setGsis(config.gsis || []);
+  };
+
+  const currentConfig: DynamoDBTableConfig = {
+    tableName,
+    partitionKey,
+    sortKey,
+    billingMode,
+    readCapacity: billingMode === "PROVISIONED" ? readCapacity : undefined,
+    writeCapacity: billingMode === "PROVISIONED" ? writeCapacity : undefined,
+    gsis,
+  };
 
   const addGSI = () => {
     if (gsis.length >= 5) return;
@@ -110,6 +131,13 @@ export default function DynamoDBConfigModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <SavedConfigPicker
+            resourceType="dynamodb"
+            onLoad={loadSavedConfig}
+            currentConfig={currentConfig}
+            configLabel="Table"
+          />
+
           {/* Basic Table Configuration */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -6,8 +6,8 @@ import {
   getDynamoDBTableSchema,
 } from "@/services/api";
 import {
+  ArrowsPointingOutIcon,
   MagnifyingGlassIcon,
-  PlusIcon,
   TrashIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
@@ -391,7 +391,7 @@ export default function DynamoDBViewer({
         </div>
 
         {/* Content */}
-        <div className="flex-1 flex flex-col p-6 space-y-4 overflow-hidden">
+        <div className="flex-1 flex flex-col p-6 gap-4 min-h-0">
           {/* Table Selection */}
           <div className="flex items-center space-x-4 flex-shrink-0">
             <label className="text-sm font-medium text-gray-700">
@@ -596,36 +596,34 @@ export default function DynamoDBViewer({
               </div>
 
               {/* Items Table */}
-              <div className="flex-1 overflow-hidden">
+              <div className="flex-1 min-h-0 overflow-auto border border-gray-200 rounded-lg pb-4">
                 {items.length === 0 ? (
                   <div className="text-center py-8 text-gray-500">
                     {loading ? "Loading items..." : "No items found"}
                   </div>
                 ) : (
-                  <div className="h-full overflow-auto border border-gray-200 rounded-lg">
-                    <table className="min-w-full divide-y divide-gray-200">
+                  <>
+                    <table className="w-full divide-y divide-gray-200 table-auto">
                       <thead className="bg-gray-50 sticky top-0 z-1">
                         <tr>
                           {getTableHeaders().map((header) => (
                             <th
                               key={header}
-                              className={`px-6 py-3 text-left text-xs font-medium uppercase tracking-wider ${
+                              className={`px-3 py-2 text-left text-xs font-medium uppercase tracking-wider whitespace-nowrap ${
                                 isKeyColumn(header)
                                   ? "bg-blue-100 text-blue-800 border-r border-blue-200"
                                   : "text-gray-500"
                               }`}
                             >
-                              <div className="flex flex-col">
-                                <span>{header}</span>
-                                {isKeyColumn(header) && (
-                                  <span className="text-xs font-normal text-blue-600 mt-1">
-                                    {getKeyType(header)}
-                                  </span>
-                                )}
-                              </div>
+                              <span>{header}</span>
+                              {isKeyColumn(header) && (
+                                <span className="ml-1.5 text-xs font-normal text-blue-500 normal-case">
+                                  ({getKeyType(header)})
+                                </span>
+                              )}
                             </th>
                           ))}
-                          <th className="px-6 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 w-20">
+                          <th className="px-3 py-2 text-center text-xs font-medium uppercase tracking-wider text-gray-500 w-14">
                             Actions
                           </th>
                         </tr>
@@ -636,51 +634,37 @@ export default function DynamoDBViewer({
                             {getTableHeaders().map((header) => (
                               <td
                                 key={header}
-                                className={`px-6 py-4 text-sm ${
+                                className={`px-3 py-2 text-sm ${
                                   isKeyColumn(header)
                                     ? "bg-blue-50 text-blue-900 border-r border-blue-200 font-medium"
                                     : "text-gray-900"
                                 }`}
                               >
-                                <div
-                                  className={`${
-                                    typeof item[header] === "object" &&
-                                    item[header] !== null
-                                      ? "max-w-md overflow-auto"
-                                      : "max-w-xs truncate"
-                                  }`}
-                                  title={
-                                    typeof item[header] === "object" &&
-                                    item[header] !== null
-                                      ? "Click to view full JSON"
-                                      : formatValue(item[header])
-                                  }
-                                >
-                                  {typeof item[header] === "object" &&
-                                  item[header] !== null ? (
-                                    <button
-                                      onClick={() =>
-                                        handleJsonClick(
-                                          item[header],
-                                          `${header} - ${selectedTable}`
-                                        )
-                                      }
-                                      className="w-full text-left text-xs bg-blue-50 hover:bg-blue-100 p-2 rounded border border-blue-200 font-mono text-gray-800 transition-colors cursor-pointer"
-                                    >
-                                      <div className="truncate">
-                                        {formatValue(item[header])}
-                                      </div>
-                                      <div className="flex justify-center mt-1">
-                                        <PlusIcon className="h-4 w-4 text-blue-600" />
-                                      </div>
-                                    </button>
-                                  ) : (
-                                    formatValue(item[header])
-                                  )}
-                                </div>
+                                {typeof item[header] === "object" &&
+                                item[header] !== null ? (
+                                  <button
+                                    onClick={() =>
+                                      handleJsonClick(
+                                        item[header],
+                                        `${header} - ${selectedTable}`
+                                      )
+                                    }
+                                    className="flex items-center gap-1.5 text-left text-xs bg-blue-50 hover:bg-blue-100 px-2 py-1 rounded border border-blue-200 font-mono text-gray-800 transition-colors cursor-pointer max-w-[200px]"
+                                    title="Click to view full JSON"
+                                  >
+                                    <ArrowsPointingOutIcon className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
+                                    <span className="truncate">
+                                      {formatValue(item[header])}
+                                    </span>
+                                  </button>
+                                ) : (
+                                  <span className="block max-w-[220px] truncate" title={formatValue(item[header])}>
+                                    {formatValue(item[header])}
+                                  </span>
+                                )}
                               </td>
                             ))}
-                            <td className="px-6 py-4 text-center">
+                            <td className="px-3 py-2 text-center">
                               <button
                                 onClick={() => handleDeleteClick(item)}
                                 className="text-red-600 hover:text-red-800 transition-colors"
@@ -693,7 +677,7 @@ export default function DynamoDBViewer({
                         ))}
                       </tbody>
                     </table>
-                  </div>
+                  </>
                 )}
               </div>
             </>

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -301,7 +301,7 @@ export default function ResourceList({
                   {/* Col 3: name + subtitle */}
                   <div className="min-w-0">
                     <h4 className="text-sm font-medium text-gray-900 truncate">
-                      {resource.name}
+                      {resource.type === "cache" ? "Cache" : resource.name}
                     </h4>
                     <p className="text-xs text-gray-500 capitalize truncate">
                       {resource.type === "mailpit"

--- a/localcloud-gui/src/components/S3ConfigModal.tsx
+++ b/localcloud-gui/src/components/S3ConfigModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { XMarkIcon, FolderIcon } from "@heroicons/react/24/outline";
 import { S3BucketConfig } from "@/types";
+import SavedConfigPicker from "./SavedConfigPicker";
 
 interface S3ConfigModalProps {
   isOpen: boolean;
@@ -36,6 +37,15 @@ export default function S3ConfigModal({
   }, [isOpen, onClose]);
 
   if (!isOpen) return null;
+
+  const loadSavedConfig = (config: S3BucketConfig) => {
+    setBucketName(config.bucketName || "");
+    setRegion(config.region || "us-east-1");
+    setVersioning(config.versioning || false);
+    setEncryption(config.encryption || false);
+  };
+
+  const currentConfig: S3BucketConfig = { bucketName, region, versioning, encryption };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -78,6 +88,13 @@ export default function S3ConfigModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          <SavedConfigPicker
+            resourceType="s3"
+            onLoad={loadSavedConfig}
+            currentConfig={currentConfig}
+            configLabel="Bucket"
+          />
+
           {/* Bucket Name */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/localcloud-gui/src/components/SavedConfigPicker.tsx
+++ b/localcloud-gui/src/components/SavedConfigPicker.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { usePreferences } from "@/context/PreferencesContext";
+import { SavedConfig } from "@/types";
+import { BookmarkIcon, CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+
+interface SavedConfigPickerProps {
+  resourceType: "s3" | "dynamodb" | "secrets";
+  onLoad: (config: SavedConfig["config"]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  currentConfig: any;
+  configLabel: string;
+}
+
+export default function SavedConfigPicker({
+  resourceType,
+  onLoad,
+  currentConfig,
+  configLabel,
+}: SavedConfigPickerProps) {
+  const { profile, savedConfigs, saveConfig } = usePreferences();
+  const [showSaveInput, setShowSaveInput] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const projectConfigs = savedConfigs.filter(
+    (c) =>
+      c.resource_type === resourceType &&
+      c.project_id === profile?.active_project_id
+  );
+
+  const handleSave = async () => {
+    if (!saveName.trim()) return;
+    setSaving(true);
+    try {
+      await saveConfig(saveName.trim(), resourceType, currentConfig);
+      setSaveName("");
+      setShowSaveInput(false);
+      toast.success(`Config "${saveName.trim()}" saved`);
+    } catch {
+      toast.error("Failed to save config");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!profile?.active_project_id) return null;
+
+  return (
+    <div className="mb-5 p-4 bg-gray-50 rounded-lg border border-gray-200">
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center space-x-2">
+          <BookmarkIcon className="h-4 w-4 text-gray-500" />
+          <span className="text-sm font-medium text-gray-700">Saved configs</span>
+          <span className="text-xs text-gray-400">({profile.active_project_label})</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowSaveInput((v) => !v)}
+          className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+        >
+          {showSaveInput ? "Cancel" : `Save ${configLabel}`}
+        </button>
+      </div>
+
+      {/* Save input */}
+      {showSaveInput && (
+        <div className="flex items-center space-x-2 mb-3">
+          <input
+            type="text"
+            placeholder={`Name this ${configLabel.toLowerCase()} config...`}
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleSave(); } }}
+            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!saveName.trim() || saving}
+            className="p-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            <CheckIcon className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => { setShowSaveInput(false); setSaveName(""); }}
+            className="p-1.5 text-gray-400 hover:text-gray-600 border border-gray-200 rounded-md"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Saved config list */}
+      {projectConfigs.length === 0 ? (
+        <p className="text-xs text-gray-400 italic">No saved configs yet for this project.</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {projectConfigs.map((cfg) => (
+            <button
+              key={cfg.id}
+              type="button"
+              onClick={() => {
+                onLoad(cfg.config);
+                toast.success(`Loaded "${cfg.name}"`);
+              }}
+              className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-200 rounded-full hover:border-blue-400 hover:text-blue-700 hover:bg-blue-50 transition-colors"
+            >
+              {cfg.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/SecretsManagerViewer.tsx
+++ b/localcloud-gui/src/components/SecretsManagerViewer.tsx
@@ -479,8 +479,17 @@ export default function SecretsManagerViewer({
 
       {/* Create Secret Modal */}
       {showCreateModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4">
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowCreateModal(false);
+          }}
+        >
+          <div
+            className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">Create Secret</h3>
@@ -602,8 +611,17 @@ export default function SecretsManagerViewer({
 
       {/* Edit Secret Modal */}
       {showEditModal && selectedSecret && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4">
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowEditModal(false);
+          }}
+        >
+          <div
+            className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div>
                 <h3 className="text-lg font-semibold text-gray-900">Edit Secret</h3>
@@ -719,8 +737,17 @@ export default function SecretsManagerViewer({
 
       {/* Delete Confirmation Modal */}
       {showDeleteModal && selectedSecret && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4">
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md">
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowDeleteModal(false);
+          }}
+        >
+          <div
+            className="bg-white rounded-xl shadow-2xl w-full max-w-md"
+            onClick={(e) => e.stopPropagation()}
+          >
             <div className="p-6">
               <div className="flex items-center space-x-3 mb-4">
                 <div className="flex-shrink-0">

--- a/localcloud-gui/src/components/ThemeableCodeBlock.tsx
+++ b/localcloud-gui/src/components/ThemeableCodeBlock.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import hljs from "highlight.js";
+import { highlightThemes, HighlightTheme } from "./highlightThemes";
+import { usePreferences } from "@/context/PreferencesContext";
+import { ClipboardDocumentIcon } from "@heroicons/react/24/outline";
+import { toast } from "react-hot-toast";
+
+import "highlight.js/lib/languages/javascript";
+import "highlight.js/lib/languages/typescript";
+import "highlight.js/lib/languages/python";
+import "highlight.js/lib/languages/bash";
+import "highlight.js/lib/languages/php";
+
+const THEME_LINK_ID = "hljs-theme-docs";
+
+const languageMap: Record<string, string> = {
+  typescript: "typescript",
+  node: "javascript",
+  javascript: "javascript",
+  python: "python",
+  cli: "bash",
+  nodemailer: "javascript",
+  sendgrid: "javascript",
+  laravel: "php",
+  django: "python",
+  flask: "python",
+};
+
+interface ThemeableCodeBlockProps {
+  code: string;
+  language: string;
+  showThemeSelector?: boolean;
+}
+
+export default function ThemeableCodeBlock({
+  code,
+  language,
+  showThemeSelector = true,
+}: ThemeableCodeBlockProps) {
+  const { profile } = usePreferences();
+  const defaultTheme = (profile?.highlight_theme as HighlightTheme) || "github";
+  const [selectedTheme, setSelectedTheme] = useState<HighlightTheme>(defaultTheme);
+
+  useEffect(() => {
+    if (profile?.highlight_theme && highlightThemes[profile.highlight_theme]) {
+      setSelectedTheme(profile.highlight_theme as HighlightTheme);
+    }
+  }, [profile?.highlight_theme]);
+
+  useEffect(() => {
+    const themeFile = highlightThemes[selectedTheme] || highlightThemes.github;
+    let link = document.getElementById(THEME_LINK_ID) as HTMLLinkElement | null;
+    if (link) {
+      link.href = `/hljs-themes/${themeFile}`;
+    } else {
+      link = document.createElement("link");
+      link.id = THEME_LINK_ID;
+      link.rel = "stylesheet";
+      link.href = `/hljs-themes/${themeFile}`;
+      document.head.appendChild(link);
+    }
+  }, [selectedTheme]);
+
+  const hljsLanguage = languageMap[language.toLowerCase()] || "text";
+  const [highlighted, setHighlighted] = useState("");
+
+  useEffect(() => {
+    try {
+      setHighlighted(hljs.highlight(code, { language: hljsLanguage }).value);
+    } catch {
+      setHighlighted(hljs.highlightAuto(code).value);
+    }
+  }, [code, hljsLanguage]);
+
+  const copy = () => {
+    navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  };
+
+  const isDarkTheme = selectedTheme.includes("dark");
+
+  return (
+    <div className="relative group">
+      <div className="flex items-center justify-end gap-2 mb-2">
+        {showThemeSelector && (
+          <>
+            <label
+              htmlFor="samples-theme-select"
+              className="text-xs font-medium text-gray-600"
+            >
+              Theme:
+            </label>
+            <select
+              id="samples-theme-select"
+              value={selectedTheme}
+              onChange={(e) =>
+                setSelectedTheme(e.target.value as HighlightTheme)
+              }
+              className="text-sm border border-gray-300 rounded px-2 py-1 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {Object.keys(highlightThemes).map((key) => (
+                <option key={key} value={key}>
+                  {key.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+        <button
+          onClick={copy}
+          className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100"
+          title="Copy"
+        >
+          <ClipboardDocumentIcon className="h-4 w-4" />
+        </button>
+      </div>
+      <pre
+        className={`rounded-lg p-4 overflow-x-auto text-sm whitespace-pre-wrap ${
+          isDarkTheme ? "bg-gray-900" : "bg-gray-100"
+        }`}
+      >
+        {highlighted ? (
+          <code
+            className="hljs"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+            style={{ background: "transparent", padding: 0 }}
+          />
+        ) : (
+          <code>{code}</code>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/localcloud-gui/src/context/PreferencesContext.tsx
+++ b/localcloud-gui/src/context/PreferencesContext.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import {
+  Project,
+  SavedConfig,
+  UserProfile,
+} from "@/types";
+import { profileApi, projectsApi, savedConfigsApi } from "@/services/api";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+interface PreferencesContextValue {
+  profile: UserProfile | null;
+  projects: Project[];
+  savedConfigs: SavedConfig[];
+  loading: boolean;
+  updateProfile: (data: Partial<UserProfile>) => Promise<void>;
+  createProject: (name: string, label: string, description?: string) => Promise<Project>;
+  deleteProject: (id: number) => Promise<void>;
+  saveConfig: (name: string, resourceType: string, config: object) => Promise<void>;
+  deleteSavedConfig: (id: number) => Promise<void>;
+  refreshSavedConfigs: () => Promise<void>;
+}
+
+const PreferencesContext = createContext<PreferencesContextValue | null>(null);
+
+export function PreferencesProvider({ children }: { children: ReactNode }) {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [savedConfigs, setSavedConfigs] = useState<SavedConfig[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadAll = useCallback(async () => {
+    try {
+      const [prof, projs, configs] = await Promise.all([
+        profileApi.get(),
+        projectsApi.list(),
+        savedConfigsApi.list(),
+      ]);
+      setProfile(prof);
+      setProjects(projs);
+      setSavedConfigs(configs);
+    } catch (err) {
+      console.error("Failed to load preferences:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadAll();
+  }, [loadAll]);
+
+  const updateProfile = useCallback(async (data: Partial<UserProfile>) => {
+    const updated = await profileApi.update(data);
+    setProfile(updated);
+  }, []);
+
+  const createProject = useCallback(
+    async (name: string, label: string, description?: string): Promise<Project> => {
+      const project = await projectsApi.create(name, label, description);
+      setProjects((prev) => [...prev, project]);
+      return project;
+    },
+    []
+  );
+
+  const deleteProject = useCallback(async (id: number) => {
+    await projectsApi.delete(id);
+    setProjects((prev) => prev.filter((p) => p.id !== id));
+    setSavedConfigs((prev) => prev.filter((c) => c.project_id !== id));
+  }, []);
+
+  const refreshSavedConfigs = useCallback(async () => {
+    const configs = await savedConfigsApi.list();
+    setSavedConfigs(configs);
+  }, []);
+
+  const saveConfig = useCallback(
+    async (name: string, resourceType: string, config: object) => {
+      if (!profile?.active_project_id) return;
+      const saved = await savedConfigsApi.create(
+        profile.active_project_id,
+        name,
+        resourceType,
+        config
+      );
+      setSavedConfigs((prev) => [saved, ...prev]);
+    },
+    [profile?.active_project_id]
+  );
+
+  const deleteSavedConfig = useCallback(async (id: number) => {
+    await savedConfigsApi.delete(id);
+    setSavedConfigs((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  return (
+    <PreferencesContext.Provider
+      value={{
+        profile,
+        projects,
+        savedConfigs,
+        loading,
+        updateProfile,
+        createProject,
+        deleteProject,
+        saveConfig,
+        deleteSavedConfig,
+        refreshSavedConfigs,
+      }}
+    >
+      {children}
+    </PreferencesContext.Provider>
+  );
+}
+
+export function usePreferences() {
+  const ctx = useContext(PreferencesContext);
+  if (!ctx) throw new Error("usePreferences must be used inside PreferencesProvider");
+  return ctx;
+}

--- a/localcloud-gui/src/hooks/useServicesData.ts
+++ b/localcloud-gui/src/hooks/useServicesData.ts
@@ -6,13 +6,7 @@ import {
   MailpitStats,
   RedisStatus,
 } from "@/types";
-import {
-  localstackApi,
-  resourceApi,
-  configApi,
-  cacheApi,
-  mailpitApi,
-} from "@/services/api";
+import { dashboardApi } from "@/services/api";
 
 interface LocalStackData {
   status: LocalStackStatus;
@@ -50,56 +44,16 @@ export function useServicesData() {
   const loadData = useCallback(async () => {
     try {
       setError(null);
-      const [localstackStatus, projectConfig, mailpitStats] = await Promise.all(
-        [
-          localstackApi.getStatus(),
-          configApi.getProjectConfig(),
-          mailpitApi.stats(),
-        ]
-      );
-
-      const resources = await resourceApi.getStatus(projectConfig.projectName);
-
-      let redis: RedisStatus = { status: "unknown" };
-      try {
-        const cacheStatus = await cacheApi.status();
-        redis = {
-          status: cacheStatus.status === "running" ? "running" : "stopped",
-          info: cacheStatus.info,
-        };
-        resources.push({
-          id: "cache-redis",
-          name: "Redis Cache",
-          type: "cache",
-          status: redis.status === "running" ? "active" : "error",
-          environment: "local",
-          project: projectConfig.projectName,
-          createdAt: new Date().toISOString(),
-          details: { info: cacheStatus.info, status: cacheStatus.status },
-        });
-      } catch {
-        console.warn("Failed to fetch Redis status");
-      }
-
-      resources.push({
-        id: "mailpit-inbox",
-        name: "Inbox",
-        type: "mailpit",
-        status: mailpitStats.status === "healthy" ? "active" : "error",
-        environment: "local",
-        project: projectConfig.projectName,
-        createdAt: new Date().toISOString(),
-        details: {
-          total: mailpitStats.total,
-          unread: mailpitStats.unread,
-          status: mailpitStats.status,
-        },
-      });
+      const payload = await dashboardApi.getData();
 
       setData({
-        localstack: { status: localstackStatus, projectConfig, resources },
-        mailpit: mailpitStats,
-        redis,
+        localstack: {
+          status: payload.localstackStatus,
+          projectConfig: payload.projectConfig,
+          resources: payload.resources,
+        },
+        mailpit: payload.mailpit,
+        redis: payload.redis,
       });
     } catch (err) {
       const error =

--- a/localcloud-gui/src/services/api.ts
+++ b/localcloud-gui/src/services/api.ts
@@ -5,8 +5,11 @@ import {
   LocalStackStatus,
   LogEntry,
   MailpitStats,
+  Project,
   ProjectConfig,
   Resource,
+  SavedConfig,
+  UserProfile,
 } from "@/types";
 import axios from "axios";
 
@@ -386,5 +389,60 @@ export async function deleteDynamoDBItem(
   if (!res.ok) throw new Error("Failed to delete item");
   return res.json();
 }
+
+// Profile
+export const profileApi = {
+  get: async (): Promise<UserProfile> => {
+    const response = await api.get<ApiResponse<UserProfile>>("/profile");
+    return response.data.data!;
+  },
+  update: async (data: Partial<UserProfile>): Promise<UserProfile> => {
+    const response = await api.put<ApiResponse<UserProfile>>("/profile", data);
+    return response.data.data!;
+  },
+};
+
+// Projects
+export const projectsApi = {
+  list: async (): Promise<Project[]> => {
+    const response = await api.get<ApiResponse<Project[]>>("/projects");
+    return response.data.data || [];
+  },
+  create: async (name: string, label: string, description?: string): Promise<Project> => {
+    const response = await api.post<ApiResponse<Project>>("/projects", { name, label, description });
+    return response.data.data!;
+  },
+  update: async (id: number, label: string, description?: string): Promise<Project> => {
+    const response = await api.put<ApiResponse<Project>>(`/projects/${id}`, { label, description });
+    return response.data.data!;
+  },
+  delete: async (id: number): Promise<void> => {
+    await api.delete(`/projects/${id}`);
+  },
+};
+
+// Saved Configs
+export const savedConfigsApi = {
+  list: async (projectId?: number, type?: string): Promise<SavedConfig[]> => {
+    const params: Record<string, string | number> = {};
+    if (projectId !== undefined) params.project_id = projectId;
+    if (type) params.type = type;
+    const response = await api.get<ApiResponse<SavedConfig[]>>("/saved-configs", { params });
+    return response.data.data || [];
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  create: async (projectId: number, name: string, resourceType: string, config: any): Promise<SavedConfig> => {
+    const response = await api.post<ApiResponse<SavedConfig>>("/saved-configs", {
+      project_id: projectId,
+      name,
+      resource_type: resourceType,
+      config,
+    });
+    return response.data.data!;
+  },
+  delete: async (id: number): Promise<void> => {
+    await api.delete(`/saved-configs/${id}`);
+  },
+};
 
 export default api;

--- a/localcloud-gui/src/services/api.ts
+++ b/localcloud-gui/src/services/api.ts
@@ -8,9 +8,18 @@ import {
   Project,
   ProjectConfig,
   Resource,
+  RedisStatus,
   SavedConfig,
   UserProfile,
 } from "@/types";
+
+export interface DashboardData {
+  localstackStatus: LocalStackStatus;
+  projectConfig: ProjectConfig;
+  mailpit: MailpitStats;
+  resources: Resource[];
+  redis: RedisStatus;
+}
 import axios from "axios";
 
 const API_BASE_URL = "/api";
@@ -115,6 +124,14 @@ export const configApi = {
   getTemplates: async (): Promise<any[]> => {
     const response = await api.get<ApiResponse<any[]>>("/config/templates");
     return response.data.data || [];
+  },
+};
+
+// Dashboard (batched data - single round-trip)
+export const dashboardApi = {
+  getData: async (): Promise<DashboardData> => {
+    const response = await api.get<ApiResponse<DashboardData>>("/dashboard");
+    return response.data.data!;
   },
 };
 

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -140,3 +140,44 @@ export interface ApiResponse<T = any> {
   error?: string;
   message?: string;
 }
+
+export type PreferredLanguage = "typescript" | "node" | "python" | "go" | "java" | "cli";
+
+export type HighlightTheme =
+  | "github"
+  | "github-dark"
+  | "github-dark-dimmed"
+  | "atom-one-dark"
+  | "atom-one-light";
+
+export interface Project {
+  id: number;
+  name: string;
+  label: string;
+  description?: string;
+  created_at: string;
+}
+
+export interface UserProfile {
+  id: number;
+  preferred_language: PreferredLanguage;
+  highlight_theme: HighlightTheme;
+  display_name: string;
+  active_project_id: number | null;
+  active_project_name: string | null;
+  active_project_label: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SavedConfig {
+  id: number;
+  project_id: number;
+  name: string;
+  resource_type: "s3" | "dynamodb" | "secrets";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
+  config_json: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
- Add SQLite (better-sqlite3) persistence layer to the API via db.js
  with tables for user_profile, projects, and saved_configs
- Add Docker named volume (localcloud-data) for DB persistence across restarts
- Add new API routes: GET/PUT /profile, CRUD /projects, CRUD /saved-configs
- Update GET /config/project to read active project from SQLite instead of
  hardcoded projectConfig object
- Add UserProfile, Project, SavedConfig TypeScript types
- Add PreferencesContext provider wrapping the entire app for global
  preference and project state
- Add profile/projects/savedConfigs API service functions
- Add project switcher dropdown and profile icon to Dashboard nav
- Remove hardcoded "Current Configuration" card from Dashboard
- Create /profile page with preference controls, project management,
  and saved config list
- Add TypeScript SDK examples to S3, DynamoDB, and Redis doc pages
- Wire language tab selection to persisted preference (auto-selects
  preferred language on page load, writes back on change)
- Add SavedConfigPicker component to DynamoDB and S3 creation modals
  for loading and saving named resource configurations per project

https://claude.ai/code/session_01NZNbEhcaXxBhpBCKz2sMQh