### PR TITLE
fix: resolve HTTPS mixed content and frame-sec blocking for Keycloak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,12 +63,16 @@ start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by d
 	@echo "$(YELLOW)  GUI:            https://app-local.localcloudkit.com:3030$(NC)"
 	@echo "$(YELLOW)  API:            https://app-local.localcloudkit.com:3030/api$(NC)"
 	@echo "$(YELLOW)  Mailpit (mail): https://mailpit.localcloudkit.com:3030$(NC)"
+	@echo "$(YELLOW)  Keycloak:       https://keycloak.localcloudkit.com:3030$(NC)"
+	@echo "$(YELLOW)  pgAdmin:        https://pgadmin.localcloudkit.com:3030$(NC)"
 	@echo ""
 	@echo "$(GREEN)--- Direct localhost URLs (no TLS) ---$(NC)"
 	@echo "$(YELLOW)  LocalStack:     http://localhost:4566$(NC)"
 	@echo "$(YELLOW)  Express API:    http://localhost:3031$(NC)"
 	@echo "$(YELLOW)  Mailpit UI:     http://localhost:8025$(NC)"
 	@echo "$(YELLOW)  Mailpit SMTP:   localhost:1025$(NC)"
+	@echo "$(YELLOW)  Keycloak:       http://localhost:8080$(NC)"
+	@echo "$(YELLOW)  pgAdmin:        http://localhost:5050$(NC)"
 	@echo ""
 
 start-legacy: ## Start all services using LocalStack 4.12 (community legacy)

--- a/localcloud-gui/next.config.ts
+++ b/localcloud-gui/next.config.ts
@@ -4,7 +4,7 @@ const nextConfig: NextConfig = {
   // Environment variables
   env: {
     NEXT_PUBLIC_API_URL:
-      process.env.NEXT_PUBLIC_API_URL || "http://localhost:3030/api",
+      process.env.NEXT_PUBLIC_API_URL || "https://app-local.localcloudkit.com:3030/api",
   },
 
   // Improve performance
@@ -17,8 +17,9 @@ const nextConfig: NextConfig = {
         source: "/(.*)",
         headers: [
           {
+            // Allow same-origin framing (needed for Keycloak auth flows)
             key: "X-Frame-Options",
-            value: "DENY",
+            value: "SAMEORIGIN",
           },
           {
             key: "X-Content-Type-Options",
@@ -27,6 +28,16 @@ const nextConfig: NextConfig = {
           {
             key: "Referrer-Policy",
             value: "origin-when-cross-origin",
+          },
+          {
+            // Allow framing from the app domain and Keycloak subdomain;
+            // upgrade-insecure-requests ensures any stray http:// sub-resources
+            // are promoted to https automatically.
+            key: "Content-Security-Policy",
+            value: [
+              "frame-ancestors 'self' https://keycloak.localcloudkit.com:3030",
+              "upgrade-insecure-requests",
+            ].join("; "),
           },
         ],
       },

--- a/localcloud-gui/src/app/keycloak/page.tsx
+++ b/localcloud-gui/src/app/keycloak/page.tsx
@@ -7,12 +7,22 @@ import {
 } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
 const KEYCLOAK_TRAEFIK_URL = "https://keycloak.localcloudkit.com:3030";
 const KEYCLOAK_DIRECT_URL = "http://localhost:8080";
-const KEYCLOAK_ADMIN_URL = `${KEYCLOAK_DIRECT_URL}/admin`;
+
+function useKeycloakBaseUrl() {
+  const [baseUrl, setBaseUrl] = useState(KEYCLOAK_TRAEFIK_URL);
+  useEffect(() => {
+    const isLocalhost =
+      window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1";
+    setBaseUrl(isLocalhost ? KEYCLOAK_DIRECT_URL : KEYCLOAK_TRAEFIK_URL);
+  }, []);
+  return baseUrl;
+}
 
 function CodeBlock({ code }: { code: string }) {
   const copy = () => {
@@ -107,31 +117,33 @@ OIDC_TOKEN_URL=http://localhost:8080/realms/master/protocol/openid-connect/token
 OIDC_AUTH_URL=http://localhost:8080/realms/master/protocol/openid-connect/auth`,
 };
 
-const resources = [
-  {
-    name: "Keycloak Admin Console (direct)",
-    url: KEYCLOAK_ADMIN_URL,
-    description: "Direct access to the Keycloak admin console on localhost:8080.",
-  },
-  {
-    name: "Keycloak Admin Console (via Traefik)",
-    url: `${KEYCLOAK_TRAEFIK_URL}/admin`,
-    description: "Access the admin console through the Traefik reverse proxy.",
-  },
-  {
-    name: "Keycloak Documentation",
-    url: "https://www.keycloak.org/documentation",
-    description: "Official Keycloak documentation — realms, clients, flows, and more.",
-  },
-  {
-    name: "OpenID Connect Playground",
-    url: "https://openidconnect.net/",
-    description: "Interactive tool for testing OIDC flows against your local Keycloak.",
-  },
-];
-
 export default function KeycloakPage() {
   const [activeTab, setActiveTab] = useState<"nodejs" | "python" | "curl" | "envvars">("nodejs");
+  const keycloakBaseUrl = useKeycloakBaseUrl();
+  const keycloakAdminUrl = `${keycloakBaseUrl}/admin`;
+
+  const resources = [
+    {
+      name: "Keycloak Admin Console",
+      url: keycloakAdminUrl,
+      description: "Access the Keycloak admin console.",
+    },
+    {
+      name: "Keycloak Admin Console (via Traefik)",
+      url: `${KEYCLOAK_TRAEFIK_URL}/admin`,
+      description: "Access the admin console through the Traefik reverse proxy.",
+    },
+    {
+      name: "Keycloak Documentation",
+      url: "https://www.keycloak.org/documentation",
+      description: "Official Keycloak documentation — realms, clients, flows, and more.",
+    },
+    {
+      name: "OpenID Connect Playground",
+      url: "https://openidconnect.net/",
+      description: "Interactive tool for testing OIDC flows against your local Keycloak.",
+    },
+  ];
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
@@ -156,7 +168,7 @@ export default function KeycloakPage() {
             </div>
             <div className="flex items-center space-x-2">
               <a
-                href={KEYCLOAK_ADMIN_URL}
+                href={keycloakAdminUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
@@ -199,7 +211,7 @@ export default function KeycloakPage() {
               </thead>
               <tbody className="divide-y divide-gray-100 bg-white">
                 {[
-                  { label: "Admin Console (direct)", value: KEYCLOAK_ADMIN_URL, link: KEYCLOAK_ADMIN_URL },
+                  { label: "Admin Console", value: keycloakAdminUrl, link: keycloakAdminUrl },
                   { label: "Admin Console (Traefik)", value: `${KEYCLOAK_TRAEFIK_URL}/admin`, link: `${KEYCLOAK_TRAEFIK_URL}/admin` },
                   { label: "Username", value: "admin", link: null },
                   { label: "Password", value: "admin", link: null },
@@ -233,11 +245,11 @@ export default function KeycloakPage() {
               </thead>
               <tbody className="divide-y divide-gray-100 bg-white">
                 {[
-                  { label: "Discovery", url: `${KEYCLOAK_DIRECT_URL}/realms/master/.well-known/openid-configuration` },
-                  { label: "Authorization", url: `${KEYCLOAK_DIRECT_URL}/realms/master/protocol/openid-connect/auth` },
-                  { label: "Token", url: `${KEYCLOAK_DIRECT_URL}/realms/master/protocol/openid-connect/token` },
-                  { label: "JWKS (public keys)", url: `${KEYCLOAK_DIRECT_URL}/realms/master/protocol/openid-connect/certs` },
-                  { label: "UserInfo", url: `${KEYCLOAK_DIRECT_URL}/realms/master/protocol/openid-connect/userinfo` },
+                  { label: "Discovery", url: `${keycloakBaseUrl}/realms/master/.well-known/openid-configuration` },
+                  { label: "Authorization", url: `${keycloakBaseUrl}/realms/master/protocol/openid-connect/auth` },
+                  { label: "Token", url: `${keycloakBaseUrl}/realms/master/protocol/openid-connect/token` },
+                  { label: "JWKS (public keys)", url: `${keycloakBaseUrl}/realms/master/protocol/openid-connect/certs` },
+                  { label: "UserInfo", url: `${keycloakBaseUrl}/realms/master/protocol/openid-connect/userinfo` },
                 ].map((row) => (
                   <tr key={row.label}>
                     <td className="px-4 py-2.5 text-gray-600">{row.label}</td>


### PR DESCRIPTION
- keycloak/page.tsx: add useKeycloakBaseUrl() hook that detects
  window.location.hostname at runtime — uses https://keycloak.localcloudkit.com:3030
  (Traefik) when served over the app domain, and http://localhost:8080 only
  when accessed directly on localhost. Fixes mixed-content errors in the Admin
  Console button, OIDC Endpoints table, Admin Credentials table, and Resources
  section.

- next.config.ts: change X-Frame-Options from DENY → SAMEORIGIN so Keycloak
  auth flows that use same-origin iframes are not blocked.

- next.config.ts: add Content-Security-Policy header with frame-ancestors
  'self' and keycloak.localcloudkit.com:3030, plus upgrade-insecure-requests
  to automatically promote any stray http:// sub-resource requests to https.

- next.config.ts: fix NEXT_PUBLIC_API_URL fallback from http://localhost:3030/api
  to https://app-local.localcloudkit.com:3030/api (was itself a mixed-content
  source if the env var was unset in the app domain context).

https://claude.ai/code/session_01Gy8sSv6cD8zWhqgDatCxnk