### PR TITLE
Fix Mailpit subdomain cert and hosts verification in setup scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,17 @@ start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by d
 	@echo "$(GREEN)Waiting for services to be ready...$(NC)"
 	@until curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 || curl -s http://localhost/health > /dev/null 2>&1; do sleep 2; done
 	@echo "$(GREEN)All services are ready!$(NC)"
-	@echo "$(YELLOW)GUI: https://app-local.localcloudkit.com:3030$(NC)"
-	@echo "$(YELLOW)API: https://app-local.localcloudkit.com:3030/api$(NC)"
-	@echo "$(YELLOW)LocalStack: http://localhost:4566$(NC)"
-	@echo "$(YELLOW)Express API (direct): http://localhost:3031$(NC)"
+	@echo ""
+	@echo "$(GREEN)--- App URLs (via Traefik, TLS) ---$(NC)"
+	@echo "$(YELLOW)  GUI:            https://app-local.localcloudkit.com:3030$(NC)"
+	@echo "$(YELLOW)  API:            https://app-local.localcloudkit.com:3030/api$(NC)"
+	@echo "$(YELLOW)  Mailpit (mail): https://mailpit.localcloudkit.com:3030$(NC)"
+	@echo ""
+	@echo "$(GREEN)--- Direct localhost URLs (no TLS) ---$(NC)"
+	@echo "$(YELLOW)  LocalStack:     http://localhost:4566$(NC)"
+	@echo "$(YELLOW)  Express API:    http://localhost:3031$(NC)"
+	@echo "$(YELLOW)  Mailpit UI:     http://localhost:8025$(NC)"
+	@echo "$(YELLOW)  Mailpit SMTP:   localhost:1025$(NC)"
 
 start-legacy: ## Start all services using LocalStack 4.12 (community legacy)
 	@$(MAKE) start LOCALSTACK_VERSION=4.12
@@ -76,8 +83,9 @@ status: ## Check Docker services status
 	@docker compose ps
 	@echo ""
 	@echo "$(YELLOW)Health Checks:$(NC)"
-	@curl -s -k https://app-local.localcloudkit.com:3030/health || curl -s http://localhost/health || echo "$(RED)GUI/API not responding$(NC)"
-	@curl -s http://localhost:4566/_localstack/health || echo "$(RED)LocalStack not responding$(NC)"
+	@curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 && echo "$(GREEN)  GUI/API:   https://app-local.localcloudkit.com:3030  ✓$(NC)" || echo "$(RED)  GUI/API:   not responding$(NC)"
+	@curl -s http://localhost:4566/_localstack/health > /dev/null 2>&1 && echo "$(GREEN)  LocalStack: http://localhost:4566  ✓$(NC)" || echo "$(RED)  LocalStack: not responding$(NC)"
+	@curl -s http://localhost:8025/api/v1/info > /dev/null 2>&1 && echo "$(GREEN)  Mailpit:   http://localhost:8025  ✓$(NC)" || echo "$(YELLOW)  Mailpit:   not responding (may not be running)$(NC)"
 
 logs: ## View Docker services logs
 	docker compose logs -f

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by d
 	@echo "$(YELLOW)  Express API:    http://localhost:3031$(NC)"
 	@echo "$(YELLOW)  Mailpit UI:     http://localhost:8025$(NC)"
 	@echo "$(YELLOW)  Mailpit SMTP:   localhost:1025$(NC)"
+	@echo ""
 
 start-legacy: ## Start all services using LocalStack 4.12 (community legacy)
 	@$(MAKE) start LOCALSTACK_VERSION=4.12

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Everything else is handled automatically!
 
 - Automatically downloads and installs `mkcert` if not found (works on macOS, Linux, Windows)
 - Installs the mkcert CA to your system trust store (requires sudo password)
-- Generates trusted certificates that work in both Chrome and Safari without warnings
-- Adds `app-local.localcloudkit.com` to `/etc/hosts` (requires sudo password)
+- Generates a single trusted certificate covering both `app-local.localcloudkit.com` and `mailpit.localcloudkit.com`
+- Adds both `app-local.localcloudkit.com` and `mailpit.localcloudkit.com` to `/etc/hosts` (requires sudo password)
 
 **No manual installation needed** - the script handles everything automatically!
 
@@ -45,7 +45,7 @@ Everything else is handled automatically!
 
 - `./scripts/setup-mkcert.sh` - Generate certificates only
 - `./scripts/install-ca.sh` - Install CA certificate only
-- `./scripts/setup-hosts.sh` - Add domain to /etc/hosts only
+- `./scripts/setup-hosts.sh` - Add both `app-local.localcloudkit.com` and `mailpit.localcloudkit.com` to /etc/hosts
 - `./scripts/cleanup-hosts.sh` - Remove LocalCloud Kit domains from /etc/hosts (with confirmation)
 - `./scripts/verify-setup.sh` - Verify setup and certificate configuration
 
@@ -64,14 +64,20 @@ This single command will:
 
 **Access URLs:**
 
+Via Traefik (TLS — trusted cert, no browser warnings):
+
 - **Web GUI**: https://app-local.localcloudkit.com:3030
 - **API Server**: https://app-local.localcloudkit.com:3030/api
-- **LocalStack**: http://localhost:4566 (direct access for AWS CLI)
-- **Mailpit UI**: https://mailpit.localcloudkit.com:3030 (email testing inbox)
-- **Mailpit SMTP**: localhost:1025 (point your app here to catch emails)
-- **Express API (direct)**: http://localhost:3031 (direct access, bypasses Traefik)
+- **Mailpit** (email inbox): https://mailpit.localcloudkit.com:3030
 
-> **Note**: Add to `/etc/hosts`: `127.0.0.1 app-local.localcloudkit.com`
+Direct localhost (no TLS — always available):
+
+- **LocalStack**: http://localhost:4566 (for AWS CLI / SDKs)
+- **Mailpit UI**: http://localhost:8025 (direct, no cert required)
+- **Mailpit SMTP**: localhost:1025 (point your app here to catch emails)
+- **Express API**: http://localhost:3031 (bypasses Traefik)
+
+> **Note**: Run `./scripts/setup.sh` once to add both domains to `/etc/hosts` and generate the TLS certificate.
 
 **📖 For detailed getting started instructions, see [GETTING_STARTED.md](GETTING_STARTED.md)**
 
@@ -428,7 +434,8 @@ docker compose down                # Stop and remove containers
 docker compose stop                # Stop without removing
 
 # Restart services
-docker compose restart             # Restart all
+make restart                       # Recommended: stop → rebuild → start (use after git pull)
+docker compose restart             # Restart without rebuild
 docker compose restart api         # Restart specific service
 
 # Environment management
@@ -464,12 +471,13 @@ LocalCloud Kit includes several setup and maintenance scripts:
   - Adds domain to /etc/hosts
 - `./scripts/setup-mkcert.sh` - Generate SSL certificates only
 - `./scripts/install-ca.sh` - Install mkcert CA certificate to system trust store
-- `./scripts/setup-hosts.sh` - Add `app-local.localcloudkit.com` to /etc/hosts
+- `./scripts/setup-hosts.sh` - Add both `app-local.localcloudkit.com` and `mailpit.localcloudkit.com` to /etc/hosts
 - `./scripts/verify-setup.sh` - Verify setup configuration
   - Checks certificate files exist and are valid
-  - Verifies certificate subject matches domain
-  - Checks /etc/hosts entry exists
+  - Verifies certificate subject and SANs (including `mailpit.localcloudkit.com`)
+  - Checks `/etc/hosts` entries for both main app and Mailpit
   - Verifies mkcert CA is installed
+  - Tests HTTPS connectivity for both app and Mailpit
   - Provides troubleshooting guidance
 
 **Cleanup Scripts:**
@@ -622,8 +630,10 @@ curl http://localhost:4566/_localstack/health   # Check LocalStack
 
 - **502 Bad Gateway**: API server isn't running → `docker compose up -d`
 - **Can't connect to LocalStack**: Wait for startup or restart → `docker compose restart localstack`
-- **Certificate errors**: Run `./scripts/setup.sh` to generate certificates
-- **Domain not resolving**: Add to `/etc/hosts` or run `sudo ./scripts/setup-hosts.sh`
+- **Certificate errors / "Not Secure"**: Run `./scripts/setup-mkcert.sh` to regenerate (also re-checks Mailpit SAN)
+- **Mailpit subdomain cert not trusted**: See [Certificate Troubleshooting](docs/CERTIFICATE_TROUBLESHOOTING.md) — cert may be missing the Mailpit SAN
+- **Domain not resolving**: Run `sudo ./scripts/setup-hosts.sh` (adds both `app-local.localcloudkit.com` and `mailpit.localcloudkit.com`)
+- **Changes after `git pull` not showing**: Use `make restart` not `make start` — running containers must be stopped and recreated
 - **Clean up old domain entries**: Run `sudo ./scripts/cleanup-hosts.sh` to remove previous LocalCloud Kit domains (interactive, with confirmation)
 
 **Development mode (GUI outside Docker):**

--- a/docs/CERTIFICATE_TROUBLESHOOTING.md
+++ b/docs/CERTIFICATE_TROUBLESHOOTING.md
@@ -116,3 +116,70 @@ The certificate should be installed automatically when you run `mkcert -install`
 **Issue:** Chrome works but Safari doesn't
 
 - **Solution:** Safari is stricter - ensure CA is properly installed in System keychain with "Always Trust"
+
+---
+
+## Mailpit Subdomain Certificate Issues
+
+### `mailpit.localcloudkit.com` shows "Not Secure"
+
+The Mailpit subdomain uses the **same certificate file** as the main app, but requires `mailpit.localcloudkit.com` to be listed as a Subject Alternative Name (SAN). If you set up LocalCloud Kit before Mailpit was added, your cert won't include it.
+
+**Step 1: Verify the Mailpit SAN is present**
+
+```bash
+openssl x509 -in traefik/certs/app-local.localcloudkit.com.pem -noout -text \
+  | grep -A2 "Subject Alternative Name"
+```
+
+You should see `DNS:mailpit.localcloudkit.com` in the output. If it's missing:
+
+**Step 2: Regenerate the certificate**
+
+```bash
+./scripts/setup-mkcert.sh
+```
+
+This regenerates the cert with all three SANs: `app-local.localcloudkit.com`, `*.app-local.localcloudkit.com`, and `mailpit.localcloudkit.com`.
+
+**Step 3: Verify the `/etc/hosts` entry exists**
+
+```bash
+grep mailpit /etc/hosts
+```
+
+If missing:
+
+```bash
+sudo ./scripts/setup-hosts.sh
+```
+
+**Step 4: Restart Traefik to pick up the new cert**
+
+```bash
+docker compose restart traefik
+```
+
+**Step 5: Restart your browser** (fully quit, don't just close the tab)
+
+### Mailpit subdomain not found / DNS error
+
+If the browser shows a DNS error (not a cert error) for `mailpit.localcloudkit.com`, the `/etc/hosts` entry is missing:
+
+```bash
+sudo ./scripts/setup-hosts.sh
+```
+
+Or add manually:
+
+```bash
+echo "127.0.0.1  mailpit.localcloudkit.com" | sudo tee -a /etc/hosts
+```
+
+### Run full verification
+
+```bash
+./scripts/verify-setup.sh
+```
+
+This checks both the main app and Mailpit: cert SANs, `/etc/hosts` entries, and HTTPS connectivity.

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -101,10 +101,16 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
    ```
 
 4. **Access the application:**
+
+   Via Traefik (TLS):
    - **GUI**: https://app-local.localcloudkit.com:3030
    - **API**: https://app-local.localcloudkit.com:3030/api
-   - **LocalStack**: http://localhost:4566 (direct access for AWS CLI)
-   - **Express API (direct)**: http://localhost:3031 (bypasses Traefik)
+   - **Mailpit**: https://mailpit.localcloudkit.com:3030
+
+   Direct localhost (no TLS):
+   - **LocalStack**: http://localhost:4566
+   - **Express API**: http://localhost:3031
+   - **Mailpit UI**: http://localhost:8025
 
 ## URL Structure
 
@@ -273,10 +279,10 @@ This allows browsers to trust the certificates without warnings.
 
 ### Certificate Features
 
-- **Domain**: `app-local.localcloudkit.com`
-- **Wildcard**: `*.app-local.localcloudkit.com` (for subdomains)
+- **SANs**: `app-local.localcloudkit.com`, `*.app-local.localcloudkit.com`, `mailpit.localcloudkit.com`
 - **Validity**: 825 days
 - **Trust**: Trusted by Chrome, Safari, and other browsers (after CA installation)
+- **Single cert** covers both the main app and the Mailpit subdomain
 
 ## Development Workflow
 
@@ -328,7 +334,31 @@ docker compose restart api
 
 ### Common Issues
 
-1. **Port Conflicts**
+1. **Code Changes Not Appearing After `git pull`**
+
+   `make start` rebuilds images but does **not** stop and recreate already-running containers. Use `make restart` instead:
+
+   ```bash
+   git pull
+   make restart
+   ```
+
+   If you pulled changes that include new npm packages and the app shows module errors:
+
+   ```bash
+   make stop
+   docker compose build --no-cache gui api
+   make start
+   ```
+
+   To confirm a container is running the new image after a rebuild:
+
+   ```bash
+   docker compose ps        # check status
+   docker compose logs api  # check for startup errors
+   ```
+
+3. **Port Conflicts**
 
    ```bash
    # Check what's using the ports
@@ -342,7 +372,7 @@ docker compose restart api
    docker compose down
    ```
 
-2. **Certificate Issues**
+4. **Certificate Issues**
 
    ```bash
    # Regenerate certificates
@@ -355,7 +385,7 @@ docker compose restart api
    docker compose restart traefik
    ```
 
-3. **Build Failures**
+5. **Build Failures**
 
    ```bash
    # Clean build
@@ -365,21 +395,22 @@ docker compose restart api
    docker compose logs [service-name]
    ```
 
-4. **Permission Issues**
+6. **Permission Issues**
 
    ```bash
    # Fix volume permissions
    sudo chown -R $USER:$USER ./volume ./logs ./traefik/certs
    ```
 
-5. **Domain Not Resolving**
+7. **Domain Not Resolving**
 
    ```bash
-   # Add to /etc/hosts
+   # Add both domains to /etc/hosts
    sudo ./scripts/setup-hosts.sh
 
    # Or manually
    echo "127.0.0.1 app-local.localcloudkit.com" | sudo tee -a /etc/hosts
+   echo "127.0.0.1 mailpit.localcloudkit.com" | sudo tee -a /etc/hosts
    ```
 
 ### Health Checks
@@ -474,6 +505,24 @@ make restart
 docker compose restart
 ```
 
+### After Pulling New Code
+
+After `git pull`, running containers must be stopped and recreated — `make start` alone won't update already-running containers:
+
+```bash
+git pull
+make restart          # recommended: stop → rebuild → start
+```
+
+If the pull added new npm dependencies:
+
+```bash
+git pull
+make stop
+docker compose build --no-cache gui api   # clean rebuild avoids stale node_modules
+make start
+```
+
 ### Maintenance
 
 ```bash
@@ -484,11 +533,11 @@ docker system prune
 make reset-env
 docker compose down -v
 
-# Update images
+# Pull updated third-party images (LocalStack, Redis, Traefik)
 docker compose pull
-docker compose up -d
+make restart          # rebuild custom images + recreate all containers
 
-# Rebuild specific service
+# Rebuild a specific custom service (clean)
 docker compose build --no-cache gui
 docker compose build --no-cache api
 ```

--- a/docs/LOCAL_WORKFLOW.md
+++ b/docs/LOCAL_WORKFLOW.md
@@ -135,11 +135,37 @@ make reset
 make status
 ```
 
-### Rebuild After Code Changes
+### After Pulling New Code (`git pull`)
+
+> **Important:** `make start` alone may not rebuild running containers after a pull. Always use `make restart` after pulling to ensure images are rebuilt and containers are recreated with the latest code.
 
 ```bash
-# Rebuild and restart
-docker compose up --build -d
+git pull
+make restart          # stop → rebuild images → start fresh containers
+```
+
+If the pull added new npm packages (changed `package.json`), do a clean rebuild to avoid stale `node_modules` inside the container:
+
+```bash
+git pull
+make stop
+docker compose build --no-cache gui api   # force clean rebuild of app images
+make start
+```
+
+**Signs you need a clean rebuild after a pull:**
+- App loads old UI / API behaves unexpectedly
+- `docker compose logs gui` or `docker compose logs api` shows module-not-found errors
+- A new feature or fix from the pull isn't appearing
+
+### Rebuild After Local Code Changes
+
+```bash
+# Rebuild and restart (containers were stopped)
+make start
+
+# Or if containers are already running
+make restart
 ```
 
 ### Regenerate Certificates
@@ -180,33 +206,55 @@ This will:
 3. Edit code → auto-reloads
 4. `make stop` when done
 
+### After Pulling New Code
+
+```bash
+git pull && make restart
+```
+
+For dependency changes: `make stop && docker compose build --no-cache gui api && make start`
+
 ### Troubleshooting
 
+- **Changes from `git pull` not showing**: Use `make restart` not `make start` — running containers must be stopped and recreated
+- **New npm packages not found after pull**: `make stop && docker compose build --no-cache gui api && make start`
 - **Certificate issues**: Run `./scripts/setup-mkcert.sh` again
 - **Port conflicts**: Check `make status` or `docker compose ps`
 - **Service won't start**: Check logs with `make logs`
 
 ## 🔍 Quick Reference
 
-| Task                  | Command                     |
-| --------------------- | --------------------------- |
-| Start services        | `make start`                |
-| Stop services         | `make stop`                 |
-| Restart services      | `make restart`              |
-| View logs             | `make logs`                 |
-| Check status          | `make status`               |
-| Generate certificates | `./scripts/setup-mkcert.sh` |
-| Full reset            | `make reset-env`            |
+| Task                        | Command                                                      |
+| --------------------------- | ------------------------------------------------------------ |
+| Start services              | `make start`                                                 |
+| Stop services               | `make stop`                                                  |
+| Restart services            | `make restart`                                               |
+| **After `git pull`**        | **`make restart`**                                           |
+| After `git pull` (new deps) | `make stop && docker compose build --no-cache gui api && make start` |
+| View logs                   | `make logs`                                                  |
+| Check status                | `make status`                                                |
+| Generate certificates       | `./scripts/setup-mkcert.sh`                                  |
+| Full reset                  | `make reset-env`                                             |
 
 ## 🌐 Access URLs
 
-| Service     | URL                                          | Description           |
-| ----------- | -------------------------------------------- | --------------------- |
-| Web GUI     | `https://app-local.localcloudkit.com:3030`   | Main application      |
-| API         | `https://app-local.localcloudkit.com:3030/api` | REST API              |
-| LocalStack  | `http://localhost:4566`           | AWS services (direct) |
-| Express API | `http://localhost:3031`           | API server (direct)   |
-| Redis       | `localhost:6380`                  | Cache (direct)        |
+**Via Traefik (TLS):**
+
+| Service        | URL                                            | Description              |
+| -------------- | ---------------------------------------------- | ------------------------ |
+| Web GUI        | `https://app-local.localcloudkit.com:3030`     | Main application         |
+| API            | `https://app-local.localcloudkit.com:3030/api` | REST API                 |
+| Mailpit        | `https://mailpit.localcloudkit.com:3030`       | Email testing UI         |
+
+**Direct localhost (no TLS):**
+
+| Service        | URL                        | Description              |
+| -------------- | -------------------------- | ------------------------ |
+| LocalStack     | `http://localhost:4566`    | AWS services             |
+| Express API    | `http://localhost:3031`    | API server               |
+| Mailpit UI     | `http://localhost:8025`    | Email testing (direct)   |
+| Mailpit SMTP   | `localhost:1025`           | SMTP server              |
+| Redis          | `localhost:6380`           | Cache                    |
 
 ## ✅ Verification
 

--- a/docs/MKCERT_SETUP.md
+++ b/docs/MKCERT_SETUP.md
@@ -63,7 +63,10 @@ This script will:
 
 1. Check if mkcert is installed (guides you if not)
 2. Install mkcert CA to your system trust store (first time only)
-3. Generate certificates for `app-local.localcloudkit.com`
+3. Generate a single certificate for `app-local.localcloudkit.com` with SANs covering:
+   - `app-local.localcloudkit.com` (main app)
+   - `*.app-local.localcloudkit.com` (wildcard)
+   - `mailpit.localcloudkit.com` (Mailpit email testing)
 4. Place certificates in `traefik/certs/`
 
 **Expected output:**
@@ -153,10 +156,18 @@ make reset
 
 ### Access Points
 
+**Via Traefik (TLS — requires `/etc/hosts` entries and mkcert CA):**
+
 - **Main GUI**: `https://app-local.localcloudkit.com:3030`
 - **API**: `https://app-local.localcloudkit.com:3030/api`
-- **LocalStack (direct)**: `http://localhost:4566`
-- **Express API (direct)**: `http://localhost:3031`
+- **Mailpit (email testing)**: `https://mailpit.localcloudkit.com:3030`
+
+**Direct localhost (no TLS — always available):**
+
+- **LocalStack**: `http://localhost:4566`
+- **Express API**: `http://localhost:3031`
+- **Mailpit UI**: `http://localhost:8025`
+- **Mailpit SMTP**: `localhost:1025`
 
 ## Troubleshooting
 
@@ -192,8 +203,13 @@ If you see certificate warnings:
    ```
 
 3. **Verify domain matches:**
-   - Certificate is for: `app-local.localcloudkit.com`
-   - You're accessing: `https://app-local.localcloudkit.com:3030` (not `http://`)
+   - Certificate covers: `app-local.localcloudkit.com` and `mailpit.localcloudkit.com`
+   - You're accessing via `https://` (not `http://`)
+   - To confirm Mailpit SAN is in the cert:
+     ```bash
+     openssl x509 -in traefik/certs/app-local.localcloudkit.com.pem -noout -text | grep -A1 "Subject Alternative"
+     ```
+   - If `mailpit.localcloudkit.com` is missing, regenerate: `./scripts/setup-mkcert.sh`
 
 ### mkcert Not Found
 

--- a/scripts/setup-mkcert.sh
+++ b/scripts/setup-mkcert.sh
@@ -421,11 +421,16 @@ echo "1. Restart Docker services:"
 echo "   ${BLUE}docker compose down && docker compose up -d${NC}"
 echo ""
 echo "2. Open in your browser:"
-echo "   ${BLUE}https://$DOMAIN${NC}"
+echo "   ${BLUE}https://$DOMAIN:3030${NC}       (main app)"
+echo "   ${BLUE}https://$MAILPIT_DOMAIN:3030${NC}  (Mailpit email testing)"
+echo ""
+echo "3. Verify setup (optional):"
+echo "   ${BLUE}./scripts/verify-setup.sh${NC}"
 echo ""
 
 if [ "$CA_INSTALLED" = true ]; then
     echo -e "${GREEN}Both Chrome and Safari will trust these certificates automatically!${NC}"
+    echo -e "${GREEN}The certificate covers both $DOMAIN and $MAILPIT_DOMAIN.${NC}"
 else
     echo -e "${YELLOW}⚠️  Remember to install the CA certificate first (see above)${NC}"
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,7 @@
 set -e
 
 DOMAIN="app-local.localcloudkit.com"
+MAILPIT_DOMAIN="mailpit.localcloudkit.com"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -34,8 +35,8 @@ echo ""
 echo -e "${BLUE}This script will:${NC}"
 echo "  1. Install mkcert (if needed)"
 echo "  2. Install mkcert CA certificate"
-echo "  3. Generate SSL certificates for $DOMAIN"
-echo "  4. Add $DOMAIN to /etc/hosts (if needed)"
+echo "  3. Generate SSL certificates for $DOMAIN and $MAILPIT_DOMAIN"
+echo "  4. Add $DOMAIN and $MAILPIT_DOMAIN to /etc/hosts (if needed)"
 echo ""
 echo -e "${YELLOW}Individual scripts are available for one-off operations:${NC}"
 echo "  - ${BLUE}./scripts/setup-mkcert.sh${NC} - Generate certificates only"
@@ -127,8 +128,37 @@ echo ""
 
 CERT_DIR="$PROJECT_ROOT/traefik/certs"
 if [ -f "$CERT_DIR/$DOMAIN.pem" ] && [ -f "$CERT_DIR/$DOMAIN-key.pem" ]; then
-    echo -e "${GREEN}✓ Certificates found${NC}"
+    echo -e "${GREEN}✓ Certificate files found${NC}"
     ls -lh "$CERT_DIR/$DOMAIN"* | sed 's/^/  /'
+    echo ""
+
+    # Verify the Mailpit subdomain is covered by the certificate SAN
+    echo -e "${BLUE}Checking certificate covers Mailpit subdomain ($MAILPIT_DOMAIN)...${NC}"
+    if command -v openssl &>/dev/null; then
+        CERT_SANS=$(openssl x509 -in "$CERT_DIR/$DOMAIN.pem" -noout -text 2>/dev/null | grep -A1 "Subject Alternative Name" | tail -1 || true)
+        if echo "$CERT_SANS" | grep -q "$MAILPIT_DOMAIN"; then
+            echo -e "${GREEN}✓ Certificate includes $MAILPIT_DOMAIN as a SAN${NC}"
+        else
+            echo -e "${YELLOW}⚠ Certificate does not include $MAILPIT_DOMAIN as a SAN${NC}"
+            echo -e "${YELLOW}  Current SANs: $CERT_SANS${NC}"
+            echo -e "${YELLOW}  Regenerating certificate to include Mailpit subdomain...${NC}"
+            rm -f "$CERT_DIR/$DOMAIN.pem" "$CERT_DIR/$DOMAIN-key.pem"
+            "$SCRIPT_DIR/setup-mkcert.sh" || {
+                echo -e "${RED}✗ Failed to regenerate certificate${NC}"
+                exit 1
+            }
+            # Re-verify after regeneration
+            CERT_SANS=$(openssl x509 -in "$CERT_DIR/$DOMAIN.pem" -noout -text 2>/dev/null | grep -A1 "Subject Alternative Name" | tail -1 || true)
+            if echo "$CERT_SANS" | grep -q "$MAILPIT_DOMAIN"; then
+                echo -e "${GREEN}✓ Certificate now includes $MAILPIT_DOMAIN as a SAN${NC}"
+            else
+                echo -e "${RED}✗ Certificate still missing $MAILPIT_DOMAIN SAN${NC}"
+                exit 1
+            fi
+        fi
+    else
+        echo -e "${YELLOW}⚠ openssl not available — cannot verify Mailpit SAN${NC}"
+    fi
 else
     echo -e "${RED}✗ Certificates not found${NC}"
     echo "Expected:"
@@ -144,27 +174,37 @@ echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━�
 echo ""
 
 if [ -f "$SCRIPT_DIR/setup-hosts.sh" ]; then
-    # Check if entry already exists (read-only check)
-    if grep -q "$DOMAIN" /etc/hosts 2>/dev/null; then
-        echo -e "${GREEN}✓ Entry for $DOMAIN already exists in /etc/hosts${NC}"
+    # Check if both entries already exist (read-only check)
+    MAIN_EXISTS=false
+    MAILPIT_EXISTS=false
+    grep -q "$DOMAIN" /etc/hosts 2>/dev/null && MAIN_EXISTS=true
+    grep -q "$MAILPIT_DOMAIN" /etc/hosts 2>/dev/null && MAILPIT_EXISTS=true
+
+    if [ "$MAIN_EXISTS" = true ] && [ "$MAILPIT_EXISTS" = true ]; then
+        echo -e "${GREEN}✓ Entries for $DOMAIN and $MAILPIT_DOMAIN already exist in /etc/hosts${NC}"
     else
+        [ "$MAIN_EXISTS" = false ] && echo -e "${YELLOW}Missing /etc/hosts entry: $DOMAIN${NC}"
+        [ "$MAILPIT_EXISTS" = false ] && echo -e "${YELLOW}Missing /etc/hosts entry: $MAILPIT_DOMAIN${NC}"
+        echo ""
         if [ "$EUID" -ne 0 ]; then
-            echo -e "${YELLOW}Adding /etc/hosts entry requires sudo privileges${NC}"
+            echo -e "${YELLOW}Adding /etc/hosts entries requires sudo privileges${NC}"
             echo "Please enter your password when prompted:"
             echo ""
             sudo "$SCRIPT_DIR/setup-hosts.sh" || {
-                echo -e "${YELLOW}⚠ Failed to add /etc/hosts entry${NC}"
-                echo -e "${YELLOW}You can add it manually or run: sudo ./scripts/setup-hosts.sh${NC}"
+                echo -e "${YELLOW}⚠ Failed to add /etc/hosts entries${NC}"
+                echo -e "${YELLOW}You can add them manually or run: sudo ./scripts/setup-hosts.sh${NC}"
             }
         else
             "$SCRIPT_DIR/setup-hosts.sh" || {
-                echo -e "${YELLOW}⚠ Failed to add /etc/hosts entry${NC}"
+                echo -e "${YELLOW}⚠ Failed to add /etc/hosts entries${NC}"
             }
         fi
     fi
 else
     echo -e "${YELLOW}⚠ setup-hosts.sh not found, skipping /etc/hosts setup${NC}"
-    echo -e "${YELLOW}You can add it manually: 127.0.0.1 $DOMAIN${NC}"
+    echo -e "${YELLOW}Add manually:${NC}"
+    echo -e "${YELLOW}  127.0.0.1 $DOMAIN${NC}"
+    echo -e "${YELLOW}  127.0.0.1 $MAILPIT_DOMAIN${NC}"
 fi
 
 echo ""
@@ -180,11 +220,13 @@ echo "   or"
 echo -e "   ${CYAN}make start${NC}"
 echo ""
 echo "2. Open in your browser:"
-echo -e "   ${CYAN}https://$DOMAIN${NC}"
+echo -e "   ${CYAN}https://$DOMAIN:3030${NC}       (main app)"
+echo -e "   ${CYAN}https://$MAILPIT_DOMAIN:3030${NC}  (Mailpit email testing)"
 echo ""
 echo -e "${YELLOW}Note:${NC} If you see certificate warnings:"
 echo "  - Make sure the CA is installed: ${BLUE}sudo ./scripts/install-ca.sh${NC}"
 echo "  - Completely quit and restart your browser"
+echo "  - Run ${BLUE}./scripts/verify-setup.sh${NC} to diagnose any issues"
 echo ""
 echo -e "${GREEN}Happy coding! 🚀${NC}"
 echo ""

--- a/scripts/verify-setup.sh
+++ b/scripts/verify-setup.sh
@@ -6,6 +6,7 @@
 set -e
 
 DOMAIN="app-local.localcloudkit.com"
+MAILPIT_DOMAIN="mailpit.localcloudkit.com"
 CERT_DIR="./traefik/certs"
 
 # Colors for output (only if terminal supports it)
@@ -44,8 +45,8 @@ else
 fi
 echo ""
 
-# Check 2: Certificate subject
-echo -e "${BLUE}✓ Checking certificate subject...${NC}"
+# Check 2: Certificate subject and SANs
+echo -e "${BLUE}✓ Checking certificate subject and SANs...${NC}"
 if [ -f "$CERT_DIR/$DOMAIN.pem" ]; then
     SUBJECT=$(openssl x509 -in "$CERT_DIR/$DOMAIN.pem" -noout -subject 2>/dev/null | sed 's/subject=//')
     if echo "$SUBJECT" | grep -q "CN=$DOMAIN"; then
@@ -55,20 +56,40 @@ if [ -f "$CERT_DIR/$DOMAIN.pem" ]; then
         echo -e "    Expected: CN=$DOMAIN"
         echo -e "    Regenerate with: ${BLUE}rm $CERT_DIR/$DOMAIN* && ./scripts/setup-mkcert.sh${NC}"
     fi
+
+    # Check that Mailpit subdomain is a SAN in the certificate
+    CERT_SANS=$(openssl x509 -in "$CERT_DIR/$DOMAIN.pem" -noout -text 2>/dev/null | grep -A1 "Subject Alternative Name" | tail -1 || true)
+    if echo "$CERT_SANS" | grep -q "$MAILPIT_DOMAIN"; then
+        echo -e "  ${GREEN}✓ Certificate covers Mailpit subdomain ($MAILPIT_DOMAIN)${NC}"
+    else
+        echo -e "  ${RED}✗ Certificate does NOT cover $MAILPIT_DOMAIN${NC}"
+        echo -e "    SANs found: $CERT_SANS"
+        echo -e "    Fix: ${BLUE}rm $CERT_DIR/$DOMAIN* && ./scripts/setup-mkcert.sh${NC}"
+        ERRORS=$((ERRORS + 1))
+    fi
 else
-    echo -e "  ${RED}✗ Cannot check certificate subject (file not found)${NC}"
+    echo -e "  ${RED}✗ Cannot check certificate (file not found)${NC}"
 fi
 echo ""
 
-# Check 3: /etc/hosts entry
-echo -e "${BLUE}✓ Checking /etc/hosts entry...${NC}"
+# Check 3: /etc/hosts entries (main + Mailpit)
+echo -e "${BLUE}✓ Checking /etc/hosts entries...${NC}"
+HOSTS_ERRORS=0
 if grep -q "$DOMAIN" /etc/hosts 2>/dev/null; then
-    echo -e "  ${GREEN}✓ Entry found in /etc/hosts${NC}"
-    grep "$DOMAIN" /etc/hosts | sed 's/^/    /'
+    echo -e "  ${GREEN}✓ Main entry found: $(grep "$DOMAIN" /etc/hosts | head -1)${NC}"
 else
-    echo -e "  ${YELLOW}⚠ Entry not found in /etc/hosts${NC}"
+    echo -e "  ${YELLOW}⚠ Main entry not found for $DOMAIN${NC}"
+    HOSTS_ERRORS=$((HOSTS_ERRORS + 1))
+fi
+if grep -q "$MAILPIT_DOMAIN" /etc/hosts 2>/dev/null; then
+    echo -e "  ${GREEN}✓ Mailpit entry found: $(grep "$MAILPIT_DOMAIN" /etc/hosts | head -1)${NC}"
+else
+    echo -e "  ${RED}✗ Mailpit entry not found for $MAILPIT_DOMAIN${NC}"
+    HOSTS_ERRORS=$((HOSTS_ERRORS + 1))
+fi
+if [ $HOSTS_ERRORS -gt 0 ]; then
     echo -e "    Run: ${BLUE}sudo ./scripts/setup-hosts.sh${NC}"
-    echo -e "    Or add manually: ${BLUE}127.0.0.1 $DOMAIN${NC}"
+    ERRORS=$((ERRORS + HOSTS_ERRORS))
 fi
 echo ""
 
@@ -111,17 +132,27 @@ else
 fi
 echo ""
 
-# Check 6: HTTPS connectivity
-echo -e "${BLUE}✓ Testing HTTPS connectivity...${NC}"
-if curl -k -s -o /dev/null -w "%{http_code}" "https://$DOMAIN/health" 2>/dev/null | grep -q "200"; then
-    echo -e "  ${GREEN}✓ HTTPS is working${NC}"
-    CERT_INFO=$(echo | openssl s_client -connect "$DOMAIN:443" -servername "$DOMAIN" 2>/dev/null | openssl x509 -noout -subject -issuer 2>/dev/null || echo "")
-    if [ -n "$CERT_INFO" ]; then
-        echo "$CERT_INFO" | sed 's/^/    /'
-    fi
+# Check 6: HTTPS connectivity (main app)
+echo -e "${BLUE}✓ Testing HTTPS connectivity (main app)...${NC}"
+if curl -k -s -o /dev/null -w "%{http_code}" "https://$DOMAIN:3030/health" 2>/dev/null | grep -q "200"; then
+    echo -e "  ${GREEN}✓ HTTPS is working for $DOMAIN${NC}"
 else
-    echo -e "  ${YELLOW}⚠ HTTPS test failed${NC}"
+    echo -e "  ${YELLOW}⚠ HTTPS test failed for $DOMAIN${NC}"
     echo -e "    Check if services are running: ${BLUE}docker compose ps${NC}"
+fi
+echo ""
+
+# Check 7: Mailpit HTTPS connectivity
+echo -e "${BLUE}✓ Testing HTTPS connectivity (Mailpit)...${NC}"
+MAILPIT_HTTP_CODE=$(curl -k -s -o /dev/null -w "%{http_code}" "https://$MAILPIT_DOMAIN:3030" 2>/dev/null || true)
+if [ "$MAILPIT_HTTP_CODE" = "200" ] || [ "$MAILPIT_HTTP_CODE" = "301" ] || [ "$MAILPIT_HTTP_CODE" = "302" ]; then
+    echo -e "  ${GREEN}✓ Mailpit is reachable at https://$MAILPIT_DOMAIN:3030${NC}"
+elif [ -z "$MAILPIT_HTTP_CODE" ] || [ "$MAILPIT_HTTP_CODE" = "000" ]; then
+    echo -e "  ${YELLOW}⚠ Cannot reach $MAILPIT_DOMAIN — services may not be running${NC}"
+    echo -e "    Start services: ${BLUE}docker compose up -d${NC}"
+else
+    echo -e "  ${YELLOW}⚠ Mailpit returned HTTP $MAILPIT_HTTP_CODE${NC}"
+    echo -e "    Check Mailpit service: ${BLUE}docker compose ps mailpit${NC}"
 fi
 echo ""
 
@@ -130,12 +161,16 @@ echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━�
 if [ $ERRORS -eq 0 ]; then
     echo -e "${GREEN}✓ Setup verification complete - All checks passed!${NC}"
     echo ""
-    echo "Access your application at:"
-    echo -e "  ${BLUE}https://$DOMAIN${NC}"
+    echo "Access your services at:"
+    echo -e "  ${BLUE}https://$DOMAIN:3030${NC}       (main app)"
+    echo -e "  ${BLUE}https://$MAILPIT_DOMAIN:3030${NC}  (Mailpit email testing)"
 else
     echo -e "${YELLOW}⚠ Setup verification complete - Found $ERRORS issue(s)${NC}"
     echo ""
     echo "Please fix the issues above and run this script again."
+    echo -e "  Re-run setup:      ${BLUE}./scripts/setup.sh${NC}"
+    echo -e "  Regenerate certs:  ${BLUE}./scripts/setup-mkcert.sh${NC}"
+    echo -e "  Fix hosts:         ${BLUE}sudo ./scripts/setup-hosts.sh${NC}"
 fi
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""


### PR DESCRIPTION
- setup.sh: add MAILPIT_DOMAIN var; Step 3 now reads the cert SANs and
  auto-regenerates the cert if mailpit.localcloudkit.com is missing;
  Step 4 checks and adds both hosts entries; success message shows both URLs
- verify-setup.sh: add SAN check to cert verification (errors if Mailpit
  subdomain missing); split hosts check to report main + Mailpit entries
  separately; add dedicated Mailpit HTTPS connectivity check (Check 7);
  summary lists both app and Mailpit URLs with remediation hints
- setup-mkcert.sh: next-steps output shows Mailpit URL alongside main app
  URL and notes that the cert covers both domains

https://claude.ai/code/session_0155AoaKFr9HHs42qiAxS3JD