### PR TITLE
fix: configure Keycloak KC_HOSTNAME and KC_PROXY_HEADERS for Traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,8 @@ services:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - KC_HTTP_ENABLED=true
+      - KC_HOSTNAME=https://keycloak.localcloudkit.com:3030
+      - KC_PROXY_HEADERS=xforwarded
       - KC_HOSTNAME_STRICT=false
       - KC_HOSTNAME_STRICT_HTTPS=false
     command: start-dev


### PR DESCRIPTION
Without KC_PROXY_HEADERS=xforwarded, Keycloak ignores Traefik's X-Forwarded-Proto header and believes it is serving plain HTTP. This causes all OIDC redirect URLs (authorization, token, issuer) to be generated as http://, producing mixed-content errors when the browser is redirected from the HTTPS Traefik entry point.

Without KC_HOSTNAME, Keycloak constructs its public issuer URL incorrectly, breaking frame-ancestors / CSP checks and OIDC discovery responses.

- Add KC_HOSTNAME=https://keycloak.localcloudkit.com:3030 so Keycloak knows its public-facing URL including scheme and port.
- Add KC_PROXY_HEADERS=xforwarded so Keycloak trusts and reads the X-Forwarded-Proto / X-Forwarded-Host headers set by Traefik, enabling correct https:// URL generation in all OIDC flows.

https://claude.ai/code/session_01Gy8sSv6cD8zWhqgDatCxnk