### PR TITLE
Add DocPageNav with profile icon + docs dropdown to all doc pages; fix language preferences; add verify-new-service skill

### DIFF
--- a/.claude/commands/verify-new-service.md
+++ b/.claude/commands/verify-new-service.md
@@ -1,0 +1,113 @@
+# Verify New Service Checklist
+
+Run this command after adding a new service to LocalCloud Kit to verify it meets all project standards.
+
+Usage: `/verify-new-service <ServiceName>`
+
+---
+
+You are performing a structured verification of a newly added service in LocalCloud Kit. Work through every item below. Report PASS ✅, FAIL ❌, or N/A for each item.
+
+## Service Name
+
+The service being verified is: **$ARGUMENTS**
+
+---
+
+## 1. Docker Compose (`docker-compose.yml`)
+
+- [ ] Service block defined with correct `image`, `container_name`, `restart` policy
+- [ ] Connected to `localstack-network` bridge network
+- [ ] Ports mapped correctly (host:container)
+- [ ] Health check defined (if applicable)
+- [ ] Environment variables use `.env` / `env.example` pattern (no hardcoded secrets)
+
+## 2. Traefik Routing (`traefik/dynamic.yml`)
+
+- [ ] Router entry added with rule `Host(\`<service>.localcloudkit.com\`) && PathPrefix(\`/\`)`
+- [ ] TLS enabled via the existing `localcloud-cert` cert resolver
+- [ ] Service entry points to correct internal port
+- [ ] Entry point set to `localcloud` (port 3030)
+
+## 3. Nginx (`nginx.conf`)
+
+- [ ] Upstream block added: `upstream <service> { server <container>:<port>; }`
+- [ ] Location block routes `/api/<service>/` to the upstream (if API-proxied)
+- [ ] Or subdomain routing handled via Traefik (no Nginx change needed)
+
+## 4. Hosts & Certificates
+
+- [ ] Subdomain `<service>.localcloudkit.com` added to `scripts/setup-hosts.sh`
+- [ ] Subdomain added to the mkcert SAN list in `scripts/setup-mkcert.sh`
+- [ ] `MAILPIT.md` / relevant doc updated with "Existing Users — Required One-Time Steps" if the cert must be regenerated
+
+## 5. API Server (`localcloud-api/server.js`)
+
+- [ ] Status/health endpoint added: `GET /api/<service>/status`
+- [ ] Any required proxy endpoints added under `/api/<service>/`
+- [ ] Winston logging used for errors
+- [ ] Endpoint documented inline with a short comment
+
+## 6. GUI — Doc Page (`localcloud-gui/src/app/<service>/page.tsx`)
+
+- [ ] `"use client"` directive present
+- [ ] Uses `DocPageNav` component (not a custom header)
+- [ ] `DocPageNav` receives correct `title` and `subtitle` props
+- [ ] Service-specific action button passed as `children` to `DocPageNav`
+- [ ] Connection settings table present (Host, Port, credentials, Web UI URLs)
+- [ ] SDK/integration examples use `ThemeableCodeBlock` (not a custom CodeBlock)
+- [ ] Language tabs default to `profile?.preferred_language` via `usePreferences()`
+- [ ] Tab changes call `updateProfile({ preferred_language: tab })` to persist preference
+- [ ] External resources table present with links to official docs
+- [ ] Both Traefik URL (`https://<service>.localcloudkit.com:3030`) and direct URL (`http://localhost:<port>`) shown in the settings table
+
+## 7. GUI — Dashboard Nav (`localcloud-gui/src/components/Dashboard.tsx`)
+
+- [ ] Service added to the **Resources** dropdown (under appropriate section heading)
+- [ ] Service added to the **Docs** dropdown linking to `/‌<service>`
+- [ ] Service status badge added to the dashboard status bar
+
+## 8. GUI — Docs Dropdown (`localcloud-gui/src/components/DocPageNav.tsx`)
+
+- [ ] New service link added to the Docs dropdown in `DocPageNav`
+- [ ] Placed under the correct section (Infrastructure / AWS Resources / Services)
+
+## 9. Markdown Documentation (`docs/<SERVICE>.md`)
+
+- [ ] File exists at `docs/<SERVICE>.md`
+- [ ] Access table includes both Traefik URL and direct localhost URL
+  - Traefik: `https://<service>.localcloudkit.com:3030`
+  - Direct: `http://localhost:<port>`
+- [ ] SMTP / connection settings listed (if applicable)
+- [ ] API endpoints table included
+- [ ] Make commands listed (e.g. `make <service>-logs`)
+- [ ] "Existing Users — Required One-Time Steps" section included if new subdomain is added
+- [ ] GUI URL references use `https://app-local.localcloudkit.com:3030` (not `http://localhost:3030`) for the main dashboard
+
+## 10. Makefile
+
+- [ ] `make <service>-logs` target added (tails container logs)
+- [ ] Any other relevant targets added (restart, clear, etc.)
+
+## 11. README.md & CHANGELOG.md
+
+- [ ] New service listed in README.md features section
+- [ ] Access URL added to README.md "Access URLs" table
+- [ ] CHANGELOG.md entry added under the current version
+
+## 12. CLAUDE.md
+
+- [ ] Service added to the **Services** table in the Architecture section
+- [ ] Subdomain listed in the Networking & Routing section
+- [ ] "Adding a New Service" checklist still accurate (update if steps changed)
+
+---
+
+## Verification Summary
+
+After checking all items, provide:
+
+1. **Overall status**: PASS / FAIL / PARTIAL
+2. **Failed items**: List each ❌ item with a brief explanation
+3. **Recommended fixes**: Ordered list of changes needed to reach full compliance
+4. **Auto-fix offer**: Ask the user if they want you to fix any failing items automatically

--- a/.claude/commands/verify-new-service.md
+++ b/.claude/commands/verify-new-service.md
@@ -92,8 +92,10 @@ The service being verified is: **$ARGUMENTS**
 ## 11. README.md & CHANGELOG.md
 
 - [ ] New service listed in README.md features section
-- [ ] Access URL added to README.md "Access URLs" table
-- [ ] CHANGELOG.md entry added under the current version
+- [ ] Access URL added to README.md "Access URLs" table (both Traefik HTTPS and direct localhost)
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]` → `### Added` summarizing the new service
+- [ ] CHANGELOG entry uses bold component name format: `- **ServiceName**: description`
+- [ ] CHANGELOG entry is user-facing language (not implementation details)
 
 ## 12. CLAUDE.md
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+## Summary
+
+<!-- What does this PR do? 1–3 bullets on the user-visible change. -->
+
+-
+-
+
+## Type of change
+
+<!-- Check all that apply -->
+
+- [ ] `feat` — new feature
+- [ ] `fix` — bug fix
+- [ ] `refactor` — code restructure, no behavior change
+- [ ] `docs` — documentation only
+- [ ] `build` / `chore` — infra, deps, tooling
+- [ ] `BREAKING CHANGE` — existing behavior changed or removed
+
+## Pre-merge checklist
+
+### Code
+- [ ] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
+- [ ] No hardcoded secrets, credentials, or localhost-only assumptions
+- [ ] TypeScript strict mode — no `any` types introduced without justification
+
+### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
+- [ ] `docker-compose.yml` service block added
+- [ ] Traefik router + TLS entry added
+- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
+- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
+- [ ] `DocPageNav` Docs dropdown updated
+- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs
+
+### Documentation & changelog
+- [ ] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
+- [ ] `README.md` updated if access URLs or features changed
+- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
+- [ ] Relevant `docs/*.md` files updated with current domain/URL info
+
+## CHANGELOG entry
+
+<!-- Paste the exact lines you added to CHANGELOG.md [Unreleased] here -->
+
+```markdown
+### Added / Changed / Fixed
+- **ComponentName**: ...
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,64 @@ When adding a new service (e.g., MailHog):
 
 ---
 
+## Changelog Standards
+
+**CHANGELOG.md is updated once per PR — not per commit.**
+
+### When to update
+
+Update `CHANGELOG.md` as the **last step before opening a PR**, after all commits are ready. Never update it mid-feature or on every commit — the Angular commit history is the working log during development.
+
+### Format — Keep a Changelog (https://keepachangelog.com)
+
+Entries go under `## [Unreleased]` at the top of the file. Use these subsections (omit any that don't apply):
+
+```markdown
+## [Unreleased]
+
+### Added
+- **ComponentName**: description of new user-visible capability
+
+### Changed
+- **ComponentName**: description of changed behavior
+
+### Fixed
+- **ComponentName**: description of what was broken and is now fixed
+
+### Removed
+- **ComponentName**: what was removed and why
+
+### Security
+- description of security fix
+```
+
+### Rules
+
+- **One entry per PR** — summarize the net user-visible effect, not the implementation steps
+- **Bold the component/scope** — matches the Angular commit scope for traceability: `- **DocPageNav**: ...`
+- **User-facing language** — write for someone reading the changelog to understand what changed, not how
+- **Angular type → changelog section mapping**:
+  - `feat` → `### Added`
+  - `fix` → `### Fixed`
+  - `refactor` / `perf` → `### Changed` (only if user-visible)
+  - `docs` / `style` / `chore` / `build` / `ci` → omit unless user-facing
+  - `revert` → `### Fixed` or `### Changed` depending on impact
+- **Breaking changes** (`feat!` / `BREAKING CHANGE:`) → always appear in `### Changed` or `### Removed` with a `⚠️` prefix
+
+### Example
+
+```markdown
+## [Unreleased]
+
+### Added
+- **DocPageNav**: shared navigation header with Docs dropdown and Profile icon across all documentation pages
+
+### Fixed
+- **REDIS.md**: corrected Docker network hostname from `redis:6379` to `localcloud-redis:6379`
+```
+
+---
+
 ## Commit Message Standards (Angular Commit Lint)
 
 **ALL commits MUST follow the Angular Conventional Commits format. This is a hard requirement — never deviate from it.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,62 @@ When adding a new service (e.g., MailHog):
 
 ---
 
+## Commit Message Standards (Angular Commit Lint)
+
+**ALL commits MUST follow the Angular Conventional Commits format. This is a hard requirement — never deviate from it.**
+
+### Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only changes |
+| `style` | Formatting, whitespace — no logic change |
+| `refactor` | Code restructure with no feature or fix |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system, Docker, dependencies |
+| `ci` | CI/CD configuration changes |
+| `chore` | Maintenance tasks (deps, tooling) |
+| `revert` | Reverts a previous commit |
+
+### Rules
+
+- **Subject line**: 72 characters max, lowercase, no trailing period, imperative mood ("add" not "added")
+- **Scope**: optional, lowercase, describes the area changed — e.g. `feat(s3)`, `fix(api)`, `docs(redis)`
+- **Body**: wrap at 100 characters; explain *why*, not *what*
+- **Breaking changes**: add `BREAKING CHANGE:` in the footer, or append `!` after the type: `feat(api)!:`
+- **The session URL** goes in the footer on its own line (already required by other instructions)
+
+### Examples
+
+```
+feat(mailpit): add SMTP inbox modal with unread badge
+
+fix(secrets): resolve ARN format mismatch on delete
+
+docs(redis): update container hostname to localcloud-redis
+
+build(docker): pin localstack image to 3.x for stability
+
+refactor(nav): extract shared DocPageNav component
+
+chore(deps): upgrade next.js to 15.2
+```
+
+---
+
 ## Code Conventions
 
 - **API routes** follow `/api/<resource>` pattern in `server.js`

--- a/docs/REDIS.md
+++ b/docs/REDIS.md
@@ -15,7 +15,7 @@ LocalCloud Kit includes full Redis cache support for local development and testi
 ## Quick Start
 
 1. Start all services: `docker compose up --build`
-2. Open the GUI: http://localhost:3030
+2. Open the GUI: https://app-local.localcloudkit.com:3030 (or http://localhost:3030 without TLS)
 3. Click "Redis Cache" in the dashboard or resource list
 4. Use the full-page interface to manage your cache
 
@@ -218,7 +218,7 @@ docker compose restart redis
 Make sure you're using the correct port:
 
 - **From host machine**: `localhost:6380`
-- **From other containers**: `redis:6379`
+- **From other containers**: `localcloud-redis:6379`
 
 ### Cache not persisting
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -17,7 +17,7 @@ LocalCloud Kit includes comprehensive AWS Secrets Manager support for secure sec
 ## Quick Start
 
 1. Start all services: `docker compose up --build`
-2. Open the GUI: http://localhost:3030
+2. Open the GUI: https://app-local.localcloudkit.com:3030 (or http://localhost:3030 without TLS)
 3. Click the "🔑 Secrets" button in the Resources section
 4. Create and manage secrets through the full-screen interface
 

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   CircleStackIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
 import Link from "next/link";
+import DocPageNav from "@/components/DocPageNav";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
@@ -196,35 +195,15 @@ export default function DynamoDBDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">DynamoDB Tables</h1>
-                  <p className="text-xs text-gray-500">Local NoSQL database via LocalStack</p>
-                </div>
-              </div>
-            </div>
-            <Link
-              href="/"
-              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
-            >
-              <CircleStackIcon className="h-4 w-4 mr-1.5" />
-              Manage Tables
-            </Link>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="DynamoDB Tables" subtitle="Local NoSQL database via LocalStack">
+        <Link
+          href="/"
+          className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+        >
+          <CircleStackIcon className="h-4 w-4 mr-1.5" />
+          Manage Tables
+        </Link>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 

--- a/localcloud-gui/src/app/keycloak/page.tsx
+++ b/localcloud-gui/src/app/keycloak/page.tsx
@@ -1,14 +1,12 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
 import { useEffect, useState } from "react";
-import { toast } from "react-hot-toast";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
 
 const KEYCLOAK_TRAEFIK_URL = "https://keycloak.localcloudkit.com:3030";
 const KEYCLOAK_DIRECT_URL = "http://localhost:8080";
@@ -24,26 +22,15 @@ function useKeycloakBaseUrl() {
   return baseUrl;
 }
 
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+// Maps from PreferredLanguage to Keycloak tab keys
+const LANG_TO_TAB: Record<string, "nodejs" | "python" | "curl" | "envvars"> = {
+  typescript: "nodejs",
+  node: "nodejs",
+  python: "python",
+  go: "curl",
+  java: "curl",
+  cli: "curl",
+};
 
 const codeExamples = {
   nodejs: `// npm install openid-client
@@ -118,8 +105,16 @@ OIDC_AUTH_URL=http://localhost:8080/realms/master/protocol/openid-connect/auth`,
 };
 
 export default function KeycloakPage() {
+  const { profile } = usePreferences();
   const [activeTab, setActiveTab] = useState<"nodejs" | "python" | "curl" | "envvars">("nodejs");
   const keycloakBaseUrl = useKeycloakBaseUrl();
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const mapped = LANG_TO_TAB[profile.preferred_language];
+      if (mapped) setActiveTab(mapped);
+    }
+  }, [profile?.preferred_language]);
   const keycloakAdminUrl = `${keycloakBaseUrl}/admin`;
 
   const resources = [
@@ -147,39 +142,17 @@ export default function KeycloakPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Keycloak</h1>
-                  <p className="text-xs text-gray-500">Local identity and access management (maps to AWS Cognito)</p>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center space-x-2">
-              <a
-                href={keycloakAdminUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
-              >
-                <ArrowTopRightOnSquareIcon className="h-4 w-4 mr-1.5" />
-                Open Admin Console
-              </a>
-            </div>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="Keycloak" subtitle="Local identity and access management (maps to AWS Cognito)">
+        <a
+          href={keycloakAdminUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+        >
+          <ArrowTopRightOnSquareIcon className="h-4 w-4 mr-1.5" />
+          Open Admin Console
+        </a>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 
@@ -290,7 +263,10 @@ export default function KeycloakPage() {
               </button>
             ))}
           </div>
-          <CodeBlock code={codeExamples[activeTab]} />
+          <ThemeableCodeBlock
+            code={codeExamples[activeTab]}
+            language={activeTab === "nodejs" ? "node" : activeTab === "curl" ? "cli" : activeTab}
+          />
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/app/localstack/page.tsx
+++ b/localcloud-gui/src/app/localstack/page.tsx
@@ -2,20 +2,40 @@
 
 import { useLocalStackStatus } from "@/hooks/useLocalStackStatus";
 import StatusCard from "@/components/StatusCard";
-import { ArrowLeftIcon } from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+
+const PAGE_TABS = ["node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
+// Maps PreferredLanguage → localstack tab (no typescript tab here — node is equivalent)
+const LANG_TO_TAB: Record<string, PageTab> = {
+  typescript: "node",
+  node: "node",
+  python: "python",
+  go: "node",
+  java: "node",
+  cli: "cli",
+};
 
 export default function LocalStackIntegrationPage() {
   const { status, projectConfig, loading } = useLocalStackStatus();
-  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+  const { profile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("node");
 
-  const tabs = [
-    { id: "node" as const, label: "Node.js" },
-    { id: "python" as const, label: "Python" },
-    { id: "cli" as const, label: "AWS CLI" },
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const mapped = LANG_TO_TAB[profile.preferred_language];
+      if (mapped) setActiveTab(mapped);
+    }
+  }, [profile?.preferred_language]);
+
+  const tabs: { id: PageTab; label: string }[] = [
+    { id: "node", label: "Node.js" },
+    { id: "python", label: "Python" },
+    { id: "cli", label: "AWS CLI" },
   ];
 
   const nodeExample = `import { S3Client } from "@aws-sdk/client-s3";
@@ -53,58 +73,34 @@ alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">LocalStack Integration</h1>
-                  <p className="text-xs text-gray-500">
-                    Local Cloud Development Environment • v{require("../../../package.json").version}
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center space-x-2">
-              {!loading && (
-                <span
-                  className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${
-                    status.running && status.health === "healthy"
-                      ? "bg-green-100 text-green-800"
-                      : status.running
-                      ? "bg-yellow-100 text-yellow-800"
-                      : "bg-gray-100 text-gray-600"
-                  }`}
-                >
-                  <span
-                    className={`h-1.5 w-1.5 rounded-full mr-1.5 ${
-                      status.running && status.health === "healthy"
-                        ? "bg-green-500"
-                        : status.running
-                        ? "bg-yellow-500"
-                        : "bg-gray-400"
-                    }`}
-                  />
-                  {status.running
-                    ? status.health === "healthy"
-                      ? "Running"
-                      : "Unhealthy"
-                    : "Stopped"}
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="LocalStack Integration" subtitle="Local AWS service emulation">
+        {!loading && (
+          <span
+            className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium ${
+              status.running && status.health === "healthy"
+                ? "bg-green-100 text-green-800"
+                : status.running
+                ? "bg-yellow-100 text-yellow-800"
+                : "bg-gray-100 text-gray-600"
+            }`}
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full mr-1.5 ${
+                status.running && status.health === "healthy"
+                  ? "bg-green-500"
+                  : status.running
+                  ? "bg-yellow-500"
+                  : "bg-gray-400"
+              }`}
+            />
+            {status.running
+              ? status.health === "healthy"
+                ? "Running"
+                : "Unhealthy"
+              : "Stopped"}
+          </span>
+        )}
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -2,12 +2,10 @@
 
 import MailpitModal from "@/components/MailpitModal";
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   InboxIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
+import DocPageNav from "@/components/DocPageNav";
 import { useState } from "react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 
@@ -162,35 +160,15 @@ export default function MailpitIntegrationPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Mailpit Integration</h1>
-                  <p className="text-xs text-gray-500">Local email testing for development</p>
-                </div>
-              </div>
-            </div>
-            <button
-              onClick={() => setShowModal(true)}
-              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
-            >
-              <InboxIcon className="h-4 w-4 mr-1.5" />
-              Manage Inbox
-            </button>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="Mailpit Integration" subtitle="Local email testing for development">
+        <button
+          onClick={() => setShowModal(true)}
+          className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+        >
+          <InboxIcon className="h-4 w-4 mr-1.5" />
+          Manage Inbox
+        </button>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 

--- a/localcloud-gui/src/app/postgres/page.tsx
+++ b/localcloud-gui/src/app/postgres/page.tsx
@@ -1,38 +1,26 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
-  ClipboardDocumentIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
-import { toast } from "react-hot-toast";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
 
 const PGADMIN_TRAEFIK_URL = "https://pgadmin.localcloudkit.com:3030";
 const PGADMIN_DIRECT_URL = "http://localhost:5050";
 
-function CodeBlock({ code }: { code: string }) {
-  const copy = () => {
-    navigator.clipboard.writeText(code);
-    toast.success("Copied to clipboard");
-  };
-  return (
-    <div className="relative group">
-      <pre className="bg-gray-900 text-gray-100 rounded-lg p-4 text-sm overflow-x-auto whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-      <button
-        onClick={copy}
-        className="absolute top-2 right-2 p-1.5 rounded bg-gray-700 hover:bg-gray-600 opacity-0 group-hover:opacity-100 transition-opacity"
-        title="Copy"
-      >
-        <ClipboardDocumentIcon className="h-4 w-4 text-gray-300" />
-      </button>
-    </div>
-  );
-}
+// Maps from PreferredLanguage to Postgres tab keys
+const LANG_TO_TAB: Record<string, "nodejs" | "python" | "go" | "java"> = {
+  typescript: "nodejs",
+  node: "nodejs",
+  python: "python",
+  go: "go",
+  java: "java",
+  cli: "nodejs",
+};
 
 const frameworkExamples = {
   nodejs: `// npm install pg
@@ -142,43 +130,29 @@ const resources = [
 ];
 
 export default function PostgresPage() {
+  const { profile } = usePreferences();
   const [activeTab, setActiveTab] = useState<"nodejs" | "python" | "go" | "java">("nodejs");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const mapped = LANG_TO_TAB[profile.preferred_language];
+      if (mapped) setActiveTab(mapped);
+    }
+  }, [profile?.preferred_language]);
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">PostgreSQL</h1>
-                  <p className="text-xs text-gray-500">Local relational database with pgAdmin GUI</p>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center space-x-2">
-              <a
-                href={PGADMIN_DIRECT_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
-              >
-                <ArrowTopRightOnSquareIcon className="h-4 w-4 mr-1.5" />
-                Open pgAdmin
-              </a>
-            </div>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="PostgreSQL" subtitle="Local relational database with pgAdmin GUI">
+        <a
+          href={PGADMIN_DIRECT_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center px-3 py-2 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+        >
+          <ArrowTopRightOnSquareIcon className="h-4 w-4 mr-1.5" />
+          Open pgAdmin
+        </a>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 
@@ -293,7 +267,10 @@ export default function PostgresPage() {
               </button>
             ))}
           </div>
-          <CodeBlock code={frameworkExamples[activeTab]} />
+          <ThemeableCodeBlock
+            code={frameworkExamples[activeTab]}
+            language={activeTab === "nodejs" ? "node" : activeTab}
+          />
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -2,12 +2,10 @@
 
 import RedisModal from "@/components/RedisModal";
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   ServerIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
-import Link from "next/link";
+import DocPageNav from "@/components/DocPageNav";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
@@ -133,35 +131,15 @@ export default function RedisDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Redis Cache</h1>
-                  <p className="text-xs text-gray-500">Local in-memory cache for development</p>
-                </div>
-              </div>
-            </div>
-            <button
-              onClick={() => setShowModal(true)}
-              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
-            >
-              <ServerIcon className="h-4 w-4 mr-1.5" />
-              Manage Cache
-            </button>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="Redis Cache" subtitle="Local in-memory cache for development">
+        <button
+          onClick={() => setShowModal(true)}
+          className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+        >
+          <ServerIcon className="h-4 w-4 mr-1.5" />
+          Manage Cache
+        </button>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -1,12 +1,11 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   FolderIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
 import Link from "next/link";
+import DocPageNav from "@/components/DocPageNav";
 import { usePreferences } from "@/context/PreferencesContext";
 import { useEffect, useState } from "react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
@@ -184,35 +183,15 @@ export default function S3DocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">S3 Buckets</h1>
-                  <p className="text-xs text-gray-500">Local object storage via LocalStack</p>
-                </div>
-              </div>
-            </div>
-            <Link
-              href="/"
-              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
-            >
-              <FolderIcon className="h-4 w-4 mr-1.5" />
-              Manage Buckets
-            </Link>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="S3 Buckets" subtitle="Local object storage via LocalStack">
+        <Link
+          href="/"
+          className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+        >
+          <FolderIcon className="h-4 w-4 mr-1.5" />
+          Manage Buckets
+        </Link>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -1,16 +1,65 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   ArrowTopRightOnSquareIcon,
   KeyIcon,
 } from "@heroicons/react/24/outline";
-import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
 
 const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-secrets-manager
+import {
+  SecretsManagerClient,
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  UpdateSecretCommand,
+  DeleteSecretCommand,
+  ListSecretsCommand,
+  SecretListEntry,
+} from "@aws-sdk/client-secrets-manager";
+
+const sm = new SecretsManagerClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a secret
+await sm.send(new CreateSecretCommand({
+  Name: "my-app/database-password",
+  SecretString: JSON.stringify({ password: "s3cr3t!" }),
+  Description: "Database password for my-app",
+}));
+
+// Get a secret value
+const { SecretString } = await sm.send(new GetSecretValueCommand({
+  SecretId: "my-app/database-password",
+}));
+const secret = JSON.parse(SecretString!) as { password: string };
+console.log(secret.password);
+
+// Update a secret
+await sm.send(new UpdateSecretCommand({
+  SecretId: "my-app/database-password",
+  SecretString: JSON.stringify({ password: "new-s3cr3t!" }),
+}));
+
+// List secrets
+const { SecretList } = await sm.send(new ListSecretsCommand({}));
+(SecretList ?? []).forEach((s: SecretListEntry) => console.log(s.Name, s.ARN));
+
+// Delete a secret (ForceDeleteWithoutRecovery skips the 30-day window)
+await sm.send(new DeleteSecretCommand({
+  SecretId: "my-app/database-password",
+  ForceDeleteWithoutRecovery: true,
+}));`,
   node: `// npm install @aws-sdk/client-secrets-manager
 import {
   SecretsManagerClient,
@@ -150,39 +199,32 @@ const externalResources = [
 ];
 
 export default function SecretsDocPage() {
-  const [activeTab, setActiveTab] = useState<"node" | "python" | "cli">("node");
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link
-                href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
-                Dashboard
-              </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Secrets Manager</h1>
-                  <p className="text-xs text-gray-500">Local secret storage via LocalStack</p>
-                </div>
-              </div>
-            </div>
-            <Link
-              href="/"
-              className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
-            >
-              <KeyIcon className="h-4 w-4 mr-1.5" />
-              Manage Secrets
-            </Link>
-          </div>
-        </div>
-      </header>
+      <DocPageNav title="Secrets Manager" subtitle="Local secret storage via LocalStack">
+        <Link
+          href="/"
+          className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+        >
+          <KeyIcon className="h-4 w-4 mr-1.5" />
+          Manage Secrets
+        </Link>
+      </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 
@@ -246,13 +288,14 @@ export default function SecretsDocPage() {
           </p>
           <div className="flex space-x-1 mb-4 border-b border-gray-200">
             {([
+              { key: "typescript" as const, label: "TypeScript" },
               { key: "node" as const, label: "Node.js" },
               { key: "python" as const, label: "Python" },
               { key: "cli" as const, label: "AWS CLI" },
             ]).map(({ key, label }) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => handleTabChange(key)}
                 className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
                   activeTab === key
                     ? "border-blue-600 text-blue-600"
@@ -263,6 +306,9 @@ export default function SecretsDocPage() {
               </button>
             ))}
           </div>
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
           {activeTab === "node" && (
             <ThemeableCodeBlock code={sdkExamples.node} language="node" />
           )}

--- a/localcloud-gui/src/components/DocPageNav.tsx
+++ b/localcloud-gui/src/components/DocPageNav.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import {
+  ArrowLeftIcon,
+  BookOpenIcon,
+  ChevronDownIcon,
+  CircleStackIcon,
+  EnvelopeIcon,
+  FolderIcon,
+  KeyIcon,
+  ServerIcon,
+  Squares2X2Icon,
+  UserCircleIcon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+
+interface DocPageNavProps {
+  title: string;
+  subtitle: string;
+  /** Optional right-side action button(s) rendered before the nav icons */
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared navigation header for all documentation pages.
+ * Includes: ← Dashboard link, logo + title, optional action buttons,
+ * the Docs dropdown, and the Profile icon — matching the Dashboard nav.
+ */
+export default function DocPageNav({ title, subtitle, children }: DocPageNavProps) {
+  const [showDocsMenu, setShowDocsMenu] = useState(false);
+  const docsMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (docsMenuRef.current && !docsMenuRef.current.contains(e.target as Node)) {
+        setShowDocsMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  return (
+    <header className="bg-white shadow-sm border-b border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between py-4">
+          {/* Left: back link + logo + title */}
+          <div className="flex items-center space-x-4">
+            <Link
+              href="/"
+              className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+              Dashboard
+            </Link>
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">{title}</h1>
+                <p className="text-xs text-gray-500">{subtitle}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Right: custom actions + Docs dropdown + Profile */}
+          <div className="flex items-center space-x-2">
+            {/* Custom action slot (e.g. "Manage Buckets" button) */}
+            {children}
+
+            {/* Docs dropdown */}
+            <div className="relative" ref={docsMenuRef}>
+              <button
+                onClick={() => setShowDocsMenu((v) => !v)}
+                className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+              >
+                <BookOpenIcon className="h-4 w-4 mr-2" />
+                Docs
+                <ChevronDownIcon
+                  className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`}
+                />
+              </button>
+              {showDocsMenu && (
+                <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                  {/* Infrastructure */}
+                  <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    Infrastructure
+                  </p>
+                  <Link
+                    href="/localstack"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                    LocalStack
+                  </Link>
+
+                  {/* AWS Resources */}
+                  <div className="border-t border-gray-100 mt-1" />
+                  <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    AWS Resources
+                  </p>
+                  <Link
+                    href="/s3"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <FolderIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    S3 Buckets
+                  </Link>
+                  <Link
+                    href="/dynamodb"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    DynamoDB
+                  </Link>
+                  <Link
+                    href="/secrets"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Secrets Manager
+                  </Link>
+
+                  {/* Services */}
+                  <div className="border-t border-gray-100 mt-1" />
+                  <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                    Services
+                  </p>
+                  <Link
+                    href="/redis"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Redis Cache
+                  </Link>
+                  <Link
+                    href="/mailpit"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Inbox
+                  </Link>
+                  <Link
+                    href="/postgres"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    PostgreSQL
+                  </Link>
+                  <Link
+                    href="/keycloak"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Keycloak
+                  </Link>
+                </div>
+              )}
+            </div>
+
+            {/* Profile icon */}
+            <Link
+              href="/profile"
+              className="p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+              title="Profile & Preferences"
+            >
+              <UserCircleIcon className="h-6 w-6" />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
- Create shared DocPageNav component with Docs dropdown and Profile icon
  matching the Dashboard navbar, used across all doc pages
- Update all 8 doc pages (s3, dynamodb, redis, secrets, mailpit, postgres,
  keycloak, localstack) to use DocPageNav instead of inline header markup
- Fix language preference on pages that were missing it:
  - secrets: add TypeScript tab + usePreferences for language defaulting
  - postgres: add usePreferences + language-to-tab mapping + switch to ThemeableCodeBlock
  - keycloak: add usePreferences + language-to-tab mapping + switch to ThemeableCodeBlock
  - localstack: add usePreferences + language-to-tab mapping
- Update docs/REDIS.md: correct GUI URL and container name (localcloud-redis)
- Update docs/SECRETS.md: correct GUI URL reference
- Add .claude/commands/verify-new-service.md slash command with a comprehensive
  12-point checklist covering docker-compose, Traefik, Nginx, hosts/certs,
  API server, GUI pages, nav dropdowns, markdown docs, Makefile, README, and CLAUDE.md

https://claude.ai/code/session_01SdV9zARf239V4ZsG1jwRzX