### PR TITLE
refactor: reorganize dashboard UI with AWS-only resources and service separation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ samples/            # Sample files for S3/DynamoDB testing
 
 ### Tech Stack
 
-- **Frontend**: Next.js 15, React 18, TypeScript 5, Tailwind CSS
+- **Frontend**: Next.js 15, React 18, TypeScript 5, Tailwind CSS, @iconify/react (AWS service icons)
 - **Backend**: Express.js 4, Node.js 22, Winston logging, Socket.IO, aws-sdk v2
 - **Infrastructure**: Docker Compose, Traefik v3, Nginx (alpine), Redis 7
 - **AWS Emulation**: LocalStack (S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager)
@@ -233,6 +233,39 @@ refactor(nav): extract shared DocPageNav component
 
 chore(deps): upgrade next.js to 15.2
 ```
+
+---
+
+## Dashboard UI Architecture
+
+The dashboard (`localcloud-gui/src/components/Dashboard.tsx`) is organized around a clear two-category model:
+
+### Two Categories of Things
+
+| Category | Examples | Managed via | Can destroy? |
+|----------|----------|-------------|--------------|
+| **Platform Services** | Keycloak, Mailpit, PostgreSQL, Redis | Their own admin UIs (pgAdmin, Keycloak console, Mailpit UI) | No — Docker Compose lifecycle |
+| **AWS Resources** | S3, DynamoDB, Secrets Manager, Lambda, API Gateway, IAM | Dashboard modals and resource list | Yes — individually, per project |
+
+### Navigation Structure
+
+- **Resources** dropdown — AWS resources grouped by service category (Storage, Database, Compute, Networking, Security & Identity). Uses Iconify AWS logos (`logos:aws-s3`, `logos:aws-dynamodb`, etc.).
+- **Services** dropdown — Platform services only (Keycloak, Mailpit, PostgreSQL, Redis), listed alphabetically.
+- **Docs** dropdown — Documentation pages for all resources and services, grouped as Infrastructure / AWS Resources / Platform Services.
+
+### Status Bar
+
+Shows health of all platform services in alphabetical order: **Keycloak | LocalStack | Mailpit | PostgreSQL | Redis**. Clicking a service opens its management modal or links to its doc page.
+
+### ResourceList Component
+
+`localcloud-gui/src/components/ResourceList.tsx` — shows **AWS resources only** (no platform services). Resources are grouped by AWS category with official AWS SVG icons via `@iconify/react`. Supports add, destroy, and inline preview per resource type.
+
+### Mailpit UX
+
+- **Status bar** — click to open `MailpitModal` (read-only inbox preview + unread badge)
+- **MailpitModal** — shows recent messages (read-only), stats bar, one-click "Send Test" button, links to Mailpit UI and docs
+- **`/mailpit` doc page** — full test email compose form (from, to, subject, body), SMTP settings, framework integration examples
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ Direct localhost (no TLS — always available):
 
 ### Main Dashboard
 
-The main dashboard provides an overview of all services and resources with real-time status indicators.
+The dashboard is divided into two distinct areas:
+
+- **Services Status Bar** — health indicators for all platform services (Keycloak, LocalStack, Mailpit, PostgreSQL, Redis), listed alphabetically. Click any service to open its management panel or documentation.
+- **AWS Resources** — a categorized view of your LocalStack resources (Storage, Database, Compute, Networking, Security & Identity), with AWS service icons, add/destroy actions, and inline resource inspection.
 
 ![Main Dashboard](docs/screenshots/01-main-dashboard.png)
 
@@ -170,7 +173,17 @@ localcloud-kit/
 
 ## 🎯 Features
 
-**Latest Release:** v0.8.0 adds Mailpit email testing (local SMTP + inbox UI), Redis cache modal, a restructured Resources navigation with labelled sections (AWS, Cache, Inbox), a comprehensive modal UX overhaul (scroll lock, Escape key, backdrop dismiss) across all viewers, DynamoDB add-item fixes (focus close, scroll, number validation), and expanded SDK connection docs with Secrets Manager examples. [View detailed changelog →](CHANGELOG.md)
+**Latest Release:** see [CHANGELOG.md](CHANGELOG.md) for the full history.
+
+### Navigation
+
+The header contains three primary dropdowns:
+
+| Dropdown | Contents |
+|----------|----------|
+| **Resources** | AWS resources organized by category (Storage, Database, Compute, Networking, Security & Identity) — things you create and destroy in LocalStack |
+| **Services** | Platform services (Keycloak, Mailpit, PostgreSQL, Redis) — always-running infrastructure managed via their own admin UIs |
+| **Docs** | Reference documentation for all services and AWS resources |
 
 ### AWS Service Emulation
 
@@ -209,10 +222,10 @@ localcloud-kit/
 #### Mailpit Email Testing
 
 - **Local SMTP Server**: Catch all outbound emails without sending to real addresses
-- **Inbox UI**: Browse, read, and inspect emails directly from the dashboard
-- **Send Test Emails**: Fire test emails from the GUI to verify templates and flows
-- **Email Details**: View headers, body, recipient info, and timestamps
-- **Inbox Management**: Clear all messages or delete individually
+- **Dashboard Inbox**: Click Mailpit in the status bar for a read-only recent messages preview with unread badge
+- **Quick Test Button**: Send a preset test email in one click from the dashboard modal
+- **Full Test Compose**: Complete compose form on the Mailpit documentation page
+- **Admin UI**: Link through to the full Mailpit web interface for advanced filtering and message inspection
 
 ### Development Tools
 

--- a/localcloud-gui/package-lock.json
+++ b/localcloud-gui/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "localcloud-gui",
-  "version": "0.1.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "localcloud-gui",
-      "version": "0.1.0",
+      "version": "0.10.1",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
+        "@iconify/react": "^6.0.2",
         "axios": "^1.6.0",
         "highlight.js": "^11.9.0",
         "marked": "^12.0.1",
@@ -184,6 +185,27 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
+      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.2",

--- a/localcloud-gui/package.json
+++ b/localcloud-gui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@iconify/react": "^6.0.2",
     "axios": "^1.6.0",
     "highlight.js": "^11.9.0",
     "marked": "^12.0.1",

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -4,10 +4,13 @@ import MailpitModal from "@/components/MailpitModal";
 import {
   ArrowTopRightOnSquareIcon,
   InboxIcon,
+  PaperAirplaneIcon,
 } from "@heroicons/react/24/outline";
 import DocPageNav from "@/components/DocPageNav";
 import { useState } from "react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { mailpitApi } from "@/services/api";
+import { toast } from "react-hot-toast";
 
 const MAILPIT_UI_URL = "https://mailpit.localcloudkit.com:3030";
 const MAILPIT_UI_DIRECT = "http://localhost:8025";
@@ -157,17 +160,42 @@ export default function MailpitIntegrationPage() {
   const [activeFrameworkTab, setActiveFrameworkTab] = useState<
     "nodemailer" | "sendgrid" | "laravel" | "django" | "flask"
   >("nodemailer");
+  const [testForm, setTestForm] = useState({
+    from: "sender@example.com",
+    to: "test@example.com",
+    subject: "Test Email from LocalCloud Kit",
+    body: "Hello! This is a test email sent from the LocalCloud Kit documentation page.",
+  });
+  const [sending, setSending] = useState(false);
+
+  const handleSendTest = async () => {
+    setSending(true);
+    try {
+      const result = await mailpitApi.sendTest(testForm);
+      if (result.success) {
+        toast.success("Test email sent — check the Mailpit inbox");
+      } else {
+        toast.error(result.error || "Failed to send email");
+      }
+    } catch {
+      toast.error("Failed to send email");
+    } finally {
+      setSending(false);
+    }
+  };
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="Mailpit Integration" subtitle="Local email testing for development">
-        <button
-          onClick={() => setShowModal(true)}
+        <a
+          href={MAILPIT_UI_URL}
+          target="_blank"
+          rel="noopener noreferrer"
           className="flex items-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
         >
           <InboxIcon className="h-4 w-4 mr-1.5" />
-          Manage Inbox
-        </button>
+          Open Mailpit
+        </a>
       </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
@@ -181,8 +209,8 @@ export default function MailpitIntegrationPage() {
             making it safe to test email flows without any risk of sending to real addresses.
           </p>
           <p className="text-sm text-gray-600 leading-relaxed mt-2">
-            The <strong>Inbox</strong> resource card on your dashboard reflects the live Mailpit state.
-            Click <em>Manage</em> on that card — or the button above — to view messages, send test emails, and clear the inbox.
+            Access Mailpit from the <strong>Services</strong> menu or the status bar on the dashboard to view recent messages.
+            Use the <strong>Send Test Email</strong> form below to verify your SMTP setup, or open the full Mailpit UI for advanced filtering and message inspection.
           </p>
         </section>
 
@@ -291,6 +319,69 @@ export default function MailpitIntegrationPage() {
               <ThemeableCodeBlock code={frameworkExamples.flask} language="flask" />
             </div>
           )}
+        </section>
+
+        {/* Test Email */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Send Test Email</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Verify your SMTP setup is working by sending a test email directly to Mailpit.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">From</label>
+              <input
+                type="email"
+                value={testForm.from}
+                onChange={(e) => setTestForm({ ...testForm, from: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-gray-700 mb-1">To</label>
+              <input
+                type="email"
+                value={testForm.to}
+                onChange={(e) => setTestForm({ ...testForm, to: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+          <div className="mb-4">
+            <label className="block text-xs font-medium text-gray-700 mb-1">Subject</label>
+            <input
+              type="text"
+              value={testForm.subject}
+              onChange={(e) => setTestForm({ ...testForm, subject: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="mb-4">
+            <label className="block text-xs font-medium text-gray-700 mb-1">Body</label>
+            <textarea
+              rows={4}
+              value={testForm.body}
+              onChange={(e) => setTestForm({ ...testForm, body: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex items-center space-x-3">
+            <button
+              onClick={handleSendTest}
+              disabled={sending}
+              className="flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              <PaperAirplaneIcon className="h-4 w-4 mr-1.5" />
+              {sending ? "Sending…" : "Send Test Email"}
+            </button>
+            <button
+              onClick={() => setShowModal(true)}
+              className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+            >
+              <InboxIcon className="h-4 w-4 mr-1.5" />
+              View Inbox
+            </button>
+          </div>
         </section>
 
         {/* Resources */}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -15,7 +15,11 @@ import {
   ServerIcon,
   Squares2X2Icon,
   UserCircleIcon,
+  CpuChipIcon,
+  GlobeAltIcon,
+  ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 import ResourceList from "./ResourceList";
@@ -48,7 +52,6 @@ export default function Dashboard() {
   const { status: localstackStatus, projectConfig: config, resources } = localstack;
   const { profile, projects, updateProfile } = usePreferences();
 
-  // Derive projectName: active project from preferences, fall back to config from API
   const projectName = profile?.active_project_name || config.projectName;
 
   const [showDynamoDBConfig, setShowDynamoDBConfig] = useState(false);
@@ -60,26 +63,29 @@ export default function Dashboard() {
   const [showMailpit, setShowMailpit] = useState(false);
   const [showRedis, setShowRedis] = useState(false);
 
-  const [selectedDynamoDBTable, setSelectedDynamoDBTable] =
-    useState<string>("");
+  const [selectedDynamoDBTable, setSelectedDynamoDBTable] = useState<string>("");
   const [selectedS3Bucket, setSelectedS3Bucket] = useState<string>("");
 
-  // Loading states for buttons
   const [createLoading, setCreateLoading] = useState(false);
   const [destroyLoading, setDestroyLoading] = useState(false);
 
   // Dropdowns
-  const [showToolsMenu, setShowToolsMenu] = useState(false);
+  const [showResourcesMenu, setShowResourcesMenu] = useState(false);
+  const [showServicesMenu, setShowServicesMenu] = useState(false);
   const [showDocsMenu, setShowDocsMenu] = useState(false);
   const [showProjectMenu, setShowProjectMenu] = useState(false);
-  const toolsMenuRef = useRef<HTMLDivElement>(null);
+  const resourcesMenuRef = useRef<HTMLDivElement>(null);
+  const servicesMenuRef = useRef<HTMLDivElement>(null);
   const docsMenuRef = useRef<HTMLDivElement>(null);
   const projectMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
-      if (toolsMenuRef.current && !toolsMenuRef.current.contains(e.target as Node)) {
-        setShowToolsMenu(false);
+      if (resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target as Node)) {
+        setShowResourcesMenu(false);
+      }
+      if (servicesMenuRef.current && !servicesMenuRef.current.contains(e.target as Node)) {
+        setShowServicesMenu(false);
       }
       if (docsMenuRef.current && !docsMenuRef.current.contains(e.target as Node)) {
         setShowDocsMenu(false);
@@ -91,6 +97,13 @@ export default function Dashboard() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
+
+  const closeAllMenus = () => {
+    setShowResourcesMenu(false);
+    setShowServicesMenu(false);
+    setShowDocsMenu(false);
+    setShowProjectMenu(false);
+  };
 
   const handleSwitchProject = async (projectId: number) => {
     try {
@@ -117,78 +130,42 @@ export default function Dashboard() {
     }
   };
 
-
   const handleCreateSingleResource = async (resourceType: string) => {
-    // Special handling for DynamoDB and S3 - show config modals instead
-    if (resourceType === "dynamodb") {
-      setShowDynamoDBConfig(true);
-      return;
-    }
-
-    if (resourceType === "s3") {
-      setShowS3Config(true);
-      return;
-    }
-
-    if (resourceType === "secretsmanager") {
-      setShowSecretsManager(true);
-      return;
-    }
+    if (resourceType === "dynamodb") { setShowDynamoDBConfig(true); return; }
+    if (resourceType === "s3") { setShowS3Config(true); return; }
+    if (resourceType === "secretsmanager") { setShowSecretsManager(true); return; }
 
     setCreateLoading(true);
     try {
-      const response = await resourceApi.createSingle(
-        projectName,
-        resourceType
-      );
+      const response = await resourceApi.createSingle(projectName, resourceType);
       if (response.success) {
         toast.success(`${resourceType} resource created successfully`);
-        setTimeout(async () => {
-          await loadInitialData();
-        }, 1000);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
       } else {
-        toast.error(
-          response.error || `Failed to create ${resourceType} resource`
-        );
+        toast.error(response.error || `Failed to create ${resourceType} resource`);
       }
     } catch (error) {
       console.error(`Create ${resourceType} resource error:`, error);
-      toast.error(
-        `Failed to create ${resourceType} resource: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`
-      );
+      toast.error(`Failed to create ${resourceType} resource: ${error instanceof Error ? error.message : "Unknown error"}`);
     } finally {
       setCreateLoading(false);
     }
   };
 
-  const handleCreateDynamoDBTable = async (
-    dynamodbConfig: DynamoDBTableConfig
-  ) => {
+  const handleCreateDynamoDBTable = async (dynamodbConfig: DynamoDBTableConfig) => {
     setCreateLoading(true);
     try {
-      const response = await resourceApi.createSingleWithConfig(
-        projectName,
-        "dynamodb",
-        { dynamodbConfig }
-      );
+      const response = await resourceApi.createSingleWithConfig(projectName, "dynamodb", { dynamodbConfig });
       if (response.success) {
         toast.success("DynamoDB table created successfully");
         setShowDynamoDBConfig(false);
-        setTimeout(async () => {
-          await loadInitialData();
-        }, 1000);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
       } else {
         toast.error(response.error || "Failed to create DynamoDB table");
       }
     } catch (error) {
       console.error("Create DynamoDB table error:", error);
-      toast.error(
-        `Failed to create DynamoDB table: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`
-      );
+      toast.error(`Failed to create DynamoDB table: ${error instanceof Error ? error.message : "Unknown error"}`);
     } finally {
       setCreateLoading(false);
     }
@@ -197,27 +174,17 @@ export default function Dashboard() {
   const handleCreateS3Bucket = async (s3Config: S3BucketConfig) => {
     setCreateLoading(true);
     try {
-      const response = await resourceApi.createSingleWithConfig(
-        projectName,
-        "s3",
-        { s3Config }
-      );
+      const response = await resourceApi.createSingleWithConfig(projectName, "s3", { s3Config });
       if (response.success) {
         toast.success("S3 bucket created successfully");
         setShowS3Config(false);
-        setTimeout(async () => {
-          await loadInitialData();
-        }, 1000);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
       } else {
         toast.error(response.error || "Failed to create S3 bucket");
       }
     } catch (error) {
       console.error("Create S3 bucket error:", error);
-      toast.error(
-        `Failed to create S3 bucket: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`
-      );
+      toast.error(`Failed to create S3 bucket: ${error instanceof Error ? error.message : "Unknown error"}`);
     } finally {
       setCreateLoading(false);
     }
@@ -226,11 +193,7 @@ export default function Dashboard() {
   const handleDestroyResources = async (resourceIds: string[]) => {
     setDestroyLoading(true);
     try {
-      const response = await resourceApi.destroy({
-        projectName: projectName,
-        resourceIds: resourceIds,
-      });
-
+      const response = await resourceApi.destroy({ projectName, resourceIds });
       if (response.success) {
         toast.success("Resources destroyed successfully");
         await loadInitialData();
@@ -239,28 +202,20 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Destroy resources error:", error);
-      toast.error(
-        `Failed to destroy resources: ${
-          error instanceof Error ? error.message : "Unknown error"
-        }`
-      );
+      toast.error(`Failed to destroy resources: ${error instanceof Error ? error.message : "Unknown error"}`);
     } finally {
       setDestroyLoading(false);
     }
   };
 
-  if (loading) {
-    return <DashboardSkeleton />;
-  }
+  if (loading) return <DashboardSkeleton />;
 
   if (error) {
     return (
       <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-red-50 to-pink-100">
         <div className="text-center">
           <div className="text-red-600 text-6xl mb-4">⚠️</div>
-          <h2 className="text-xl font-bold text-gray-900 mb-2">
-            Failed to Load Data
-          </h2>
+          <h2 className="text-xl font-bold text-gray-900 mb-2">Failed to Load Data</h2>
           <p className="text-gray-600 mb-4">{error.message}</p>
           <button
             onClick={loadInitialData}
@@ -273,118 +228,108 @@ export default function Dashboard() {
     );
   }
 
+  const serviceStatusClass = (status: string) => {
+    if (status === "running") return "bg-green-100 text-green-800";
+    if (status === "stopped") return "bg-red-100 text-red-800";
+    return "bg-gray-100 text-gray-600";
+  };
+  const serviceDotClass = (status: string) => {
+    if (status === "running") return "bg-green-500";
+    if (status === "stopped") return "bg-red-500";
+    return "bg-gray-400";
+  };
+  const serviceLabel = (status: string) => {
+    if (status === "running") return "Running";
+    if (status === "stopped") return "Stopped";
+    return "Unknown";
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
-            {/* Logo + Title */}
+            {/* Logo */}
             <div className="flex items-center space-x-3">
-              <Image
-                src="/logo.svg"
-                alt="LocalCloud Kit"
-                width={40}
-                height={40}
-              />
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={40} height={40} />
               <div>
-                <h1 className="text-2xl font-bold text-gray-900">
-                  LocalCloud Kit
-                </h1>
-                <p className="text-xs text-gray-500">
-                  Local Cloud Development Environment • v{packageJson.version}
-                </p>
+                <h1 className="text-2xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">Local Cloud Development Environment • v{packageJson.version}</p>
               </div>
             </div>
 
             {/* Nav */}
             <div className="flex items-center space-x-3">
-              {/* Resources dropdown */}
-              <div className="relative" ref={toolsMenuRef}>
+
+              {/* Resources dropdown — AWS resources only */}
+              <div className="relative" ref={resourcesMenuRef}>
                 <button
-                  onClick={() => { setShowToolsMenu((v) => !v); setShowDocsMenu(false); }}
+                  onClick={() => { setShowResourcesMenu((v) => !v); setShowServicesMenu(false); setShowDocsMenu(false); }}
                   className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
                 >
                   <Squares2X2Icon className="h-4 w-4 mr-2" />
                   Resources
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showToolsMenu ? "rotate-180" : ""}`} />
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showResourcesMenu ? "rotate-180" : ""}`} />
                 </button>
-                {showToolsMenu && (
-                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    {/* AWS */}
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS</p>
+                {showResourcesMenu && (
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    {/* Storage */}
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
                     <button
-                      onClick={() => { setShowDynamoDB(true); setShowToolsMenu(false); }}
+                      onClick={() => { setShowBuckets(true); closeAllMenus(); }}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      DynamoDB Tables
-                    </button>
-                    <button
-                      onClick={() => { setShowBuckets(true); setShowToolsMenu(false); }}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <FolderIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />
                       S3 Buckets
                     </button>
+
+                    {/* Database */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
                     <button
-                      onClick={() => { setShowSecretsManager(true); setShowToolsMenu(false); }}
+                      onClick={() => { setShowDynamoDB(true); closeAllMenus(); }}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      DynamoDB Tables
+                    </button>
+
+                    {/* Compute */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compute</p>
+                    <span className="flex items-center w-full px-4 py-2 text-sm text-gray-400 cursor-default">
+                      <CpuChipIcon className="h-4 w-4 mr-3 flex-shrink-0" />
+                      Lambda <span className="ml-auto text-xs">coming soon</span>
+                    </span>
+
+                    {/* Networking */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Networking</p>
+                    <span className="flex items-center w-full px-4 py-2 text-sm text-gray-400 cursor-default">
+                      <GlobeAltIcon className="h-4 w-4 mr-3 flex-shrink-0" />
+                      API Gateway <span className="ml-auto text-xs">coming soon</span>
+                    </span>
+
+                    {/* Security & Identity */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Security & Identity</p>
+                    <button
+                      onClick={() => { setShowSecretsManager(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                       Secrets Manager
                     </button>
-
-                    {/* Databases */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Databases</p>
-                    <Link
-                      href="/postgres"
-                      onClick={() => setShowToolsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      PostgreSQL
-                    </Link>
-
-                    {/* Identity */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Identity</p>
-                    <Link
-                      href="/keycloak"
-                      onClick={() => setShowToolsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Keycloak
-                    </Link>
-
-                    {/* Cache */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Cache</p>
-                    <button
-                      onClick={() => { setShowRedis(true); setShowToolsMenu(false); }}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Redis Cache
-                    </button>
-
-                    {/* Inbox */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Inbox</p>
-                    <button
-                      onClick={() => { setShowMailpit(true); setShowToolsMenu(false); }}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Mailpit
-                    </button>
+                    <span className="flex items-center w-full px-4 py-2 text-sm text-gray-400 cursor-default">
+                      <ShieldCheckIcon className="h-4 w-4 mr-3 flex-shrink-0" />
+                      IAM <span className="ml-auto text-xs">coming soon</span>
+                    </span>
 
                     {/* Logs */}
                     <div className="border-t border-gray-100 mt-1" />
                     <button
-                      onClick={() => { setShowLogs(true); setShowToolsMenu(false); }}
+                      onClick={() => { setShowLogs(true); closeAllMenus(); }}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
                       <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
@@ -394,10 +339,57 @@ export default function Dashboard() {
                 )}
               </div>
 
+              {/* Services dropdown — platform services */}
+              <div className="relative" ref={servicesMenuRef}>
+                <button
+                  onClick={() => { setShowServicesMenu((v) => !v); setShowResourcesMenu(false); setShowDocsMenu(false); }}
+                  className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+                >
+                  <ServerIcon className="h-4 w-4 mr-2" />
+                  Services
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showServicesMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showServicesMenu && (
+                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    {/* Alphabetical: Keycloak, Mailpit, PostgreSQL, Redis */}
+                    <Link
+                      href="/keycloak"
+                      onClick={() => closeAllMenus()}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Keycloak
+                    </Link>
+                    <button
+                      onClick={() => { setShowMailpit(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Mailpit
+                    </button>
+                    <Link
+                      href="/postgres"
+                      onClick={() => closeAllMenus()}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      PostgreSQL
+                    </Link>
+                    <button
+                      onClick={() => { setShowRedis(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Redis Cache
+                    </button>
+                  </div>
+                )}
+              </div>
+
               {/* Docs dropdown */}
               <div className="relative" ref={docsMenuRef}>
                 <button
-                  onClick={() => { setShowDocsMenu((v) => !v); setShowToolsMenu(false); }}
+                  onClick={() => { setShowDocsMenu((v) => !v); setShowResourcesMenu(false); setShowServicesMenu(false); }}
                   className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
                 >
                   <BookOpenIcon className="h-4 w-4 mr-2" />
@@ -406,7 +398,7 @@ export default function Dashboard() {
                 </button>
                 {showDocsMenu && (
                   <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    {/* LocalStack */}
+                    {/* Infrastructure */}
                     <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
                     <Link
                       href="/localstack"
@@ -421,40 +413,40 @@ export default function Dashboard() {
                     <div className="border-t border-gray-100 mt-1" />
                     <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
                     <Link
-                      href="/s3"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <FolderIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      S3 Buckets
-                    </Link>
-                    <Link
                       href="/dynamodb"
                       onClick={() => setShowDocsMenu(false)}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />
                       DynamoDB
+                    </Link>
+                    <Link
+                      href="/s3"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      S3 Buckets
                     </Link>
                     <Link
                       href="/secrets"
                       onClick={() => setShowDocsMenu(false)}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                       Secrets Manager
                     </Link>
 
-                    {/* Services */}
+                    {/* Platform Services */}
                     <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Services</p>
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Platform Services</p>
                     <Link
-                      href="/redis"
+                      href="/keycloak"
                       onClick={() => setShowDocsMenu(false)}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Redis Cache
+                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Keycloak
                     </Link>
                     <Link
                       href="/mailpit"
@@ -462,7 +454,7 @@ export default function Dashboard() {
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
                       <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Inbox
+                      Mailpit
                     </Link>
                     <Link
                       href="/postgres"
@@ -473,12 +465,12 @@ export default function Dashboard() {
                       PostgreSQL
                     </Link>
                     <Link
-                      href="/keycloak"
+                      href="/redis"
                       onClick={() => setShowDocsMenu(false)}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Keycloak
+                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      Redis Cache
                     </Link>
                   </div>
                 )}
@@ -487,7 +479,7 @@ export default function Dashboard() {
               {/* Project Switcher */}
               <div className="relative" ref={projectMenuRef}>
                 <button
-                  onClick={() => { setShowProjectMenu((v) => !v); setShowToolsMenu(false); setShowDocsMenu(false); }}
+                  onClick={() => { setShowProjectMenu((v) => !v); setShowResourcesMenu(false); setShowServicesMenu(false); setShowDocsMenu(false); }}
                   className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
                 >
                   <span className="h-2 w-2 rounded-full bg-blue-500 mr-2 flex-shrink-0" />
@@ -537,17 +529,33 @@ export default function Dashboard() {
               >
                 <UserCircleIcon className="h-6 w-6" />
               </Link>
-
             </div>
           </div>
         </div>
       </header>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Services status bar */}
-        <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 flex items-center space-x-6">
+
+        {/* Services status bar — alphabetical: Keycloak, LocalStack, Mailpit, PostgreSQL, Redis */}
+        <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 flex items-center flex-wrap gap-y-2 gap-x-0">
+
+          {/* Keycloak */}
+          <Link
+            href="/keycloak"
+            className="flex items-center space-x-2 hover:opacity-75 transition-opacity px-3"
+            title="Keycloak — click to view admin info"
+          >
+            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(keycloak.status)}`} />
+            <span className="text-sm font-medium text-gray-700">Keycloak</span>
+            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(keycloak.status)}`}>
+              {serviceLabel(keycloak.status)}
+            </span>
+          </Link>
+
+          <div className="h-4 w-px bg-gray-200" />
+
           {/* LocalStack */}
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-2 px-3">
             <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
               localstackStatus.health === "healthy" ? "bg-green-500" :
               localstackStatus.health === "unhealthy" ? "bg-red-500" : "bg-gray-400"
@@ -567,32 +575,10 @@ export default function Dashboard() {
 
           <div className="h-4 w-px bg-gray-200" />
 
-          {/* Redis */}
-          <button
-            onClick={() => setShowRedis(true)}
-            className="flex items-center space-x-2 hover:opacity-75 transition-opacity"
-            title="Open Redis Cache"
-          >
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
-              redis.status === "running" ? "bg-green-500" :
-              redis.status === "stopped" ? "bg-red-500" : "bg-gray-400"
-            }`} />
-            <span className="text-sm font-medium text-gray-700">Redis</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-              redis.status === "running" ? "bg-green-100 text-green-800" :
-              redis.status === "stopped" ? "bg-red-100 text-red-800" :
-              "bg-gray-100 text-gray-600"
-            }`}>
-              {redis.status === "running" ? "Running" : redis.status === "stopped" ? "Stopped" : "Unknown"}
-            </span>
-          </button>
-
-          <div className="h-4 w-px bg-gray-200" />
-
           {/* Mailpit */}
           <button
             onClick={() => setShowMailpit(true)}
-            className="flex items-center space-x-2 hover:opacity-75 transition-opacity"
+            className="flex items-center space-x-2 hover:opacity-75 transition-opacity px-3"
             title="Open Mailpit Inbox"
           >
             <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
@@ -616,56 +602,42 @@ export default function Dashboard() {
           {/* PostgreSQL */}
           <Link
             href="/postgres"
-            className="flex items-center space-x-2 hover:opacity-75 transition-opacity"
+            className="flex items-center space-x-2 hover:opacity-75 transition-opacity px-3"
             title="PostgreSQL — click to view connection info"
           >
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
-              postgres.status === "running" ? "bg-green-500" :
-              postgres.status === "stopped" ? "bg-red-500" : "bg-gray-400"
-            }`} />
+            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(postgres.status)}`} />
             <span className="text-sm font-medium text-gray-700">PostgreSQL</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-              postgres.status === "running" ? "bg-green-100 text-green-800" :
-              postgres.status === "stopped" ? "bg-red-100 text-red-800" :
-              "bg-gray-100 text-gray-600"
-            }`}>
-              {postgres.status === "running" ? "Running" : postgres.status === "stopped" ? "Stopped" : "Unknown"}
+            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(postgres.status)}`}>
+              {serviceLabel(postgres.status)}
             </span>
           </Link>
 
           <div className="h-4 w-px bg-gray-200" />
 
-          {/* Keycloak */}
-          <Link
-            href="/keycloak"
-            className="flex items-center space-x-2 hover:opacity-75 transition-opacity"
-            title="Keycloak — click to view admin info"
+          {/* Redis */}
+          <button
+            onClick={() => setShowRedis(true)}
+            className="flex items-center space-x-2 hover:opacity-75 transition-opacity px-3"
+            title="Open Redis Cache"
           >
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
-              keycloak.status === "running" ? "bg-green-500" :
-              keycloak.status === "stopped" ? "bg-red-500" : "bg-gray-400"
-            }`} />
-            <span className="text-sm font-medium text-gray-700">Keycloak</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-              keycloak.status === "running" ? "bg-green-100 text-green-800" :
-              keycloak.status === "stopped" ? "bg-red-100 text-red-800" :
-              "bg-gray-100 text-gray-600"
-            }`}>
-              {keycloak.status === "running" ? "Running" : keycloak.status === "stopped" ? "Stopped" : "Unknown"}
+            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(redis.status)}`} />
+            <span className="text-sm font-medium text-gray-700">Redis</span>
+            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(redis.status)}`}>
+              {serviceLabel(redis.status)}
             </span>
-          </Link>
+          </button>
 
           {!localstackStatus.running && (
             <>
               <div className="h-4 w-px bg-gray-200" />
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-gray-500 px-3">
                 Run <code className="bg-gray-100 px-1 rounded">docker compose up -d</code> to start
               </span>
             </>
           )}
         </div>
 
-        {/* Resource Management */}
+        {/* AWS Resource Management */}
         {localstackStatus.running && (
           <div className="mb-8">
             <ResourceList
@@ -687,11 +659,7 @@ export default function Dashboard() {
                 setSelectedDynamoDBTable(tableName);
                 setShowDynamoDB(true);
               }}
-              onViewCache={() => setShowRedis(true)}
-              onViewSecretsManager={() => {
-                setShowSecretsManager(true);
-              }}
-              onViewMailpit={() => setShowMailpit(true)}
+              onViewSecretsManager={() => setShowSecretsManager(true)}
             />
           </div>
         )}
@@ -733,10 +701,7 @@ export default function Dashboard() {
       {showBuckets && (
         <BucketViewer
           isOpen={showBuckets}
-          onClose={() => {
-            setShowBuckets(false);
-            setSelectedS3Bucket("");
-          }}
+          onClose={() => { setShowBuckets(false); setSelectedS3Bucket(""); }}
           projectName={projectName}
           selectedBucketName={selectedS3Bucket}
         />
@@ -745,10 +710,7 @@ export default function Dashboard() {
       {showDynamoDB && (
         <DynamoDBViewer
           isOpen={showDynamoDB}
-          onClose={() => {
-            setShowDynamoDB(false);
-            setSelectedDynamoDBTable("");
-          }}
+          onClose={() => { setShowDynamoDB(false); setSelectedDynamoDBTable(""); }}
           projectName={projectName}
           selectedTableName={selectedDynamoDBTable}
         />
@@ -757,9 +719,7 @@ export default function Dashboard() {
       {showSecretsManager && (
         <SecretsManagerViewer
           isOpen={showSecretsManager}
-          onClose={() => {
-            setShowSecretsManager(false);
-          }}
+          onClose={() => setShowSecretsManager(false)}
           projectName={projectName}
         />
       )}

--- a/localcloud-gui/src/components/MailpitModal.tsx
+++ b/localcloud-gui/src/components/MailpitModal.tsx
@@ -8,12 +8,20 @@ import {
   TrashIcon,
   XMarkIcon,
   EnvelopeIcon,
+  PaperAirplaneIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { toast } from "react-hot-toast";
 
 const MAILPIT_UI_URL = "https://mailpit.localcloudkit.com:3030";
+
+const TEST_EMAIL_DEFAULTS = {
+  from: "sender@example.com",
+  to: "test@example.com",
+  subject: "Test Email from LocalCloud Kit",
+  body: "Hello! This is a test email sent from the LocalCloud Kit dashboard.",
+};
 
 interface MailMessage {
   ID: string;
@@ -28,16 +36,9 @@ interface MailpitModalProps {
   onClose: () => void;
 }
 
-
 export default function MailpitModal({ onClose }: MailpitModalProps) {
   const { stats, refetch } = useMailpitStats();
 
-  const [form, setForm] = useState({
-    from: "sender@example.com",
-    to: "test@example.com",
-    subject: "Test Email from LocalCloud Kit",
-    body: "Hello! This is a test email sent from the LocalCloud Kit dashboard.",
-  });
   const [sending, setSending] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [messages, setMessages] = useState<MailMessage[]>([]);
@@ -53,7 +54,6 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
     return () => clearInterval(interval);
   }, [fetchMessages]);
 
-  // Close on Escape + lock body scroll
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     document.addEventListener("keydown", onKey);
@@ -64,12 +64,12 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
     };
   }, [onClose]);
 
-  const handleSend = async () => {
+  const handleSendTest = async () => {
     setSending(true);
     try {
-      const result = await mailpitApi.sendTest(form);
+      const result = await mailpitApi.sendTest(TEST_EMAIL_DEFAULTS);
       if (result.success) {
-        toast.success("Email sent — check the inbox below");
+        toast.success("Test email sent");
         refetch();
         fetchMessages();
       } else {
@@ -102,16 +102,16 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-3xl max-h-[90vh] flex flex-col overflow-hidden"
+        className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
           <div className="flex items-center space-x-3">
-            <span className="text-2xl">📬</span>
+            <EnvelopeIcon className="h-5 w-5 text-gray-500" />
             <div>
               <h2 className="text-lg font-semibold text-gray-900">Mailpit Inbox</h2>
-              <p className="text-xs text-gray-500">Local email testing</p>
+              <p className="text-xs text-gray-500">Local email testing · read-only preview</p>
             </div>
           </div>
           <div className="flex items-center space-x-2">
@@ -122,7 +122,7 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
               className="flex items-center px-3 py-1.5 text-xs font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
             >
               <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1" />
-              Open Mailpit UI
+              Open Mailpit
             </a>
             <Link
               href="/mailpit"
@@ -130,7 +130,7 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
               className="flex items-center px-3 py-1.5 text-xs font-medium text-gray-600 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors"
             >
               <BookOpenIcon className="h-3.5 w-3.5 mr-1" />
-              Documentation
+              Docs
             </Link>
             <button
               onClick={onClose}
@@ -144,7 +144,7 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
         {/* Scrollable body */}
         <div className="overflow-y-auto flex-1 divide-y divide-gray-100">
 
-          {/* Stats bar */}
+          {/* Stats + actions bar */}
           <div className="px-6 py-4 bg-gray-50 flex items-center justify-between">
             <div className="flex items-center space-x-6">
               <div>
@@ -169,14 +169,25 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
                 </span>
               </div>
             </div>
-            <button
-              onClick={handleClear}
-              disabled={clearing || stats.total === 0}
-              className="flex items-center px-3 py-1.5 text-sm font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 disabled:opacity-40 transition-colors"
-            >
-              <TrashIcon className="h-4 w-4 mr-1.5" />
-              {clearing ? "Clearing…" : "Clear All"}
-            </button>
+            <div className="flex items-center space-x-2">
+              <button
+                onClick={handleSendTest}
+                disabled={sending}
+                className="flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 disabled:opacity-40 transition-colors"
+                title="Send a preset test email to verify SMTP is working"
+              >
+                <PaperAirplaneIcon className="h-4 w-4 mr-1.5" />
+                {sending ? "Sending…" : "Send Test"}
+              </button>
+              <button
+                onClick={handleClear}
+                disabled={clearing || stats.total === 0}
+                className="flex items-center px-3 py-1.5 text-sm font-medium text-red-600 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 disabled:opacity-40 transition-colors"
+              >
+                <TrashIcon className="h-4 w-4 mr-1.5" />
+                {clearing ? "Clearing…" : "Clear All"}
+              </button>
+            </div>
           </div>
 
           {/* Recent Messages */}
@@ -186,9 +197,12 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
               <span className="text-xs text-gray-400">Auto-refreshes every 5s</span>
             </div>
             {messages.length === 0 ? (
-              <div className="text-center py-6 text-gray-400">
+              <div className="text-center py-8 text-gray-400">
                 <EnvelopeIcon className="h-8 w-8 mx-auto mb-2 opacity-40" />
-                <p className="text-sm">No messages yet. Send a test email below.</p>
+                <p className="text-sm">No messages yet.</p>
+                <p className="text-xs mt-1">
+                  Use <span className="font-medium">Send Test</span> above or point your app at SMTP localhost:1025.
+                </p>
               </div>
             ) : (
               <div className="overflow-hidden rounded-lg border border-gray-200">
@@ -230,56 +244,16 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
                 </table>
               </div>
             )}
-          </div>
-
-          {/* Send Test Email */}
-          <div className="px-6 py-4">
-            <h3 className="text-sm font-semibold text-gray-900 mb-3">Send Test Email</h3>
-            <div className="grid grid-cols-2 gap-3 mb-3">
-              <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">From</label>
-                <input
-                  type="email"
-                  value={form.from}
-                  onChange={(e) => setForm({ ...form, from: e.target.value })}
-                  className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
-              <div>
-                <label className="block text-xs font-medium text-gray-700 mb-1">To</label>
-                <input
-                  type="email"
-                  value={form.to}
-                  onChange={(e) => setForm({ ...form, to: e.target.value })}
-                  className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                />
-              </div>
-            </div>
-            <div className="mb-3">
-              <label className="block text-xs font-medium text-gray-700 mb-1">Subject</label>
-              <input
-                type="text"
-                value={form.subject}
-                onChange={(e) => setForm({ ...form, subject: e.target.value })}
-                className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <div className="mb-3">
-              <label className="block text-xs font-medium text-gray-700 mb-1">Body</label>
-              <textarea
-                rows={3}
-                value={form.body}
-                onChange={(e) => setForm({ ...form, body: e.target.value })}
-                className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              />
-            </div>
-            <button
-              onClick={handleSend}
-              disabled={sending}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
-            >
-              {sending ? "Sending…" : "Send Test Email"}
-            </button>
+            <p className="mt-3 text-xs text-gray-400 text-center">
+              For the full inbox experience, compose options, and SMTP settings —{" "}
+              <Link href="/mailpit" onClick={onClose} className="text-blue-500 hover:underline">
+                view documentation
+              </Link>{" "}
+              or{" "}
+              <a href={MAILPIT_UI_URL} target="_blank" rel="noopener noreferrer" className="text-blue-500 hover:underline">
+                open Mailpit UI
+              </a>.
+            </p>
           </div>
 
         </div>

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import { Resource } from "@/types";
+import { Icon } from "@iconify/react";
 import {
   TrashIcon,
   EyeIcon,
@@ -23,9 +23,7 @@ interface ResourceListProps {
   loading?: boolean;
   onViewS3?: (bucketName: string) => void;
   onViewDynamoDB?: (tableName: string) => void;
-  onViewCache?: () => void;
   onViewSecretsManager?: () => void;
-  onViewMailpit?: () => void;
   onRefresh?: () => void;
   onAddS3?: () => void;
   onAddDynamoDB?: () => void;
@@ -34,8 +32,34 @@ interface ResourceListProps {
   addLoading?: boolean;
 }
 
-// Resource types that are services (not AWS resources) — not selectable/destroyable
-const SERVICE_TYPES = ["cache", "mailpit", "postgres", "keycloak"];
+// AWS resource types only — platform services are excluded
+const AWS_RESOURCE_TYPES = ["s3", "dynamodb", "lambda", "apigateway", "iam", "secretsmanager"];
+
+const AWS_CATEGORIES = [
+  { name: "Storage", types: ["s3"] },
+  { name: "Database", types: ["dynamodb"] },
+  { name: "Compute", types: ["lambda"] },
+  { name: "Networking", types: ["apigateway"] },
+  { name: "Security & Identity", types: ["iam", "secretsmanager"] },
+];
+
+const RESOURCE_ICON: Record<string, string> = {
+  s3: "logos:aws-s3",
+  dynamodb: "logos:aws-dynamodb",
+  lambda: "logos:aws-lambda",
+  apigateway: "logos:aws-api-gateway",
+  iam: "logos:aws-iam",
+  secretsmanager: "logos:aws-secrets-manager",
+};
+
+const RESOURCE_LABEL: Record<string, string> = {
+  s3: "S3 Bucket",
+  dynamodb: "DynamoDB Table",
+  lambda: "Lambda Function",
+  apigateway: "API Gateway",
+  iam: "IAM",
+  secretsmanager: "Secrets Manager",
+};
 
 export default function ResourceList({
   resources,
@@ -44,9 +68,7 @@ export default function ResourceList({
   loading = false,
   onViewS3,
   onViewDynamoDB,
-  onViewCache,
   onViewSecretsManager,
-  onViewMailpit,
   onRefresh,
   onAddS3,
   onAddDynamoDB,
@@ -100,33 +122,6 @@ export default function ResourceList({
     }
   };
 
-  const getResourceIcon = (type: string) => {
-    switch (type) {
-      case "s3":
-        return "🪣";
-      case "dynamodb":
-        return "🗄️";
-      case "lambda":
-        return "⚡";
-      case "apigateway":
-        return "🌐";
-      case "iam":
-        return "🔐";
-      case "cache":
-        return "🧊";
-      case "secretsmanager":
-        return "🔑";
-      case "mailpit":
-        return "📬";
-      case "postgres":
-        return "🐘";
-      case "keycloak":
-        return "🔒";
-      default:
-        return "📦";
-    }
-  };
-
   const handleSelectResource = (resourceId: string) => {
     setSelectedResources((prev) =>
       prev.includes(resourceId)
@@ -152,19 +147,16 @@ export default function ResourceList({
     }
   };
 
-  const filteredResources = resources.filter(
-    (resource) => resource.project === projectName
-  );
-
-  const selectableResources = filteredResources.filter(
-    (r: Resource) => !SERVICE_TYPES.includes(r.type)
+  // Only show AWS resources (no platform services)
+  const awsResources = resources.filter(
+    (r) => r.project === projectName && AWS_RESOURCE_TYPES.includes(r.type)
   );
 
   const handleSelectAll = () => {
-    if (selectedResources.length === selectableResources.length) {
+    if (selectedResources.length === awsResources.length) {
       setSelectedResources([]);
     } else {
-      setSelectedResources(selectableResources.map((r) => r.id));
+      setSelectedResources(awsResources.map((r) => r.id));
     }
   };
 
@@ -175,11 +167,12 @@ export default function ResourceList({
       {/* Header */}
       <div className="px-6 py-4 border-b border-gray-200">
         <div className="flex items-center justify-between">
-          <h3 className="text-lg font-medium text-gray-900">
-            Resources ({filteredResources.length})
-          </h3>
+          <div>
+            <h3 className="text-lg font-medium text-gray-900">AWS Resources</h3>
+            <p className="text-xs text-gray-500 mt-0.5">{awsResources.length} resource{awsResources.length !== 1 ? "s" : ""} in &quot;{projectName}&quot;</p>
+          </div>
           <div className="flex items-center space-x-2">
-            {/* Destroy Selected — only when rows are checked */}
+            {/* Destroy Selected */}
             {selectedResources.length > 0 && (
               <button
                 onClick={handleDestroySelected}
@@ -195,7 +188,7 @@ export default function ResourceList({
               </button>
             )}
 
-            {/* Refresh icon */}
+            {/* Refresh */}
             {onRefresh && (
               <button
                 onClick={onRefresh}
@@ -220,31 +213,34 @@ export default function ResourceList({
                   <ChevronDownIcon className={`h-3.5 w-3.5 ml-1.5 transition-transform ${showAddMenu ? "rotate-180" : ""}`} />
                 </button>
                 {showAddMenu && (
-                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
                     {onAddS3 && (
                       <button
                         onClick={() => { onAddS3(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                       >
-                        <span className="mr-3">🪣</span>
+                        <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 flex-shrink-0" />
                         S3 Bucket
                       </button>
                     )}
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Database</p>
                     {onAddDynamoDB && (
                       <button
                         onClick={() => { onAddDynamoDB(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                       >
-                        <span className="mr-3">🗄️</span>
+                        <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 flex-shrink-0" />
                         DynamoDB Table
                       </button>
                     )}
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Security & Identity</p>
                     {onAddSecrets && (
                       <button
                         onClick={() => { onAddSecrets(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                       >
-                        <span className="mr-3">🔑</span>
+                        <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
                         Secrets Manager
                       </button>
                     )}
@@ -256,282 +252,231 @@ export default function ResourceList({
         </div>
       </div>
 
-      {/* Empty state — inside the card so the header stays visible */}
-      {filteredResources.length === 0 ? (
+      {/* Empty state */}
+      {awsResources.length === 0 ? (
         <div className="px-6 py-12 text-center">
-          <div className="text-gray-400 text-5xl mb-3">📦</div>
-          <h4 className="text-sm font-medium text-gray-900 mb-1">No Resources Found</h4>
+          <Icon icon="logos:aws" className="w-12 h-12 mx-auto mb-3 opacity-30" />
+          <h4 className="text-sm font-medium text-gray-900 mb-1">No AWS Resources</h4>
           <p className="text-sm text-gray-500">
-            No resources found for project &quot;{projectName}&quot;.
+            Add your first resource using the button above.
           </p>
         </div>
       ) : (
         <>
-          {/* Column labels */}
-          <div className="grid items-center gap-x-4 px-6 py-2 bg-gray-50 border-b border-gray-200"
-            style={{ gridTemplateColumns: "1.25rem 2rem 1fr 9rem 6rem 1.75rem" }}>
-            <div />
-            <div />
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Resource</span>
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Status</span>
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide text-center">Action</span>
-            <div />
-          </div>
+          {/* Category sections */}
+          {AWS_CATEGORIES.map((category) => {
+            const categoryResources = awsResources.filter((r) =>
+              category.types.includes(r.type)
+            );
+            if (categoryResources.length === 0) return null;
 
-          {/* Resource List */}
-          <div className="divide-y divide-gray-200">
-            {filteredResources.map((resource) => (
-              <div key={resource.id} className="px-6 py-3.5">
-                <div
-                  className="grid items-center gap-x-4"
-                  style={{ gridTemplateColumns: "1.25rem 2rem 1fr 9rem 6rem 1.75rem" }}
-                >
-                  {/* Col 1: checkbox or spacer */}
-                  {SERVICE_TYPES.includes(resource.type) ? (
-                    <div />
-                  ) : (
-                    <input
-                      type="checkbox"
-                      checked={selectedResources.includes(resource.id)}
-                      onChange={() => handleSelectResource(resource.id)}
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                  )}
-
-                  {/* Col 2: emoji icon */}
-                  <span className="text-xl leading-none text-center">
-                    {getResourceIcon(resource.type)}
+            return (
+              <div key={category.name}>
+                {/* Category header */}
+                <div className="px-6 py-2 bg-gray-50 border-b border-gray-200 flex items-center space-x-2">
+                  <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                    {category.name}
                   </span>
-
-                  {/* Col 3: name + subtitle */}
-                  <div className="min-w-0">
-                    <h4 className="text-sm font-medium text-gray-900 truncate">
-                      {resource.type === "cache" ? "Cache" : resource.name}
-                    </h4>
-                    <p className="text-xs text-gray-500 capitalize truncate">
-                      {resource.type === "mailpit"
-                        ? "Mailpit"
-                        : resource.type === "cache"
-                        ? "Redis"
-                        : resource.type === "postgres"
-                        ? "PostgreSQL • pgAdmin"
-                        : resource.type === "keycloak"
-                        ? "Keycloak • Identity Provider"
-                        : `${resource.type} • ${resource.project}`}
-                    </p>
-                  </div>
-
-                  {/* Col 4: status badge — fixed column keeps all badges aligned */}
-                  <div>
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${getStatusColor(resource.status)}`}
-                    >
-                      {getStatusIcon(resource.status)}
-                      <span className="ml-1 capitalize">{resource.status}</span>
-                    </span>
-                  </div>
-
-                  {/* Col 5: action button — always rendered so col 6 stays aligned */}
-                  <div className="flex justify-center">
-                    {resource.status === "active" && (
-                      <>
-                        {resource.type === "s3" && onViewS3 && (
-                          <button
-                            onClick={() => onViewS3(resource.name)}
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open S3 Bucket"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </button>
-                        )}
-                        {resource.type === "dynamodb" && onViewDynamoDB && (
-                          <button
-                            onClick={() => onViewDynamoDB(resource.name)}
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open DynamoDB Table"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </button>
-                        )}
-                        {resource.type === "cache" && onViewCache && (
-                          <button
-                            onClick={onViewCache}
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open Redis Cache"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </button>
-                        )}
-                        {resource.type === "mailpit" && onViewMailpit && (
-                          <button
-                            onClick={onViewMailpit}
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open Mailpit Inbox"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </button>
-                        )}
-                        {resource.type === "secretsmanager" && onViewSecretsManager && (
-                          <button
-                            onClick={onViewSecretsManager}
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open Secrets Manager"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </button>
-                        )}
-                        {resource.type === "postgres" && (
-                          <Link
-                            href="/postgres"
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open PostgreSQL info"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </Link>
-                        )}
-                        {resource.type === "keycloak" && (
-                          <Link
-                            href="/keycloak"
-                            className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                            title="Open Keycloak info"
-                          >
-                            <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
-                            Open
-                          </Link>
-                        )}
-                      </>
-                    )}
-                  </div>
-
-                  {/* Col 6: details toggle */}
-                  <div className="flex justify-center">
-                    <button
-                      onClick={() =>
-                        setShowDetails(showDetails === resource.id ? null : resource.id)
-                      }
-                      className={`text-gray-400 hover:text-gray-600 transition-colors ${showDetails === resource.id ? "text-gray-600" : ""}`}
-                      title="Show Details"
-                    >
-                      <EyeIcon className="h-4 w-4" />
-                    </button>
-                  </div>
+                  <span className="text-xs text-gray-400">({categoryResources.length})</span>
                 </div>
 
-                {/* Resource Details */}
-                {showDetails === resource.id && (
-                  <div className="mt-4 pl-8 border-l-2 border-gray-200">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                      <div>
-                        <dt className="font-medium text-gray-500">Resource ID</dt>
-                        <dd className="text-gray-900 font-mono">{resource.id}</dd>
-                      </div>
-                      <div>
-                        <dt className="font-medium text-gray-500">Created</dt>
-                        <dd className="text-gray-900">
-                          {new Date(resource.createdAt).toLocaleString()}
-                        </dd>
-                      </div>
+                {/* Column labels — only on first category */}
+                <div
+                  className="grid items-center gap-x-4 px-6 py-2 bg-white border-b border-gray-100"
+                  style={{ gridTemplateColumns: "1.25rem 2.5rem 1fr 9rem 6rem 1.75rem" }}
+                >
+                  <div />
+                  <div />
+                  <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">Resource</span>
+                  <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">Status</span>
+                  <span className="text-xs font-medium text-gray-400 uppercase tracking-wide text-center">Action</span>
+                  <div />
+                </div>
 
-                      {resource.type === "mailpit" && resource.details && (
-                        <>
-                          <div>
-                            <dt className="font-medium text-gray-500">Total Emails</dt>
-                            <dd className="text-gray-900">{resource.details.total}</dd>
-                          </div>
-                          <div>
-                            <dt className="font-medium text-gray-500">Unread</dt>
-                            <dd className={resource.details.unread > 0 ? "text-red-600 font-medium" : "text-gray-900"}>
-                              {resource.details.unread}
-                            </dd>
-                          </div>
-                          <div>
-                            <dt className="font-medium text-gray-500">SMTP</dt>
-                            <dd className="text-gray-900 font-mono">localhost:1025</dd>
-                          </div>
-                          <div>
-                            <dt className="font-medium text-gray-500">Web UI</dt>
-                            <dd className="text-gray-900 font-mono">localhost:8025</dd>
-                          </div>
-                        </>
-                      )}
+                <div className="divide-y divide-gray-100">
+                  {categoryResources.map((resource) => (
+                    <div key={resource.id} className="px-6 py-3.5">
+                      <div
+                        className="grid items-center gap-x-4"
+                        style={{ gridTemplateColumns: "1.25rem 2.5rem 1fr 9rem 6rem 1.75rem" }}
+                      >
+                        {/* Checkbox */}
+                        <input
+                          type="checkbox"
+                          checked={selectedResources.includes(resource.id)}
+                          onChange={() => handleSelectResource(resource.id)}
+                          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                        />
 
-                      {resource.type === "secretsmanager" && resource.details && (
-                        <>
-                          <div>
-                            <dt className="font-medium text-gray-500">ARN</dt>
-                            <dd className="text-gray-900 font-mono text-sm break-all">
-                              <div className="flex items-center space-x-2">
-                                <code className="flex-1 min-w-0">
-                                  {resource.details.arn}
-                                </code>
+                        {/* AWS icon */}
+                        <div className="flex items-center justify-center">
+                          <Icon
+                            icon={RESOURCE_ICON[resource.type] || "logos:aws"}
+                            className="w-6 h-6"
+                          />
+                        </div>
+
+                        {/* Name + type */}
+                        <div className="min-w-0">
+                          <h4 className="text-sm font-medium text-gray-900 truncate">
+                            {resource.name}
+                          </h4>
+                          <p className="text-xs text-gray-500 truncate">
+                            {RESOURCE_LABEL[resource.type] || resource.type} · {resource.project}
+                          </p>
+                        </div>
+
+                        {/* Status badge */}
+                        <div>
+                          <span
+                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${getStatusColor(resource.status)}`}
+                          >
+                            {getStatusIcon(resource.status)}
+                            <span className="ml-1 capitalize">{resource.status}</span>
+                          </span>
+                        </div>
+
+                        {/* Action button */}
+                        <div className="flex justify-center">
+                          {resource.status === "active" && (
+                            <>
+                              {resource.type === "s3" && onViewS3 && (
                                 <button
-                                  onClick={() =>
-                                    resource.details?.arn &&
-                                    copyArnToClipboard(resource.details.arn)
-                                  }
-                                  className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
-                                  title="Copy ARN"
+                                  onClick={() => onViewS3(resource.name)}
+                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
+                                  title="Browse S3 Bucket"
                                 >
-                                  <ClipboardDocumentIcon className="h-4 w-4" />
+                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  Open
                                 </button>
-                              </div>
-                              {copiedArn === resource.details.arn && (
-                                <p className="text-xs text-green-600 mt-1">
-                                  ✓ Copied to clipboard
-                                </p>
                               )}
-                            </dd>
-                          </div>
-                          {resource.details.description && (
-                            <div>
-                              <dt className="font-medium text-gray-500">Description</dt>
-                              <dd className="text-gray-900">{resource.details.description}</dd>
-                            </div>
+                              {resource.type === "dynamodb" && onViewDynamoDB && (
+                                <button
+                                  onClick={() => onViewDynamoDB(resource.name)}
+                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
+                                  title="Browse DynamoDB Table"
+                                >
+                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  Open
+                                </button>
+                              )}
+                              {resource.type === "secretsmanager" && onViewSecretsManager && (
+                                <button
+                                  onClick={onViewSecretsManager}
+                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
+                                  title="Browse Secrets Manager"
+                                >
+                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  Open
+                                </button>
+                              )}
+                            </>
                           )}
-                          <div>
-                            <dt className="font-medium text-gray-500">Last Changed</dt>
-                            <dd className="text-gray-900">
-                              {new Date(resource.details.lastChangedDate).toLocaleString()}
-                            </dd>
+                        </div>
+
+                        {/* Details toggle */}
+                        <div className="flex justify-center">
+                          <button
+                            onClick={() =>
+                              setShowDetails(showDetails === resource.id ? null : resource.id)
+                            }
+                            className={`text-gray-400 hover:text-gray-600 transition-colors ${showDetails === resource.id ? "text-gray-600" : ""}`}
+                            title="Show Details"
+                          >
+                            <EyeIcon className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+
+                      {/* Resource Details */}
+                      {showDetails === resource.id && (
+                        <div className="mt-4 pl-8 border-l-2 border-gray-200">
+                          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                            <div>
+                              <dt className="font-medium text-gray-500">Resource ID</dt>
+                              <dd className="text-gray-900 font-mono">{resource.id}</dd>
+                            </div>
+                            <div>
+                              <dt className="font-medium text-gray-500">Created</dt>
+                              <dd className="text-gray-900">
+                                {new Date(resource.createdAt).toLocaleString()}
+                              </dd>
+                            </div>
+
+                            {resource.type === "secretsmanager" && resource.details && (
+                              <>
+                                <div>
+                                  <dt className="font-medium text-gray-500">ARN</dt>
+                                  <dd className="text-gray-900 font-mono text-sm break-all">
+                                    <div className="flex items-center space-x-2">
+                                      <code className="flex-1 min-w-0">
+                                        {resource.details.arn}
+                                      </code>
+                                      <button
+                                        onClick={() =>
+                                          resource.details?.arn &&
+                                          copyArnToClipboard(resource.details.arn)
+                                        }
+                                        className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                                        title="Copy ARN"
+                                      >
+                                        <ClipboardDocumentIcon className="h-4 w-4" />
+                                      </button>
+                                    </div>
+                                    {copiedArn === resource.details.arn && (
+                                      <p className="text-xs text-green-600 mt-1">
+                                        ✓ Copied to clipboard
+                                      </p>
+                                    )}
+                                  </dd>
+                                </div>
+                                {resource.details.description && (
+                                  <div>
+                                    <dt className="font-medium text-gray-500">Description</dt>
+                                    <dd className="text-gray-900">{resource.details.description}</dd>
+                                  </div>
+                                )}
+                                <div>
+                                  <dt className="font-medium text-gray-500">Last Changed</dt>
+                                  <dd className="text-gray-900">
+                                    {new Date(resource.details.lastChangedDate).toLocaleString()}
+                                  </dd>
+                                </div>
+                              </>
+                            )}
+
+                            {resource.type !== "secretsmanager" &&
+                              resource.details &&
+                              Object.entries(resource.details).map(([key, value]) => (
+                                <div key={key}>
+                                  <dt className="font-medium text-gray-500 capitalize">
+                                    {key.replace(/([A-Z])/g, " $1")}
+                                  </dt>
+                                  <dd className="text-gray-900">{String(value)}</dd>
+                                </div>
+                              ))}
                           </div>
-                        </>
+                        </div>
                       )}
-
-                      {resource.type !== "secretsmanager" &&
-                        resource.details &&
-                        Object.entries(resource.details).map(([key, value]) => (
-                          <div key={key}>
-                            <dt className="font-medium text-gray-500 capitalize">
-                              {key.replace(/([A-Z])/g, " $1")}
-                            </dt>
-                            <dd className="text-gray-900">{String(value)}</dd>
-                          </div>
-                        ))}
                     </div>
-                  </div>
-                )}
+                  ))}
+                </div>
               </div>
-            ))}
-          </div>
+            );
+          })}
 
-          {/* Select All */}
-          {selectableResources.length > 0 && (
+          {/* Select All footer */}
+          {awsResources.length > 0 && (
             <div className="px-6 py-3 bg-gray-50 border-t border-gray-200">
               <div className="flex items-center space-x-3">
                 <input
                   type="checkbox"
-                  checked={selectedResources.length === selectableResources.length && selectableResources.length > 0}
+                  checked={selectedResources.length === awsResources.length && awsResources.length > 0}
                   onChange={handleSelectAll}
                   className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                 />
                 <span className="text-sm text-gray-700">
-                  Select all ({selectableResources.length} resources)
+                  Select all ({awsResources.length} resource{awsResources.length !== 1 ? "s" : ""})
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Refactor ResourceList to display only AWS resources (S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager) organized by service category, removing platform service entries
- Replace emoji icons with Iconify AWS service logos for a more professional appearance
- Separate platform services (Keycloak, Mailpit, PostgreSQL, Redis) into a dedicated Services menu in the dashboard header
- Simplify component props by removing service-specific view handlers (`onViewCache`, `onViewMailpit`) and consolidating resource filtering logic

## Type of change

- [x] `refactor` — code restructure, no behavior change
- [x] `feat` — new feature (Services menu, categorized resource view)

## Details

### ResourceList Component (`localcloud-gui/src/components/ResourceList.tsx`)
- **Removed**: `SERVICE_TYPES` constant; replaced with `AWS_RESOURCE_TYPES` (AWS services only)
- **Added**: `AWS_CATEGORIES` for organizing resources by service type (Storage, Database, Compute, Networking, Security & Identity)
- **Added**: `RESOURCE_ICON` and `RESOURCE_LABEL` lookup tables mapping resource types to Iconify icons and display labels
- **Removed**: `getResourceIcon()` function (emoji-based); now uses Iconify icons via `<Icon>` component
- **Removed**: Props `onViewCache` and `onViewMailpit` (platform services no longer managed here)
- **Changed**: Resource filtering now only includes AWS resources; platform services are excluded entirely
- **Changed**: Resource list now displays in category sections with headers and counts
- **Changed**: Column layout adjusted to accommodate AWS service icons

### Dashboard Component (`localcloud-gui/src/components/Dashboard.tsx`)
- **Added**: `showServicesMenu` state and `servicesMenuRef` for platform services dropdown
- **Added**: `closeAllMenus()` helper to manage multiple dropdown states
- **Changed**: Resources dropdown renamed from "Tools" to "Resources" and reorganized with AWS service categories
- **Changed**: Added new Services dropdown (separate from Resources) for platform services (Keycloak, Mailpit, PostgreSQL, Redis)
- **Removed**: Service-specific view handlers passed to ResourceList
- **Added**: Service status helper functions (`serviceStatusClass`, `serviceDotClass`, `serviceLabel`)
- **Changed**: Imported `CpuChipIcon`, `GlobeAltIcon`, `ShieldCheckIcon` from Heroicons and `Icon` from Iconify

### MailpitModal Component (`localcloud-gui/src/components/MailpitModal.tsx`)
- **Added**: `TEST_EMAIL_DEFAULTS` constant for test email form
- **Removed**: Form state from component; now uses defaults
- **Changed**: Renamed `handleSend` to `handleSendTest` for clarity
- **Changed**: Modal header icon from emoji to `EnvelopeIcon`
- **Changed**: Subtitle text updated to "read-only preview"

### Mailpit Documentation Page (`localcloud-gui/src/app/mailpit/page.tsx`)
- **Added**: Test email form with send functionality
- **Changed**: "Manage Inbox" button replaced with direct link to Mailpit UI
- **Changed**: Documentation text updated to reflect new dashboard organization

### Dependencies
- **Added**: `@iconify/react` (^6.0.2) for AWS service icons

## Pre-merge checklist

### Code
- [x] All changes follow existing code patterns and TypeScript conventions
- [x] No hardcoded secrets or credentials introduced
- [x] Component refactoring maintains backward compatibility where applicable

### Documentation & changelog
- [x] `CLAUDE.md` updated with new Dashboard UI Architecture section
- [x] `README.md` updated to reflect Services Status Bar and AWS Resources organization
- [x] Component changes documented inline

## Test Plan

- Verify ResourceList displays only AWS resources (S3, DynamoDB, Secrets Manager) with correct category grouping
- Confirm platform services (Keycloak, Mailpit, PostgreSQL, Redis) appear only in Services dropdown, not in resource list
- Test that AWS service icons render correctly via Iconify
- Verify Resources and Services dropdowns

https://claude.ai/code/session_01FJ8w2mcitYsa2nGetECJPE