### PR TITLE
feat(lambda,apigateway,ssm): add Lambda, API Gateway, and Parameter Store services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Lambda**: Lambda function management — create modal with runtime/handler selection, dedicated `/lambda` doc page with SDK examples (TypeScript, Node.js, Python, CLI), API routes (`/api/lambda/functions`), and shell script (`list_lambda_functions.sh`)
+- **API Gateway**: API Gateway management — create modal, dedicated `/apigateway` doc page with full REST API walkthrough (resources, methods, mock/Lambda integrations, stage deployment), API routes (`/api/apigateway/apis`), and shell script (`list_apis.sh`)
+- **Parameter Store**: SSM Parameter Store service — create modal with String / StringList / SecureString type selection, dedicated `/ssm` doc page with SDK examples, API routes (`/api/ssm/parameters` CRUD), and shell scripts (`list_parameters.sh`, `create_parameter.sh`, `get_parameter.sh`, `delete_parameter.sh`)
+- **ResourceList**: Lambda, API Gateway, and Parameter Store entries in the `+ Add` dropdown under Compute, Networking, and Security & Identity sections
+- **Dashboard**: Resources dropdown now includes Compute (Lambda), Networking (API Gateway), and Parameter Store sections; Docs dropdown updated with Lambda, API Gateway, and Parameter Store links; mobile menu updated accordingly
+- **docs/LAMBDA.md**: Lambda integration reference — runtimes, API endpoints, SDK examples, CLI usage, troubleshooting
+- **docs/API_GATEWAY.md**: API Gateway integration reference — REST API creation, resource/method/integration setup, stage deployment, Lambda proxy
+- **docs/SSM.md**: Parameter Store integration reference — parameter types, hierarchical paths, SDK examples, best practices
+
 ## [0.11.5] - 2026-03-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,21 @@ samples/            # Sample files for S3/DynamoDB testing
 
 - **S3** — bucket management, multipart uploads (up to 100MB), nested folders
 - **DynamoDB** — tables, CRUD, GSI, query/scan
-- **Lambda** — function management
-- **API Gateway** — REST endpoint creation
+- **Lambda** — function management, runtime/handler config, placeholder zip creation; upload real code via `update-function-code`
+- **API Gateway** — REST endpoint creation with name and description
 - **IAM** — identity & access management
 - **Secrets Manager** — secret storage, encryption, ARN management
+- **SSM Parameter Store** — parameter management (String, StringList, SecureString)
 - **Redis** — local cache (not AWS, but integrated into the GUI)
+
+### Saved Configs
+
+All AWS resource creation modals (S3, DynamoDB, Lambda, API Gateway, Secrets Manager, SSM) support **saved configs**:
+- Users can toggle "Save as config for future use" and give the config a name
+- Saved configs are stored per-project via `savedConfigsApi` and surfaced as clickable pills in the modal
+- Clicking a pill loads its values into the form
+- Config data flows: modal → `usePreferences().saveConfig()` → `savedConfigsApi.create()` → backend → SQLite
+- Resource types for saved configs: `s3`, `dynamodb`, `lambda`, `apigateway`, `secretsmanager`, `ssm`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Local Cloud Development Environment**
 
-Build and test cloud apps locally — no AWS account needed. Free, fast, and with full data visibility. Emulates S3, DynamoDB, Secrets Manager, Redis cache, and email testing with Mailpit.
+Build and test cloud apps locally — no AWS account needed. Free, fast, and with full data visibility. Emulates S3, DynamoDB, Lambda, API Gateway, SSM Parameter Store, Secrets Manager, Redis cache, and email testing with Mailpit.
 
 [![Version](https://img.shields.io/badge/version-0.11.5-blue.svg)](https://github.com/jonbrobinson/localcloud-kit/releases/tag/v0.11.5)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -192,6 +192,30 @@ The header contains three primary dropdowns:
 - **Query & Scan**: Advanced querying with GSI support
 - **Schema Validation**: Interactive forms for adding items with type checking
 
+#### Lambda Functions
+
+- **Function Management**: Create, list, and delete Lambda functions
+- **Runtime Selection**: Python 3.9–3.12, Node.js 18/20, Java 17/21, Go, .NET 8
+- **Handler Configuration**: Set entry point via modal or AWS CLI
+- **Function Invocation**: Invoke functions with custom payloads
+- **SDK Integration**: Full AWS SDK v2/v3 and boto3 support
+
+#### API Gateway
+
+- **REST API Creation**: Create and manage REST API stubs
+- **Resource & Method Definition**: Add paths, HTTP methods, and integrations via SDK or CLI
+- **Mock & Lambda Integrations**: Connect to Lambda functions or use mock responses
+- **Stage Deployments**: Deploy APIs to named stages (dev, staging, prod)
+- **Invoke URL**: Accessible at `http://localhost:4566/restapis/{id}/{stage}/_user_request_/{path}`
+
+#### Parameter Store
+
+- **Hierarchical Parameters**: Organise with `/`-delimited path namespaces
+- **Three Types**: String (plain text), StringList (comma-separated), SecureString (encrypted)
+- **Path-based Retrieval**: Fetch all parameters under a path with `get-parameters-by-path`
+- **Config Loading**: Use as a drop-in configuration store for local app development
+- **SDK Integration**: Full AWS SDK v2/v3 and boto3 support
+
 #### Secrets Manager
 
 - **Secure Storage**: Store and manage secrets with encryption support
@@ -287,7 +311,10 @@ See [docs/LOCALSTACK.md](docs/LOCALSTACK.md) for `make start-legacy`, version pi
 2. Click individual resource buttons:
    - 🪣 **S3 Bucket** - Create storage buckets
    - 🗄️ **DynamoDB Table** - Create NoSQL tables
-   - 🔑 **Secrets Manager** - Store secrets
+   - ⚡ **Lambda Function** - Deploy serverless functions
+   - 🌐 **API Gateway** - Create REST APIs
+   - 🔒 **Parameter Store** - Store configuration and secrets
+   - 🔑 **Secrets Manager** - Store sensitive secrets
 3. Or use the batch creation modal for multiple resources
 
 #### Via Shell Scripts
@@ -398,11 +425,17 @@ docker compose up -d --scale api=3 # Scale services
 - **[docs/CERTIFICATE_TROUBLESHOOTING.md](docs/CERTIFICATE_TROUBLESHOOTING.md)** — Fix certificate issues
 - **[docs/LOCAL_WORKFLOW.md](docs/LOCAL_WORKFLOW.md)** — Daily development workflow
 
-### Services
+### AWS Services
+
+- **[docs/LAMBDA.md](docs/LAMBDA.md)** — Lambda functions
+- **[docs/API_GATEWAY.md](docs/API_GATEWAY.md)** — API Gateway
+- **[docs/SSM.md](docs/SSM.md)** — SSM Parameter Store
+- **[docs/SECRETS.md](docs/SECRETS.md)** — Secrets Manager
+
+### Platform Services
 
 - **[docs/MAILPIT.md](docs/MAILPIT.md)** — Email testing
 - **[docs/REDIS.md](docs/REDIS.md)** — Redis cache
-- **[docs/SECRETS.md](docs/SECRETS.md)** — Secrets Manager
 - **[docs/KEYCLOAK.md](docs/KEYCLOAK.md)** — Identity & access
 - **[docs/PGADMIN.md](docs/PGADMIN.md)** — PostgreSQL UI
 

--- a/docs/API_GATEWAY.md
+++ b/docs/API_GATEWAY.md
@@ -1,0 +1,200 @@
+# AWS API Gateway Integration
+
+LocalCloud Kit includes AWS API Gateway support for building and testing REST APIs locally via LocalStack.
+
+## Features
+
+- **REST API Management**: Create, list, and delete REST APIs
+- **Resource & Method Definition**: Add resources, methods, and integrations via SDK or CLI
+- **Mock & Lambda Integrations**: Connect to Lambda functions or use mock responses
+- **Stage Deployments**: Deploy APIs to named stages (dev, staging, prod)
+- **GUI Management**: Create APIs via the dashboard with name and description
+- **API Endpoints**: RESTful management endpoints
+- **Shell Scripts**: Automation scripts for API Gateway operations
+
+## Quick Start
+
+1. Start all services: `make start`
+2. Open the GUI: https://app-local.localcloudkit.com:3030
+3. Click **Resources → API Gateway** to create a new REST API
+4. Add resources and methods via the AWS CLI or SDK at `http://localhost:4566`
+
+## Invoke URL Pattern
+
+After deploying to a stage, APIs are accessible at:
+
+```
+http://localhost:4566/restapis/{apiId}/{stage}/_user_request_/{path}
+```
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/api/apigateway/apis` | List all REST APIs |
+| `GET` | `/api/apigateway/apis/:apiId` | Get API details |
+| `DELETE` | `/api/apigateway/apis/:apiId` | Delete a REST API |
+
+### Example Requests
+
+#### List all APIs
+
+```bash
+curl http://localhost:3031/api/apigateway/apis
+```
+
+#### Delete an API
+
+```bash
+curl -X DELETE http://localhost:3031/api/apigateway/apis/abc123xyz
+```
+
+## Shell Scripts
+
+Located in `scripts/shell/`:
+
+| Script | Description |
+| ------ | ----------- |
+| `list_apis.sh` | List REST APIs with optional project filter |
+
+### Example Usage
+
+```bash
+# List all APIs
+./scripts/shell/list_apis.sh
+
+# List APIs for a specific project
+./scripts/shell/list_apis.sh my-project
+```
+
+## Using with AWS SDK
+
+### Python (boto3)
+
+```python
+import boto3
+
+apigw = boto3.client(
+    "apigateway",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a REST API
+api = apigw.create_rest_api(name="my-api")
+api_id = api["id"]
+
+# Get the root resource
+resources = apigw.get_resources(restApiId=api_id)
+root_id = resources["items"][0]["id"]
+
+# Create a resource path
+resource = apigw.create_resource(
+    restApiId=api_id,
+    parentId=root_id,
+    pathPart="hello",
+)
+
+# Add a GET method with mock integration
+apigw.put_method(
+    restApiId=api_id,
+    resourceId=resource["id"],
+    httpMethod="GET",
+    authorizationType="NONE",
+)
+apigw.put_integration(
+    restApiId=api_id,
+    resourceId=resource["id"],
+    httpMethod="GET",
+    type="MOCK",
+    requestTemplates={"application/json": '{"statusCode": 200}'},
+)
+
+# Deploy to dev stage
+apigw.create_deployment(restApiId=api_id, stageName="dev")
+invoke_url = f"http://localhost:4566/restapis/{api_id}/dev/_user_request_/hello"
+print(f"Invoke at: {invoke_url}")
+```
+
+### AWS CLI
+
+```bash
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create API
+API_ID=$(awslocal apigateway create-rest-api \
+  --name my-api --query 'id' --output text)
+
+# Get root resource
+ROOT_ID=$(awslocal apigateway get-resources \
+  --rest-api-id $API_ID \
+  --query 'items[0].id' --output text)
+
+# Create /hello resource
+RESOURCE_ID=$(awslocal apigateway create-resource \
+  --rest-api-id $API_ID \
+  --parent-id $ROOT_ID \
+  --path-part hello \
+  --query 'id' --output text)
+
+# Add GET method + mock integration
+awslocal apigateway put-method \
+  --rest-api-id $API_ID \
+  --resource-id $RESOURCE_ID \
+  --http-method GET \
+  --authorization-type NONE
+
+awslocal apigateway put-integration \
+  --rest-api-id $API_ID \
+  --resource-id $RESOURCE_ID \
+  --http-method GET \
+  --type MOCK \
+  --request-templates '{"application/json":"{\"statusCode\":200}"}'
+
+# Deploy to dev
+awslocal apigateway create-deployment \
+  --rest-api-id $API_ID \
+  --stage-name dev
+
+# Invoke
+curl http://localhost:4566/restapis/$API_ID/dev/_user_request_/hello
+```
+
+## Lambda Proxy Integration
+
+```python
+# After creating a Lambda function named "hello-fn":
+apigw.put_integration(
+    restApiId=api_id,
+    resourceId=resource["id"],
+    httpMethod="GET",
+    type="AWS_PROXY",
+    integrationHttpMethod="POST",
+    uri=f"arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:000000000000:function:hello-fn/invocations",
+)
+```
+
+## Troubleshooting
+
+### API not found
+
+```bash
+# List all APIs to find the ID
+awslocal apigateway get-rest-apis
+```
+
+### 404 on invocation
+
+- Verify the stage has been deployed with `create-deployment`
+- Confirm the path matches exactly (case-sensitive)
+- Check the integration is correctly configured
+
+---
+
+[← Back to Main Documentation](../README.md)

--- a/docs/LAMBDA.md
+++ b/docs/LAMBDA.md
@@ -1,0 +1,202 @@
+# AWS Lambda Integration
+
+LocalCloud Kit includes AWS Lambda support for serverless function development and testing via LocalStack.
+
+## Features
+
+- **Function Management**: Create, list, and delete Lambda functions
+- **Multiple Runtimes**: Python 3.9–3.12, Node.js 18/20, Java 17/21, Go, .NET 8
+- **Function Invocation**: Invoke functions directly from the dashboard or CLI
+- **GUI Management**: Create functions via the dashboard with runtime and handler configuration
+- **API Endpoints**: RESTful endpoints for programmatic access
+- **Shell Scripts**: Automation scripts for Lambda operations
+
+## Quick Start
+
+1. Start all services: `make start`
+2. Open the GUI: https://app-local.localcloudkit.com:3030
+3. Click **Resources → Lambda Functions** to create a new function
+4. Connect via the AWS SDK at `http://localhost:4566`
+
+## Docker Setup
+
+Lambda runs as part of LocalStack services:
+
+- Enabled in `docker-compose.yml` by default
+- No additional configuration required
+- Functions run in-process in LocalStack (no Docker-in-Docker needed)
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/api/lambda/functions` | List all Lambda functions |
+| `GET` | `/api/lambda/functions/:name` | Get function details |
+| `DELETE` | `/api/lambda/functions/:name` | Delete a function |
+| `POST` | `/api/lambda/functions/:name/invoke` | Invoke a function |
+
+### Example Requests
+
+#### List all functions
+
+```bash
+curl http://localhost:3031/api/lambda/functions
+```
+
+#### Invoke a function
+
+```bash
+curl -X POST http://localhost:3031/api/lambda/functions/my-function/invoke \
+  -H "Content-Type: application/json" \
+  -d '{"payload": {"key": "value"}}'
+```
+
+#### Delete a function
+
+```bash
+curl -X DELETE http://localhost:3031/api/lambda/functions/my-function
+```
+
+## Shell Scripts
+
+Located in `scripts/shell/`:
+
+| Script | Description |
+| ------ | ----------- |
+| `list_lambda_functions.sh` | List Lambda functions with optional project filter |
+
+### Example Usage
+
+```bash
+# List all functions
+./scripts/shell/list_lambda_functions.sh
+
+# List functions for a specific project
+./scripts/shell/list_lambda_functions.sh my-project
+```
+
+## Supported Runtimes
+
+| Runtime | Notes |
+| ------- | ----- |
+| `python3.12` | Latest Python (recommended) |
+| `python3.11` | Python 3.11 |
+| `python3.10` | Python 3.10 |
+| `python3.9` | Python 3.9 |
+| `nodejs20.x` | Node.js 20 (recommended) |
+| `nodejs18.x` | Node.js 18 |
+| `java21` | Java 21 |
+| `java17` | Java 17 |
+| `go1.x` | Go |
+| `dotnet8` | .NET 8 |
+
+## Using with AWS SDK
+
+### Python (boto3)
+
+```python
+import boto3, json, zipfile, io
+
+lambda_client = boto3.client(
+    "lambda",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Build a minimal zip in memory
+code = b"def lambda_handler(e, c): return {'statusCode': 200, 'body': 'Hello!'}"
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w") as z:
+    z.writestr("lambda_function.py", code)
+
+# Create function
+lambda_client.create_function(
+    FunctionName="my-function",
+    Runtime="python3.12",
+    Role="arn:aws:iam::000000000000:role/irrelevant",
+    Handler="lambda_function.lambda_handler",
+    Code={"ZipFile": buf.getvalue()},
+)
+
+# Invoke function
+response = lambda_client.invoke(
+    FunctionName="my-function",
+    Payload=json.dumps({"key": "value"}),
+)
+print(json.loads(response["Payload"].read()))
+```
+
+### Node.js
+
+```javascript
+import { LambdaClient, InvokeCommand } from "@aws-sdk/client-lambda";
+
+const lambda = new LambdaClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+const response = await lambda.send(new InvokeCommand({
+  FunctionName: "my-function",
+  Payload: JSON.stringify({ key: "value" }),
+}));
+console.log(JSON.parse(Buffer.from(response.Payload).toString()));
+```
+
+### AWS CLI
+
+```bash
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a function
+echo 'def lambda_handler(e,c): return {"statusCode":200}' > lambda_function.py
+zip function.zip lambda_function.py
+
+awslocal lambda create-function \
+  --function-name my-function \
+  --runtime python3.12 \
+  --role arn:aws:iam::000000000000:role/irrelevant \
+  --handler lambda_function.lambda_handler \
+  --zip-file fileb://function.zip
+
+# Invoke
+awslocal lambda invoke \
+  --function-name my-function \
+  --payload '{"key":"value"}' \
+  response.json
+cat response.json
+```
+
+## Troubleshooting
+
+### Function not found
+
+```bash
+# List all functions to verify name
+awslocal lambda list-functions
+```
+
+### Invocation error
+
+```bash
+# Check function logs (LocalStack Community writes to stdout)
+docker compose logs localstack | grep my-function
+```
+
+### GUI not showing functions
+
+```bash
+# Verify functions exist via API
+curl http://localhost:3031/api/lambda/functions
+```
+
+---
+
+[← Back to Main Documentation](../README.md)

--- a/docs/SSM.md
+++ b/docs/SSM.md
@@ -1,0 +1,241 @@
+# AWS SSM Parameter Store Integration
+
+LocalCloud Kit includes AWS Systems Manager Parameter Store support for managing configuration data and secrets locally via LocalStack.
+
+## Features
+
+- **Hierarchical Parameters**: Organise with `/`-delimited path namespaces
+- **Three Parameter Types**: String, StringList, and SecureString (encrypted)
+- **Complete CRUD**: Create, read, update, and delete parameters
+- **GUI Management**: Create parameters via the dashboard with type selection
+- **API Endpoints**: RESTful endpoints for programmatic access
+- **Shell Scripts**: Automation scripts for all parameter operations
+
+## Quick Start
+
+1. Start all services: `make start`
+2. Open the GUI: https://app-local.localcloudkit.com:3030
+3. Click **Resources → Parameter Store** to create a new parameter
+4. Connect via the AWS SDK at `http://localhost:4566`
+
+## Parameter Types
+
+| Type | Use Case |
+| ---- | -------- |
+| `String` | Plain text values — hostnames, URLs, config flags |
+| `StringList` | Comma-separated values — e.g. `us-east-1,eu-west-1` |
+| `SecureString` | Sensitive data encrypted at rest using KMS |
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| `GET` | `/api/ssm/parameters` | List all parameters |
+| `POST` | `/api/ssm/parameters` | Create / update a parameter |
+| `GET` | `/api/ssm/parameters/:name` | Get a parameter value |
+| `PUT` | `/api/ssm/parameters/:name` | Update a parameter |
+| `DELETE` | `/api/ssm/parameters/:name` | Delete a parameter |
+
+### Example Requests
+
+#### List all parameters
+
+```bash
+curl http://localhost:3031/api/ssm/parameters
+```
+
+#### Create a parameter
+
+```bash
+curl -X POST http://localhost:3031/api/ssm/parameters \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "/my-app/database/host",
+    "value": "localhost",
+    "type": "String",
+    "description": "Database hostname"
+  }'
+```
+
+#### Get a parameter
+
+```bash
+curl "http://localhost:3031/api/ssm/parameters//my-app/database/host"
+```
+
+#### Delete a parameter
+
+```bash
+curl -X DELETE "http://localhost:3031/api/ssm/parameters//my-app/database/host"
+```
+
+## Shell Scripts
+
+Located in `scripts/shell/`:
+
+| Script | Description |
+| ------ | ----------- |
+| `list_parameters.sh` | List all SSM parameters |
+| `create_parameter.sh` | Create or update a parameter |
+| `get_parameter.sh` | Get a parameter value |
+| `delete_parameter.sh` | Delete a parameter |
+
+### Example Usage
+
+```bash
+# Create a parameter
+./scripts/shell/create_parameter.sh "/my-app/db/host" "localhost" "String" "DB hostname"
+
+# Get a parameter
+./scripts/shell/get_parameter.sh "/my-app/db/host"
+
+# List all parameters
+./scripts/shell/list_parameters.sh
+
+# Delete a parameter
+./scripts/shell/delete_parameter.sh "/my-app/db/host"
+```
+
+## Using with AWS SDK
+
+### Python (boto3)
+
+```python
+import boto3
+
+ssm = boto3.client(
+    "ssm",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create parameters
+ssm.put_parameter(
+    Name="/my-app/database/host",
+    Value="localhost",
+    Type="String",
+    Description="Database hostname",
+    Overwrite=True,
+)
+ssm.put_parameter(
+    Name="/my-app/database/password",
+    Value="s3cr3t!",
+    Type="SecureString",
+    Overwrite=True,
+)
+
+# Get a parameter (decrypted)
+response = ssm.get_parameter(
+    Name="/my-app/database/password",
+    WithDecryption=True,
+)
+print(response["Parameter"]["Value"])
+
+# Get all parameters under a path
+response = ssm.get_parameters_by_path(
+    Path="/my-app/",
+    Recursive=True,
+    WithDecryption=True,
+)
+for p in response["Parameters"]:
+    print(f"{p['Name']} = {p['Value']}")
+
+# Delete
+ssm.delete_parameter(Name="/my-app/database/host")
+```
+
+### AWS CLI
+
+```bash
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create parameters
+awslocal ssm put-parameter \
+  --name "/my-app/database/host" \
+  --value "localhost" \
+  --type String \
+  --overwrite
+
+awslocal ssm put-parameter \
+  --name "/my-app/database/password" \
+  --value "s3cr3t!" \
+  --type SecureString \
+  --overwrite
+
+# Get a parameter
+awslocal ssm get-parameter \
+  --name "/my-app/database/host"
+
+# Get all under a path
+awslocal ssm get-parameters-by-path \
+  --path "/my-app/" \
+  --recursive \
+  --with-decryption
+
+# List all
+awslocal ssm describe-parameters
+
+# Delete
+awslocal ssm delete-parameter --name "/my-app/database/host"
+```
+
+## Best Practices
+
+1. **Use Hierarchical Paths**: Organise with `/app/env/service/key` patterns
+   - ✅ `/my-app/prod/database/password`
+   - ✅ `/shared/smtp/host`
+   - ❌ `dbpassword`, `host1`
+
+2. **SecureString for Sensitive Data**: Always use `SecureString` for passwords, API keys, and tokens
+
+3. **String vs StringList**: Use `StringList` for comma-separated config values read as arrays
+
+4. **Descriptions**: Add descriptions — they show up in the GUI and CLI
+
+## Common Use Cases
+
+### App Configuration Loading
+
+```python
+import boto3
+
+def load_config(app_name: str, env: str) -> dict:
+    ssm = boto3.client("ssm", endpoint_url="http://localhost:4566",
+                       region_name="us-east-1",
+                       aws_access_key_id="test", aws_secret_access_key="test")
+    response = ssm.get_parameters_by_path(
+        Path=f"/{app_name}/{env}/",
+        Recursive=True,
+        WithDecryption=True,
+    )
+    return {p["Name"].split("/")[-1]: p["Value"] for p in response["Parameters"]}
+
+config = load_config("my-app", "dev")
+print(config)  # {"host": "localhost", "port": "5432", ...}
+```
+
+## Troubleshooting
+
+### Parameter not found
+
+```bash
+# List all parameters
+awslocal ssm describe-parameters
+
+# Check exact name
+awslocal ssm get-parameter --name "/exact/parameter/name"
+```
+
+### SecureString decryption issues
+
+LocalStack decrypts SecureString using a local KMS key automatically — ensure you pass `--with-decryption` or `WithDecryption=True`.
+
+---
+
+[← Back to Main Documentation](../README.md)

--- a/localcloud-api/lib/resources.js
+++ b/localcloud-api/lib/resources.js
@@ -103,6 +103,14 @@ export async function createSingleResource(projectName, resourceType, config = {
       command += ` --config '${JSON.stringify(config.secretsmanagerConfig)}'`;
     }
 
+    if (resourceType === "lambda" && config.lambdaConfig) {
+      command += ` --config '${JSON.stringify(config.lambdaConfig)}'`;
+    }
+
+    if (resourceType === "apigateway" && config.apigatewayConfig) {
+      command += ` --config '${JSON.stringify(config.apigatewayConfig)}'`;
+    }
+
     console.log("[DEBUG] Running command:", command);
 
     const { stdout, stderr } = await execAsync(command, {

--- a/localcloud-api/routes/apigateway.js
+++ b/localcloud-api/routes/apigateway.js
@@ -1,0 +1,56 @@
+import express from "express";
+import { execAsync, internalEndpoint, awsRegion, awsEnv } from "../lib/aws.js";
+import { addLog } from "../lib/context.js";
+
+const router = express.Router();
+
+// List REST APIs, optionally filtered by project
+router.get("/apigateway/apis", async (req, res) => {
+  try {
+    const { projectName } = req.query;
+    const args = projectName ? ` "${projectName}"` : "";
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/list_apis.sh${args}`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `API Gateway list warning: ${stderr}`, "automation");
+    res.json({ success: true, data: JSON.parse(stdout) });
+  } catch (error) {
+    addLog("error", `Failed to list API Gateway APIs: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list APIs", message: error.message });
+  }
+});
+
+// Get a specific REST API
+router.get("/apigateway/apis/:apiId", async (req, res) => {
+  try {
+    const { apiId } = req.params;
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} apigateway get-rest-api --rest-api-id "${apiId}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `API Gateway get warning: ${stderr}`, "automation");
+    res.json({ success: true, data: JSON.parse(stdout) });
+  } catch (error) {
+    addLog("error", `Failed to get API Gateway API: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get API", message: error.message });
+  }
+});
+
+// Delete a REST API
+router.delete("/apigateway/apis/:apiId", async (req, res) => {
+  try {
+    const { apiId } = req.params;
+    await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} apigateway delete-rest-api --rest-api-id "${apiId}"`,
+      { env: awsEnv() }
+    );
+    addLog("success", `API Gateway ${apiId} deleted`, "automation");
+    res.json({ success: true, data: { apiId, message: "API deleted" } });
+  } catch (error) {
+    addLog("error", `Failed to delete API Gateway API: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to delete API", message: error.message });
+  }
+});
+
+export default router;

--- a/localcloud-api/routes/lambda.js
+++ b/localcloud-api/routes/lambda.js
@@ -1,0 +1,74 @@
+import express from "express";
+import { execAsync, internalEndpoint, awsRegion, awsEnv } from "../lib/aws.js";
+import { addLog } from "../lib/context.js";
+
+const router = express.Router();
+
+// List Lambda functions, optionally filtered by project
+router.get("/lambda/functions", async (req, res) => {
+  try {
+    const { projectName } = req.query;
+    const args = projectName ? ` "${projectName}"` : "";
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/list_lambda_functions.sh${args}`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `Lambda list warning: ${stderr}`, "automation");
+    res.json({ success: true, data: JSON.parse(stdout) });
+  } catch (error) {
+    addLog("error", `Failed to list Lambda functions: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list Lambda functions", message: error.message });
+  }
+});
+
+// Get a specific Lambda function
+router.get("/lambda/functions/:functionName", async (req, res) => {
+  try {
+    const { functionName } = req.params;
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} lambda get-function --function-name "${functionName}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `Lambda get warning: ${stderr}`, "automation");
+    res.json({ success: true, data: JSON.parse(stdout) });
+  } catch (error) {
+    addLog("error", `Failed to get Lambda function: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get Lambda function", message: error.message });
+  }
+});
+
+// Delete a Lambda function
+router.delete("/lambda/functions/:functionName", async (req, res) => {
+  try {
+    const { functionName } = req.params;
+    await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} lambda delete-function --function-name "${functionName}"`,
+      { env: awsEnv() }
+    );
+    addLog("success", `Lambda function ${functionName} deleted`, "automation");
+    res.json({ success: true, data: { functionName, message: "Function deleted" } });
+  } catch (error) {
+    addLog("error", `Failed to delete Lambda function: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to delete Lambda function", message: error.message });
+  }
+});
+
+// Invoke a Lambda function
+router.post("/lambda/functions/:functionName/invoke", async (req, res) => {
+  try {
+    const { functionName } = req.params;
+    const payload = req.body.payload ? JSON.stringify(req.body.payload) : "{}";
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} lambda invoke --function-name "${functionName}" --payload '${payload}' /dev/stdout`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `Lambda invoke warning: ${stderr}`, "automation");
+    addLog("success", `Lambda function ${functionName} invoked`, "automation");
+    res.json({ success: true, data: { functionName, result: stdout.trim() } });
+  } catch (error) {
+    addLog("error", `Failed to invoke Lambda function: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to invoke Lambda function", message: error.message });
+  }
+});
+
+export default router;

--- a/localcloud-api/routes/ssm.js
+++ b/localcloud-api/routes/ssm.js
@@ -1,0 +1,107 @@
+import express from "express";
+import { execAsync, internalEndpoint, awsRegion, awsEnv } from "../lib/aws.js";
+import { addLog } from "../lib/context.js";
+
+const router = express.Router();
+
+// List SSM parameters
+router.get("/ssm/parameters", async (req, res) => {
+  try {
+    const { pathPrefix = "/", maxResults = "50" } = req.query;
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/list_parameters.sh "${pathPrefix}" "${maxResults}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `SSM list warning: ${stderr}`, "automation");
+    res.json({ success: true, data: JSON.parse(stdout) });
+  } catch (error) {
+    addLog("error", `Failed to list SSM parameters: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list parameters", message: error.message });
+  }
+});
+
+// Create / put a parameter
+router.post("/ssm/parameters", async (req, res) => {
+  try {
+    const { name, value, type = "String", description = "" } = req.body;
+
+    if (!name || !value) {
+      return res.status(400).json({ success: false, error: "Parameter name and value are required" });
+    }
+
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/create_parameter.sh "${name}" "${value}" "${type}" "${description}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `SSM create warning: ${stderr}`, "automation");
+    addLog("success", `SSM parameter ${name} created`, "automation");
+    res.json({ success: true, data: { name, message: stdout.trim() } });
+  } catch (error) {
+    addLog("error", `Failed to create SSM parameter: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to create parameter", message: error.message });
+  }
+});
+
+// Get a parameter value
+router.get("/ssm/parameters/:name(*)", async (req, res) => {
+  try {
+    const { name } = req.params;
+    const { withDecryption = "false" } = req.query;
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/get_parameter.sh "${name}" ${withDecryption}`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `SSM get warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    if (withDecryption !== "true" && data?.Parameter?.Value) {
+      data.Parameter.Value = "***MASKED***";
+    }
+    res.json({ success: true, data });
+  } catch (error) {
+    addLog("error", `Failed to get SSM parameter: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get parameter", message: error.message });
+  }
+});
+
+// Update a parameter
+router.put("/ssm/parameters/:name(*)", async (req, res) => {
+  try {
+    const { name } = req.params;
+    const { value, type = "String", description = "" } = req.body;
+
+    if (!value) {
+      return res.status(400).json({ success: false, error: "Parameter value is required" });
+    }
+
+    const { stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/create_parameter.sh "${name}" "${value}" "${type}" "${description}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `SSM update warning: ${stderr}`, "automation");
+    addLog("success", `SSM parameter ${name} updated`, "automation");
+    res.json({ success: true, data: { name, message: "Parameter updated successfully" } });
+  } catch (error) {
+    addLog("error", `Failed to update SSM parameter: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to update parameter", message: error.message });
+  }
+});
+
+// Delete a parameter
+router.delete("/ssm/parameters/:name(*)", async (req, res) => {
+  try {
+    const { name } = req.params;
+    const { stdout, stderr } = await execAsync(
+      `/bin/sh /app/scripts/shell/delete_parameter.sh "${name}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `SSM delete warning: ${stderr}`, "automation");
+    addLog("success", `SSM parameter ${name} deleted`, "automation");
+    res.json({ success: true, data: { name, message: stdout.trim() } });
+  } catch (error) {
+    addLog("error", `Failed to delete SSM parameter: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to delete parameter", message: error.message });
+  }
+});
+
+export default router;

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -21,6 +21,9 @@ import mailpitRouter from "./routes/mailpit.js";
 import secretsRouter from "./routes/secrets.js";
 import postgresRouter from "./routes/postgres.js";
 import keycloakRouter from "./routes/keycloak.js";
+import lambdaRouter from "./routes/lambda.js";
+import apigatewayRouter from "./routes/apigateway.js";
+import ssmRouter from "./routes/ssm.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -60,6 +63,9 @@ app.use(mailpitRouter);
 app.use(secretsRouter);
 app.use(postgresRouter);
 app.use(keycloakRouter);
+app.use(lambdaRouter);
+app.use(apigatewayRouter);
+app.use(ssmRouter);
 
 // Socket.IO connection handling
 io.on("connection", (socket) => {

--- a/localcloud-gui/src/app/apigateway/page.tsx
+++ b/localcloud-gui/src/app/apigateway/page.tsx
@@ -1,0 +1,465 @@
+"use client";
+
+import { ArrowTopRightOnSquareIcon, GlobeAltIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+import ServiceStatusBadge from "@/components/ServiceStatusBadge";
+
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
+const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-api-gateway
+import {
+  APIGatewayClient,
+  CreateRestApiCommand,
+  GetRestApisCommand,
+  GetResourcesCommand,
+  CreateResourceCommand,
+  PutMethodCommand,
+  PutIntegrationCommand,
+  CreateDeploymentCommand,
+  DeleteRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+
+const apigw = new APIGatewayClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a REST API
+const { id: apiId } = await apigw.send(new CreateRestApiCommand({
+  name: "my-api",
+  description: "My test API",
+}));
+
+// Get the root resource
+const { items } = await apigw.send(new GetResourcesCommand({ restApiId: apiId! }));
+const rootId = items?.[0].id!;
+
+// Create a resource (path)
+const { id: resourceId } = await apigw.send(new CreateResourceCommand({
+  restApiId: apiId!,
+  parentId: rootId,
+  pathPart: "hello",
+}));
+
+// Add a GET method
+await apigw.send(new PutMethodCommand({
+  restApiId: apiId!,
+  resourceId: resourceId!,
+  httpMethod: "GET",
+  authorizationType: "NONE",
+}));
+
+// Add a mock integration
+await apigw.send(new PutIntegrationCommand({
+  restApiId: apiId!,
+  resourceId: resourceId!,
+  httpMethod: "GET",
+  type: "MOCK",
+  requestTemplates: { "application/json": '{"statusCode": 200}' },
+}));
+
+// Deploy to a stage
+await apigw.send(new CreateDeploymentCommand({
+  restApiId: apiId!,
+  stageName: "dev",
+}));
+
+// Invoke: http://localhost:4566/restapis/{apiId}/dev/_user_request_/hello
+
+// List all APIs
+const { items: apis } = await apigw.send(new GetRestApisCommand({}));
+apis?.forEach((a) => console.log(a.id, a.name));
+
+// Delete an API
+await apigw.send(new DeleteRestApiCommand({ restApiId: apiId! }));`,
+
+  node: `// npm install @aws-sdk/client-api-gateway
+import {
+  APIGatewayClient,
+  CreateRestApiCommand,
+  GetRestApisCommand,
+  GetResourcesCommand,
+  CreateResourceCommand,
+  PutMethodCommand,
+  PutIntegrationCommand,
+  CreateDeploymentCommand,
+  DeleteRestApiCommand,
+} from "@aws-sdk/client-api-gateway";
+
+const apigw = new APIGatewayClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a REST API
+const { id: apiId } = await apigw.send(new CreateRestApiCommand({ name: "my-api" }));
+
+// Get the root resource
+const { items } = await apigw.send(new GetResourcesCommand({ restApiId: apiId }));
+const rootId = items[0].id;
+
+// Create a /hello resource
+const { id: resourceId } = await apigw.send(new CreateResourceCommand({
+  restApiId: apiId,
+  parentId: rootId,
+  pathPart: "hello",
+}));
+
+// Add GET method + mock integration
+await apigw.send(new PutMethodCommand({
+  restApiId: apiId,
+  resourceId,
+  httpMethod: "GET",
+  authorizationType: "NONE",
+}));
+await apigw.send(new PutIntegrationCommand({
+  restApiId: apiId,
+  resourceId,
+  httpMethod: "GET",
+  type: "MOCK",
+  requestTemplates: { "application/json": '{"statusCode": 200}' },
+}));
+
+// Deploy
+await apigw.send(new CreateDeploymentCommand({ restApiId: apiId, stageName: "dev" }));
+
+// List APIs
+const { items: apis } = await apigw.send(new GetRestApisCommand({}));
+apis.forEach((a) => console.log(a.id, a.name));`,
+
+  python: `# pip install boto3
+import boto3
+
+apigw = boto3.client(
+    "apigateway",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a REST API
+api = apigw.create_rest_api(name="my-api", description="My test API")
+api_id = api["id"]
+
+# Get the root resource
+resources = apigw.get_resources(restApiId=api_id)
+root_id = resources["items"][0]["id"]
+
+# Create a /hello resource
+resource = apigw.create_resource(
+    restApiId=api_id,
+    parentId=root_id,
+    pathPart="hello",
+)
+resource_id = resource["id"]
+
+# Add GET method
+apigw.put_method(
+    restApiId=api_id,
+    resourceId=resource_id,
+    httpMethod="GET",
+    authorizationType="NONE",
+)
+
+# Mock integration
+apigw.put_integration(
+    restApiId=api_id,
+    resourceId=resource_id,
+    httpMethod="GET",
+    type="MOCK",
+    requestTemplates={"application/json": '{"statusCode": 200}'},
+)
+
+# Deploy to dev stage
+apigw.create_deployment(restApiId=api_id, stageName="dev")
+print(f"Invoke at: http://localhost:4566/restapis/{api_id}/dev/_user_request_/hello")
+
+# List all APIs
+for a in apigw.get_rest_apis()["items"]:
+    print(a["id"], a["name"])
+
+# Delete an API
+apigw.delete_rest_api(restApiId=api_id)`,
+
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a REST API
+API_ID=$(awslocal apigateway create-rest-api \\
+  --name my-api \\
+  --query 'id' --output text)
+echo "API ID: $API_ID"
+
+# Get the root resource ID
+ROOT_ID=$(awslocal apigateway get-resources \\
+  --rest-api-id $API_ID \\
+  --query 'items[0].id' --output text)
+
+# Create a resource at /hello
+RESOURCE_ID=$(awslocal apigateway create-resource \\
+  --rest-api-id $API_ID \\
+  --parent-id $ROOT_ID \\
+  --path-part hello \\
+  --query 'id' --output text)
+
+# Add a GET method
+awslocal apigateway put-method \\
+  --rest-api-id $API_ID \\
+  --resource-id $RESOURCE_ID \\
+  --http-method GET \\
+  --authorization-type NONE
+
+# Add a mock integration
+awslocal apigateway put-integration \\
+  --rest-api-id $API_ID \\
+  --resource-id $RESOURCE_ID \\
+  --http-method GET \\
+  --type MOCK \\
+  --request-templates '{"application/json":"{\"statusCode\":200}"}'
+
+# Deploy to dev stage
+awslocal apigateway create-deployment \\
+  --rest-api-id $API_ID \\
+  --stage-name dev
+
+# Invoke the endpoint
+curl http://localhost:4566/restapis/$API_ID/dev/_user_request_/hello
+
+# List all APIs
+awslocal apigateway get-rest-apis
+
+# Delete an API
+awslocal apigateway delete-rest-api --rest-api-id $API_ID`,
+};
+
+const externalResources = [
+  {
+    name: "AWS API Gateway Documentation",
+    url: "https://docs.aws.amazon.com/apigateway/",
+    description: "Official AWS API Gateway docs — routing, stages, and authorizers.",
+  },
+  {
+    name: "API Gateway SDK v3 (Node.js)",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/api-gateway/",
+    description: "APIGatewayClient API reference for the AWS SDK v3.",
+  },
+  {
+    name: "boto3 API Gateway Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html",
+    description: "Complete boto3 API Gateway client reference for Python.",
+  },
+  {
+    name: "LocalStack API Gateway Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_apigateway/",
+    description: "Which API Gateway operations are supported by LocalStack.",
+  },
+];
+
+export default function APIGatewayDocPage() {
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-pink-50 to-rose-100">
+      <DocPageNav title="API Gateway" subtitle="REST API management via LocalStack">
+        <ServiceStatusBadge service="localstack" name="LocalStack" />
+        <Link
+          href="/"
+          className="flex items-center px-3 py-1.5 text-sm font-medium text-pink-700 bg-pink-50 rounded-lg hover:bg-pink-100 transition-colors"
+        >
+          <GlobeAltIcon className="h-4 w-4 mr-1.5" />
+          Manage APIs
+        </Link>
+      </DocPageNav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About API Gateway</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>AWS API Gateway</strong> via LocalStack — a fully managed
+            service for creating, publishing, and managing REST APIs. You can define resources, methods,
+            integrations (including Lambda proxy), and deploy to stages — all locally without an AWS account.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            APIs are accessible at{" "}
+            <code className="bg-gray-100 px-1 rounded font-mono text-xs">
+              http://localhost:4566/restapis/&#123;apiId&#125;/&#123;stage&#125;/_user_request_/&#123;path&#125;
+            </code>
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Management endpoint</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Invoke URL pattern</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900 text-xs">http://localhost:4566/restapis/{"{apiId}"}/{"{stage}"}/_user_request_/{"{path}"}</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Create REST APIs, define resources, and deploy to stages.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "typescript" as const, label: "TypeScript" },
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => handleTabChange(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-pink-600 text-pink-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="javascript" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="bash" />
+          )}
+        </section>
+
+        {/* API Endpoints */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">LocalCloud Kit API</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Method</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Endpoint</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {[
+                  ["GET", "/api/apigateway/apis", "List all REST APIs"],
+                  ["GET", "/api/apigateway/apis/:apiId", "Get API details"],
+                  ["DELETE", "/api/apigateway/apis/:apiId", "Delete a REST API"],
+                ].map(([method, endpoint, desc]) => (
+                  <tr key={endpoint}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono ${
+                        method === "GET" ? "bg-green-50 text-green-700" :
+                        method === "DELETE" ? "bg-red-50 text-red-700" : "bg-gray-50 text-gray-700"
+                      }`}>{method}</span>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-gray-900 text-xs">{endpoint}</td>
+                    <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/app/lambda/page.tsx
+++ b/localcloud-gui/src/app/lambda/page.tsx
@@ -345,6 +345,64 @@ export default function LambdaDocPage() {
           )}
         </section>
 
+        {/* Uploading Function Code */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">Uploading Function Code</h2>
+          <p className="text-sm text-gray-600 leading-relaxed mb-4">
+            When you create a Lambda function from the dashboard, LocalStack provisions it with a
+            minimal placeholder zip. To run real code, upload your own deployment package using the
+            AWS CLI or any AWS SDK.
+          </p>
+
+          <h3 className="text-sm font-semibold text-gray-800 mb-2">Step 1 — Package your code</h3>
+          <ThemeableCodeBlock
+            language="bash"
+            code={`# Python example
+echo 'def lambda_handler(event, context):
+    return {"statusCode": 200, "body": "Hello!"}' > lambda_function.py
+zip function.zip lambda_function.py
+
+# Node.js example
+echo 'exports.handler = async (event) => ({ statusCode: 200, body: "Hello!" });' > index.js
+zip function.zip index.js`}
+          />
+
+          <h3 className="text-sm font-semibold text-gray-800 mt-4 mb-2">Step 2 — Upload to LocalStack</h3>
+          <ThemeableCodeBlock
+            language="bash"
+            code={`export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+# Replace YOUR_FUNCTION_NAME with your function name shown on the dashboard
+awslocal='aws --endpoint-url http://localhost:4566'
+
+$awslocal lambda update-function-code \\
+  --function-name YOUR_FUNCTION_NAME \\
+  --zip-file fileb://function.zip`}
+          />
+
+          <h3 className="text-sm font-semibold text-gray-800 mt-4 mb-2">Step 3 — Verify and invoke</h3>
+          <ThemeableCodeBlock
+            language="bash"
+            code={`# Check the function is updated
+$awslocal lambda get-function --function-name YOUR_FUNCTION_NAME
+
+# Invoke it
+$awslocal lambda invoke \\
+  --function-name YOUR_FUNCTION_NAME \\
+  --payload '{"key":"value"}' \\
+  response.json
+cat response.json`}
+          />
+
+          <div className="mt-4 rounded-md bg-orange-50 border border-orange-200 p-3 text-xs text-orange-800">
+            <strong>Tip:</strong> Use <code className="font-mono">update-function-code</code> (not{" "}
+            <code className="font-mono">create-function</code>) to push new code to an existing function.
+            The function ARN and configuration stay the same.
+          </div>
+        </section>
+
         {/* API Endpoints */}
         <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900 mb-4">LocalCloud Kit API</h2>

--- a/localcloud-gui/src/app/lambda/page.tsx
+++ b/localcloud-gui/src/app/lambda/page.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { ArrowTopRightOnSquareIcon, BoltIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+import ServiceStatusBadge from "@/components/ServiceStatusBadge";
+
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
+const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-lambda
+import {
+  LambdaClient,
+  CreateFunctionCommand,
+  InvokeCommand,
+  ListFunctionsCommand,
+  DeleteFunctionCommand,
+  GetFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { readFileSync } from "fs";
+
+const lambda = new LambdaClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a Lambda function (requires a zip file)
+const zipBuffer = readFileSync("function.zip");
+await lambda.send(new CreateFunctionCommand({
+  FunctionName: "my-function",
+  Runtime: "python3.12",
+  Role: "arn:aws:iam::000000000000:role/irrelevant",
+  Handler: "lambda_function.lambda_handler",
+  Code: { ZipFile: zipBuffer },
+  Description: "My test function",
+}));
+
+// Invoke a function
+const response = await lambda.send(new InvokeCommand({
+  FunctionName: "my-function",
+  Payload: JSON.stringify({ key: "value" }),
+}));
+const result = JSON.parse(Buffer.from(response.Payload!).toString());
+console.log(result);
+
+// List functions
+const { Functions } = await lambda.send(new ListFunctionsCommand({}));
+Functions?.forEach((f) => console.log(f.FunctionName, f.Runtime));
+
+// Delete a function
+await lambda.send(new DeleteFunctionCommand({ FunctionName: "my-function" }));`,
+
+  node: `// npm install @aws-sdk/client-lambda
+import {
+  LambdaClient,
+  CreateFunctionCommand,
+  InvokeCommand,
+  ListFunctionsCommand,
+  DeleteFunctionCommand,
+} from "@aws-sdk/client-lambda";
+import { readFileSync } from "fs";
+
+const lambda = new LambdaClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a function
+const zipBuffer = readFileSync("function.zip");
+await lambda.send(new CreateFunctionCommand({
+  FunctionName: "my-function",
+  Runtime: "nodejs20.x",
+  Role: "arn:aws:iam::000000000000:role/irrelevant",
+  Handler: "index.handler",
+  Code: { ZipFile: zipBuffer },
+}));
+
+// Invoke and read response
+const res = await lambda.send(new InvokeCommand({
+  FunctionName: "my-function",
+  Payload: JSON.stringify({ message: "hello" }),
+}));
+console.log(JSON.parse(Buffer.from(res.Payload).toString()));
+
+// List all functions
+const { Functions } = await lambda.send(new ListFunctionsCommand({}));
+Functions?.forEach((f) => console.log(f.FunctionName));
+
+// Delete a function
+await lambda.send(new DeleteFunctionCommand({ FunctionName: "my-function" }));`,
+
+  python: `# pip install boto3
+import boto3, json, zipfile, io
+
+lambda_client = boto3.client(
+    "lambda",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a minimal zip in-memory for testing
+code = b"""
+def lambda_handler(event, context):
+    return {"statusCode": 200, "body": json.dumps({"message": "Hello!"})}
+"""
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w") as z:
+    z.writestr("lambda_function.py", code)
+zip_bytes = buf.getvalue()
+
+# Create function
+lambda_client.create_function(
+    FunctionName="my-function",
+    Runtime="python3.12",
+    Role="arn:aws:iam::000000000000:role/irrelevant",
+    Handler="lambda_function.lambda_handler",
+    Code={"ZipFile": zip_bytes},
+)
+
+# Invoke function
+response = lambda_client.invoke(
+    FunctionName="my-function",
+    Payload=json.dumps({"key": "value"}),
+)
+result = json.loads(response["Payload"].read())
+print(result)
+
+# List functions
+response = lambda_client.list_functions()
+for fn in response.get("Functions", []):
+    print(fn["FunctionName"], fn["Runtime"])
+
+# Delete function
+lambda_client.delete_function(FunctionName="my-function")`,
+
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a minimal zip for testing
+echo 'def lambda_handler(e,c): return {"statusCode":200}' > lambda_function.py
+zip function.zip lambda_function.py
+
+# Create a Lambda function
+awslocal lambda create-function \\
+  --function-name my-function \\
+  --runtime python3.12 \\
+  --role arn:aws:iam::000000000000:role/irrelevant \\
+  --handler lambda_function.lambda_handler \\
+  --zip-file fileb://function.zip
+
+# Invoke a function
+awslocal lambda invoke \\
+  --function-name my-function \\
+  --payload '{"key":"value"}' \\
+  response.json
+cat response.json
+
+# List functions
+awslocal lambda list-functions
+
+# Update function code
+zip function.zip lambda_function.py
+awslocal lambda update-function-code \\
+  --function-name my-function \\
+  --zip-file fileb://function.zip
+
+# Delete a function
+awslocal lambda delete-function --function-name my-function`,
+};
+
+const externalResources = [
+  {
+    name: "AWS Lambda Documentation",
+    url: "https://docs.aws.amazon.com/lambda/",
+    description: "Official AWS Lambda docs — triggers, runtimes, and deployment.",
+  },
+  {
+    name: "Lambda SDK v3 (Node.js)",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/lambda/",
+    description: "LambdaClient API reference for the AWS SDK v3.",
+  },
+  {
+    name: "boto3 Lambda Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html",
+    description: "Complete boto3 Lambda client reference for Python.",
+  },
+  {
+    name: "LocalStack Lambda Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_lambda/",
+    description: "Which Lambda API operations are supported by LocalStack.",
+  },
+];
+
+export default function LambdaDocPage() {
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-orange-50 to-amber-100">
+      <DocPageNav title="Lambda" subtitle="Serverless functions via LocalStack">
+        <ServiceStatusBadge service="localstack" name="LocalStack" />
+        <Link
+          href="/"
+          className="flex items-center px-3 py-1.5 text-sm font-medium text-orange-700 bg-orange-50 rounded-lg hover:bg-orange-100 transition-colors"
+        >
+          <BoltIcon className="h-4 w-4 mr-1.5" />
+          Manage Functions
+        </Link>
+      </DocPageNav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Lambda</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>AWS Lambda</strong> via LocalStack — a serverless compute
+            service that runs your code in response to events. You can create functions in any supported
+            runtime, invoke them manually or via triggers, and update your code without any deployment
+            pipeline.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Functions are accessible at <code className="bg-gray-100 px-1 rounded font-mono text-xs">http://localhost:4566</code> using
+            any AWS SDK or the AWS CLI. Use the dashboard to create and manage functions, or interact
+            directly via SDK.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Supported Runtimes */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Supported Runtimes</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {[
+              "python3.12", "python3.11", "python3.10", "python3.9",
+              "nodejs20.x", "nodejs18.x",
+              "java21", "java17",
+              "go1.x",
+              "dotnet8",
+            ].map((r) => (
+              <span key={r} className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-mono font-medium bg-orange-50 text-orange-800 border border-orange-200">
+                {r}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Create, invoke, and manage Lambda functions using any AWS SDK.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "typescript" as const, label: "TypeScript" },
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => handleTabChange(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-orange-600 text-orange-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="javascript" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="bash" />
+          )}
+        </section>
+
+        {/* API Endpoints */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">LocalCloud Kit API</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Method</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Endpoint</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {[
+                  ["GET", "/api/lambda/functions", "List all Lambda functions"],
+                  ["GET", "/api/lambda/functions/:name", "Get function details"],
+                  ["DELETE", "/api/lambda/functions/:name", "Delete a function"],
+                  ["POST", "/api/lambda/functions/:name/invoke", "Invoke a function"],
+                ].map(([method, endpoint, desc]) => (
+                  <tr key={endpoint}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono ${
+                        method === "GET" ? "bg-green-50 text-green-700" :
+                        method === "POST" ? "bg-blue-50 text-blue-700" :
+                        method === "DELETE" ? "bg-red-50 text-red-700" : "bg-gray-50 text-gray-700"
+                      }`}>{method}</span>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-gray-900 text-xs">{endpoint}</td>
+                    <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/app/ssm/page.tsx
+++ b/localcloud-gui/src/app/ssm/page.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import { ArrowTopRightOnSquareIcon, AdjustmentsHorizontalIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+import ServiceStatusBadge from "@/components/ServiceStatusBadge";
+
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
+const sdkExamples = {
+  typescript: `// npm install @aws-sdk/client-ssm
+import {
+  SSMClient,
+  PutParameterCommand,
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  DeleteParameterCommand,
+  DescribeParametersCommand,
+} from "@aws-sdk/client-ssm";
+
+const ssm = new SSMClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a String parameter
+await ssm.send(new PutParameterCommand({
+  Name: "/my-app/database/host",
+  Value: "localhost",
+  Type: "String",
+  Description: "Database hostname",
+  Overwrite: true,
+}));
+
+// Create a SecureString parameter
+await ssm.send(new PutParameterCommand({
+  Name: "/my-app/database/password",
+  Value: "s3cr3t!",
+  Type: "SecureString",
+  Description: "Database password",
+  Overwrite: true,
+}));
+
+// Get a parameter value
+const { Parameter } = await ssm.send(new GetParameterCommand({
+  Name: "/my-app/database/host",
+  WithDecryption: true,
+}));
+console.log(Parameter?.Value);
+
+// Get all parameters under a path
+const { Parameters } = await ssm.send(new GetParametersByPathCommand({
+  Path: "/my-app/",
+  Recursive: true,
+  WithDecryption: true,
+}));
+Parameters?.forEach((p) => console.log(p.Name, p.Value));
+
+// Delete a parameter
+await ssm.send(new DeleteParameterCommand({ Name: "/my-app/database/host" }));`,
+
+  node: `// npm install @aws-sdk/client-ssm
+import {
+  SSMClient,
+  PutParameterCommand,
+  GetParameterCommand,
+  GetParametersByPathCommand,
+  DeleteParameterCommand,
+  DescribeParametersCommand,
+} from "@aws-sdk/client-ssm";
+
+const ssm = new SSMClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create / update a parameter
+await ssm.send(new PutParameterCommand({
+  Name: "/my-app/config/api-url",
+  Value: "https://api.example.com",
+  Type: "String",
+  Overwrite: true,
+}));
+
+// Read a parameter
+const { Parameter } = await ssm.send(new GetParameterCommand({
+  Name: "/my-app/config/api-url",
+}));
+console.log(Parameter?.Value);
+
+// Read all parameters under a path
+const { Parameters } = await ssm.send(new GetParametersByPathCommand({
+  Path: "/my-app/",
+  Recursive: true,
+}));
+Parameters?.forEach((p) => console.log(p.Name, "=", p.Value));
+
+// Delete a parameter
+await ssm.send(new DeleteParameterCommand({ Name: "/my-app/config/api-url" }));`,
+
+  python: `# pip install boto3
+import boto3
+
+ssm = boto3.client(
+    "ssm",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Create a String parameter
+ssm.put_parameter(
+    Name="/my-app/database/host",
+    Value="localhost",
+    Type="String",
+    Description="Database hostname",
+    Overwrite=True,
+)
+
+# Create a SecureString parameter
+ssm.put_parameter(
+    Name="/my-app/database/password",
+    Value="s3cr3t!",
+    Type="SecureString",
+    Description="Database password",
+    Overwrite=True,
+)
+
+# Get a parameter value
+response = ssm.get_parameter(
+    Name="/my-app/database/host",
+    WithDecryption=True,
+)
+print(response["Parameter"]["Value"])
+
+# Get all parameters under a path
+response = ssm.get_parameters_by_path(
+    Path="/my-app/",
+    Recursive=True,
+    WithDecryption=True,
+)
+for p in response.get("Parameters", []):
+    print(f"{p['Name']} = {p['Value']}")
+
+# Delete a parameter
+ssm.delete_parameter(Name="/my-app/database/host")`,
+
+  cli: `# Configure the AWS CLI for LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+alias awslocal='aws --endpoint-url http://localhost:4566'
+
+# Create a String parameter
+awslocal ssm put-parameter \\
+  --name "/my-app/database/host" \\
+  --value "localhost" \\
+  --type String \\
+  --description "Database hostname" \\
+  --overwrite
+
+# Create a SecureString parameter
+awslocal ssm put-parameter \\
+  --name "/my-app/database/password" \\
+  --value "s3cr3t!" \\
+  --type SecureString \\
+  --overwrite
+
+# Get a parameter value
+awslocal ssm get-parameter \\
+  --name "/my-app/database/host" \\
+  --with-decryption
+
+# Get all parameters under a path
+awslocal ssm get-parameters-by-path \\
+  --path "/my-app/" \\
+  --recursive \\
+  --with-decryption
+
+# List all parameters
+awslocal ssm describe-parameters
+
+# Delete a parameter
+awslocal ssm delete-parameter --name "/my-app/database/host"`,
+};
+
+const externalResources = [
+  {
+    name: "AWS Systems Manager Parameter Store",
+    url: "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html",
+    description: "Official AWS SSM Parameter Store docs — hierarchy, encryption, and versioning.",
+  },
+  {
+    name: "SSM SDK v3 (Node.js)",
+    url: "https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/ssm/",
+    description: "SSMClient API reference for the AWS SDK v3.",
+  },
+  {
+    name: "boto3 SSM Reference",
+    url: "https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm.html",
+    description: "Complete boto3 SSM client reference for Python.",
+  },
+  {
+    name: "LocalStack SSM Coverage",
+    url: "https://docs.localstack.cloud/references/coverage/coverage_ssm/",
+    description: "Which SSM API operations are supported by LocalStack.",
+  },
+];
+
+export default function SSMDocPage() {
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100">
+      <DocPageNav title="Parameter Store" subtitle="SSM configuration management via LocalStack">
+        <ServiceStatusBadge service="localstack" name="LocalStack" />
+        <Link
+          href="/"
+          className="flex items-center px-3 py-1.5 text-sm font-medium text-teal-700 bg-teal-50 rounded-lg hover:bg-teal-100 transition-colors"
+        >
+          <AdjustmentsHorizontalIcon className="h-4 w-4 mr-1.5" />
+          Manage Parameters
+        </Link>
+      </DocPageNav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About Parameter Store</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>AWS Systems Manager Parameter Store</strong> via LocalStack —
+            a secure, hierarchical storage for configuration data and secrets. Unlike Secrets Manager,
+            Parameter Store is free for standard parameters and integrates with most AWS services via
+            native parameter resolution.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Use <code className="bg-gray-100 px-1 rounded font-mono text-xs">/</code>-delimited paths
+            to organise parameters (e.g.{" "}
+            <code className="bg-gray-100 px-1 rounded font-mono text-xs">/my-app/prod/db/host</code>).
+            Store plain strings, comma-separated lists, or encrypted <code className="bg-gray-100 px-1 rounded font-mono text-xs">SecureString</code> values.
+          </p>
+        </section>
+
+        {/* Parameter Types */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Parameter Types</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Type</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Use Case</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Example</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 font-mono text-teal-700 font-medium">String</td>
+                  <td className="px-4 py-2.5 text-gray-600">Any plain-text value</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-500 text-xs">localhost:5432</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 font-mono text-teal-700 font-medium">StringList</td>
+                  <td className="px-4 py-2.5 text-gray-600">Comma-separated values</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-500 text-xs">us-east-1,eu-west-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 font-mono text-teal-700 font-medium">SecureString</td>
+                  <td className="px-4 py-2.5 text-gray-600">Sensitive data, encrypted at rest</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-500 text-xs">password / API key</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Region</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Access Key ID</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+                <tr>
+                  <td className="px-4 py-2.5 text-gray-600">Secret Access Key</td>
+                  <td className="px-4 py-2.5 font-mono text-gray-900">test</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* SDK Examples */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">SDK Examples</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Store, retrieve, and manage configuration parameters using any AWS SDK.
+          </p>
+          <div className="flex space-x-1 mb-4 border-b border-gray-200">
+            {([
+              { key: "typescript" as const, label: "TypeScript" },
+              { key: "node" as const, label: "Node.js" },
+              { key: "python" as const, label: "Python" },
+              { key: "cli" as const, label: "AWS CLI" },
+            ]).map(({ key, label }) => (
+              <button
+                key={key}
+                onClick={() => handleTabChange(key)}
+                className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                  activeTab === key
+                    ? "border-teal-600 text-teal-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {activeTab === "typescript" && (
+            <ThemeableCodeBlock code={sdkExamples.typescript} language="typescript" />
+          )}
+          {activeTab === "node" && (
+            <ThemeableCodeBlock code={sdkExamples.node} language="javascript" />
+          )}
+          {activeTab === "python" && (
+            <ThemeableCodeBlock code={sdkExamples.python} language="python" />
+          )}
+          {activeTab === "cli" && (
+            <ThemeableCodeBlock code={sdkExamples.cli} language="bash" />
+          )}
+        </section>
+
+        {/* API Endpoints */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">LocalCloud Kit API</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Method</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Endpoint</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {[
+                  ["GET", "/api/ssm/parameters", "List all parameters"],
+                  ["POST", "/api/ssm/parameters", "Create / update a parameter"],
+                  ["GET", "/api/ssm/parameters/:name", "Get parameter value"],
+                  ["PUT", "/api/ssm/parameters/:name", "Update a parameter"],
+                  ["DELETE", "/api/ssm/parameters/:name", "Delete a parameter"],
+                ].map(([method, endpoint, desc]) => (
+                  <tr key={endpoint}>
+                    <td className="px-4 py-2.5">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono ${
+                        method === "GET" ? "bg-green-50 text-green-700" :
+                        method === "POST" ? "bg-blue-50 text-blue-700" :
+                        method === "PUT" ? "bg-yellow-50 text-yellow-700" :
+                        method === "DELETE" ? "bg-red-50 text-red-700" : "bg-gray-50 text-gray-700"
+                      }`}>{method}</span>
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-gray-900 text-xs">{endpoint}</td>
+                    <td className="px-4 py-2.5 text-gray-600">{desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r) => (
+                  <tr key={r.url}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-blue-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/components/APIGatewayConfigModal.tsx
+++ b/localcloud-gui/src/components/APIGatewayConfigModal.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify/react";
 import { APIGatewayConfig } from "@/types";
+import { usePreferences } from "@/context/PreferencesContext";
+import { toast } from "react-hot-toast";
 
 interface APIGatewayConfigModalProps {
   isOpen: boolean;
@@ -20,8 +22,13 @@ export default function APIGatewayConfigModal({
   projectName,
   loading = false,
 }: APIGatewayConfigModalProps) {
+  const { profile, savedConfigs, saveConfig } = usePreferences();
   const [apiName, setApiName] = useState(`${projectName}-api`);
   const [description, setDescription] = useState("");
+
+  // Save config toggle
+  const [saveConfig_, setSaveConfig_] = useState(false);
+  const [configName, setConfigName] = useState("");
 
   useEffect(() => {
     if (!isOpen) return;
@@ -38,14 +45,39 @@ export default function APIGatewayConfigModal({
     if (isOpen) {
       setApiName(`${projectName}-api`);
       setDescription("");
+      setSaveConfig_(false);
+      setConfigName("");
     }
   }, [isOpen, projectName]);
 
   if (!isOpen) return null;
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const projectConfigs = savedConfigs.filter(
+    (c) => c.resource_type === "apigateway" && c.project_id === profile?.active_project_id
+  );
+
+  const loadSavedConfig = (config: APIGatewayConfig) => {
+    setApiName(config.apiName || "");
+    setDescription(config.description || "");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ apiName, description });
+    if (!apiName.trim()) return;
+    if (saveConfig_ && !configName.trim()) return;
+
+    const config: APIGatewayConfig = { apiName, description };
+
+    if (saveConfig_ && configName.trim()) {
+      try {
+        await saveConfig(configName.trim(), "apigateway", config);
+        toast.success(`Config "${configName.trim()}" saved`);
+      } catch {
+        toast.error("Failed to save config — API will still be created");
+      }
+    }
+
+    onSubmit(config);
   };
 
   return (
@@ -78,6 +110,25 @@ export default function APIGatewayConfigModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* Saved Configs */}
+          {projectConfigs.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-2">Saved configs</p>
+              <div className="flex flex-wrap gap-2">
+                {projectConfigs.map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => loadSavedConfig(c.config as APIGatewayConfig)}
+                    className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-pink-50 text-pink-700 border border-pink-200 hover:bg-pink-100 transition-colors"
+                  >
+                    {c.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* API Name */}
           <div>
@@ -117,6 +168,33 @@ export default function APIGatewayConfigModal({
             <code className="font-mono">http://localhost:4566</code>.
           </div>
 
+          {/* Save Config Toggle */}
+          <div className="border-t border-gray-100 pt-4">
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={saveConfig_}
+                onChange={(e) => setSaveConfig_(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-pink-600 focus:ring-pink-500"
+              />
+              <span className="text-sm text-gray-700">Save as config for future use</span>
+            </label>
+            {saveConfig_ && (
+              <div className="mt-3">
+                <input
+                  type="text"
+                  value={configName}
+                  onChange={(e) => setConfigName(e.target.value)}
+                  placeholder="Config name (e.g. My REST API)"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500 text-gray-900"
+                />
+                {saveConfig_ && !configName.trim() && (
+                  <p className="text-xs text-red-500 mt-1">Config name is required</p>
+                )}
+              </div>
+            )}
+          </div>
+
           {/* Actions */}
           <div className="flex justify-end space-x-3 pt-2">
             <button
@@ -130,7 +208,7 @@ export default function APIGatewayConfigModal({
             <button
               type="submit"
               className="px-4 py-2 text-sm font-medium text-white bg-pink-600 rounded-md hover:bg-pink-700 disabled:opacity-50"
-              disabled={loading || !apiName.trim()}
+              disabled={loading || !apiName.trim() || (saveConfig_ && !configName.trim())}
             >
               {loading ? "Creating..." : "Create API"}
             </button>

--- a/localcloud-gui/src/components/APIGatewayConfigModal.tsx
+++ b/localcloud-gui/src/components/APIGatewayConfigModal.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { APIGatewayConfig } from "@/types";
+
+interface APIGatewayConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (config: APIGatewayConfig) => void;
+  projectName: string;
+  loading?: boolean;
+}
+
+export default function APIGatewayConfigModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectName,
+  loading = false,
+}: APIGatewayConfigModalProps) {
+  const [apiName, setApiName] = useState(`${projectName}-api`);
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setApiName(`${projectName}-api`);
+      setDescription("");
+    }
+  }, [isOpen, projectName]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ apiName, description });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-pink-50 rounded-lg">
+              <Icon icon="logos:aws-api-gateway" className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Create REST API</h2>
+              <p className="text-xs text-gray-500">Create a new API Gateway REST API in LocalStack</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+            aria-label="Close"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* API Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              API Name
+            </label>
+            <input
+              type="text"
+              value={apiName}
+              onChange={(e) => setApiName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500 text-gray-900"
+              placeholder="my-rest-api"
+              required
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              A unique name for the REST API
+            </p>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-pink-500 focus:border-pink-500 text-gray-900"
+              placeholder="API for my application"
+            />
+          </div>
+
+          {/* Info */}
+          <div className="rounded-md bg-pink-50 border border-pink-200 p-3 text-xs text-pink-800">
+            Creates a REST API stub. Add resources and methods via the AWS CLI or SDK at{" "}
+            <code className="font-mono">http://localhost:4566</code>.
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-pink-600 rounded-md hover:bg-pink-700 disabled:opacity-50"
+              disabled={loading || !apiName.trim()}
+            >
+              {loading ? "Creating..." : "Create API"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@
 import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
 import { projectsApi, resourceApi } from "@/services/api";
-import { DynamoDBTableConfig, S3BucketConfig } from "@/types";
+import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig } from "@/types";
 import {
   Bars3Icon,
   BookOpenIcon,
@@ -37,6 +37,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import S3ConfigModal from "./S3ConfigModal";
 import SecretsConfigModal from "./SecretsConfigModal";
 import SecretsManagerViewer from "./SecretsManagerViewer";
+import LambdaConfigModal from "./LambdaConfigModal";
+import APIGatewayConfigModal from "./APIGatewayConfigModal";
+import SSMConfigModal from "./SSMConfigModal";
 
 export default function Dashboard() {
   const {
@@ -58,6 +61,9 @@ export default function Dashboard() {
   const [showDynamoDBConfig, setShowDynamoDBConfig] = useState(false);
   const [showS3Config, setShowS3Config] = useState(false);
   const [showSecretsConfig, setShowSecretsConfig] = useState(false);
+  const [showLambdaConfig, setShowLambdaConfig] = useState(false);
+  const [showAPIGatewayConfig, setShowAPIGatewayConfig] = useState(false);
+  const [showSSMConfig, setShowSSMConfig] = useState(false);
   const [showLogs, setShowLogs] = useState(false);
   const [showBuckets, setShowBuckets] = useState(false);
   const [showDynamoDB, setShowDynamoDB] = useState(false);
@@ -157,6 +163,9 @@ export default function Dashboard() {
     if (resourceType === "dynamodb") { setShowDynamoDBConfig(true); return; }
     if (resourceType === "s3") { setShowS3Config(true); return; }
     if (resourceType === "secretsmanager") { setShowSecretsConfig(true); return; }
+    if (resourceType === "lambda") { setShowLambdaConfig(true); return; }
+    if (resourceType === "apigateway") { setShowAPIGatewayConfig(true); return; }
+    if (resourceType === "ssm") { setShowSSMConfig(true); return; }
 
     setCreateLoading(true);
     try {
@@ -231,6 +240,63 @@ export default function Dashboard() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const apiMessage = (error as any)?.response?.data?.error;
       toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create secret"));
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleCreateLambda = async (lambdaConfig: LambdaFunctionConfig) => {
+    setCreateLoading(true);
+    try {
+      const response = await resourceApi.createSingleWithConfig(projectName, "lambda", { lambdaConfig });
+      if (response.success) {
+        toast.success("Lambda function created successfully");
+        setShowLambdaConfig(false);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
+      } else {
+        toast.error(response.error || "Failed to create Lambda function");
+      }
+    } catch (error) {
+      console.error("Create Lambda error:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to create Lambda function");
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleCreateAPIGateway = async (apigatewayConfig: APIGatewayConfig) => {
+    setCreateLoading(true);
+    try {
+      const response = await resourceApi.createSingleWithConfig(projectName, "apigateway", { apigatewayConfig });
+      if (response.success) {
+        toast.success("API Gateway created successfully");
+        setShowAPIGatewayConfig(false);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
+      } else {
+        toast.error(response.error || "Failed to create API Gateway");
+      }
+    } catch (error) {
+      console.error("Create API Gateway error:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to create API Gateway");
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleCreateSSMParameter = async (ssmConfig: SSMParameterConfig) => {
+    setCreateLoading(true);
+    try {
+      const response = await resourceApi.createSingleWithConfig(projectName, "ssm", { ssmConfig });
+      if (response.success) {
+        toast.success("SSM parameter created successfully");
+        setShowSSMConfig(false);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
+      } else {
+        toast.error(response.error || "Failed to create SSM parameter");
+      }
+    } catch (error) {
+      console.error("Create SSM parameter error:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to create SSM parameter");
     } finally {
       setCreateLoading(false);
     }
@@ -346,6 +412,28 @@ export default function Dashboard() {
                       DynamoDB Tables
                     </button>
 
+                    {/* Compute */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compute</p>
+                    <button
+                      onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      Lambda Functions
+                    </button>
+
+                    {/* Networking */}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Networking</p>
+                    <button
+                      onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      API Gateway
+                    </button>
+
                     {/* Security & Identity */}
                     <div className="border-t border-gray-100 mt-1" />
                     <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Security & Identity</p>
@@ -355,6 +443,13 @@ export default function Dashboard() {
                     >
                       <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                       Secrets Manager
+                    </button>
+                    <button
+                      onClick={() => { setShowSSMConfig(true); closeAllMenus(); }}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      Parameter Store
                     </button>
 
                   </div>
@@ -453,12 +548,36 @@ export default function Dashboard() {
                       S3 Buckets
                     </Link>
                     <Link
+                      href="/lambda"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      Lambda
+                    </Link>
+                    <Link
+                      href="/apigateway"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      API Gateway
+                    </Link>
+                    <Link
                       href="/secrets"
                       onClick={() => setShowDocsMenu(false)}
                       className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                     >
                       <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                       Secrets Manager
+                    </Link>
+                    <Link
+                      href="/ssm"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      Parameter Store
                     </Link>
 
                     {/* Platform Services */}
@@ -625,8 +744,17 @@ export default function Dashboard() {
                 <button onClick={() => { setShowDynamoDB(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB Tables
                 </button>
+                <button onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda Functions
+                </button>
+                <button onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
+                </button>
                 <button onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
+                </button>
+                <button onClick={() => { setShowSSMConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
                 </button>
               </div>
 
@@ -668,8 +796,17 @@ export default function Dashboard() {
                 <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB
                 </Link>
+                <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda
+                </Link>
+                <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
+                </Link>
                 <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
+                </Link>
+                <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
                 </Link>
                 <Link href="/mailpit" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />Mailpit
@@ -800,6 +937,9 @@ export default function Dashboard() {
               onAddS3={() => handleCreateSingleResource("s3")}
               onAddDynamoDB={() => handleCreateSingleResource("dynamodb")}
               onAddSecrets={() => handleCreateSingleResource("secretsmanager")}
+              onAddLambda={() => handleCreateSingleResource("lambda")}
+              onAddAPIGateway={() => handleCreateSingleResource("apigateway")}
+              onAddSSM={() => handleCreateSingleResource("ssm")}
               refreshLoading={loading}
               addLoading={createLoading}
               onViewS3={(bucketName) => {
@@ -911,6 +1051,36 @@ export default function Dashboard() {
 
       {showRedis && (
         <RedisModal onClose={() => setShowRedis(false)} />
+      )}
+
+      {showLambdaConfig && (
+        <LambdaConfigModal
+          isOpen={showLambdaConfig}
+          onClose={() => setShowLambdaConfig(false)}
+          onSubmit={handleCreateLambda}
+          projectName={projectName}
+          loading={createLoading}
+        />
+      )}
+
+      {showAPIGatewayConfig && (
+        <APIGatewayConfigModal
+          isOpen={showAPIGatewayConfig}
+          onClose={() => setShowAPIGatewayConfig(false)}
+          onSubmit={handleCreateAPIGateway}
+          projectName={projectName}
+          loading={createLoading}
+        />
+      )}
+
+      {showSSMConfig && (
+        <SSMConfigModal
+          isOpen={showSSMConfig}
+          onClose={() => setShowSSMConfig(false)}
+          onSubmit={handleCreateSSMParameter}
+          projectName={projectName}
+          loading={createLoading}
+        />
       )}
     </div>
   );

--- a/localcloud-gui/src/components/LambdaConfigModal.tsx
+++ b/localcloud-gui/src/components/LambdaConfigModal.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify/react";
 import { LambdaFunctionConfig } from "@/types";
+import { usePreferences } from "@/context/PreferencesContext";
+import { toast } from "react-hot-toast";
 
 interface LambdaConfigModalProps {
   isOpen: boolean;
@@ -33,10 +35,15 @@ export default function LambdaConfigModal({
   projectName,
   loading = false,
 }: LambdaConfigModalProps) {
+  const { profile, savedConfigs, saveConfig } = usePreferences();
   const [functionName, setFunctionName] = useState(`${projectName}-lambda`);
   const [runtime, setRuntime] = useState("python3.12");
   const [handler, setHandler] = useState("lambda_function.lambda_handler");
   const [description, setDescription] = useState("");
+
+  // Save config toggle
+  const [saveConfig_, setSaveConfig_] = useState(false);
+  const [configName, setConfigName] = useState("");
 
   useEffect(() => {
     if (!isOpen) return;
@@ -55,6 +62,8 @@ export default function LambdaConfigModal({
       setRuntime("python3.12");
       setHandler("lambda_function.lambda_handler");
       setDescription("");
+      setSaveConfig_(false);
+      setConfigName("");
     }
   }, [isOpen, projectName]);
 
@@ -69,9 +78,34 @@ export default function LambdaConfigModal({
 
   if (!isOpen) return null;
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const projectConfigs = savedConfigs.filter(
+    (c) => c.resource_type === "lambda" && c.project_id === profile?.active_project_id
+  );
+
+  const loadSavedConfig = (config: LambdaFunctionConfig) => {
+    setFunctionName(config.functionName || "");
+    setRuntime(config.runtime || "python3.12");
+    setHandler(config.handler || "lambda_function.lambda_handler");
+    setDescription(config.description || "");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ functionName, runtime, handler, description });
+    if (!functionName.trim()) return;
+    if (saveConfig_ && !configName.trim()) return;
+
+    const config: LambdaFunctionConfig = { functionName, runtime, handler, description };
+
+    if (saveConfig_ && configName.trim()) {
+      try {
+        await saveConfig(configName.trim(), "lambda", config);
+        toast.success(`Config "${configName.trim()}" saved`);
+      } catch {
+        toast.error("Failed to save config — function will still be created");
+      }
+    }
+
+    onSubmit(config);
   };
 
   return (
@@ -104,6 +138,25 @@ export default function LambdaConfigModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* Saved Configs */}
+          {projectConfigs.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-gray-500 mb-2">Saved configs</p>
+              <div className="flex flex-wrap gap-2">
+                {projectConfigs.map((c) => (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={() => loadSavedConfig(c.config as LambdaFunctionConfig)}
+                    className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-orange-50 text-orange-700 border border-orange-200 hover:bg-orange-100 transition-colors"
+                  >
+                    {c.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* Function Name */}
           <div>
@@ -173,7 +226,34 @@ export default function LambdaConfigModal({
 
           {/* Note */}
           <div className="rounded-md bg-orange-50 border border-orange-200 p-3 text-xs text-orange-800">
-            LocalStack creates the function with a placeholder zip. Replace the code via the AWS CLI or SDK after creation.
+            LocalStack creates the function with a placeholder zip. Upload your code via the AWS CLI or SDK after creation.
+          </div>
+
+          {/* Save Config Toggle */}
+          <div className="border-t border-gray-100 pt-4">
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={saveConfig_}
+                onChange={(e) => setSaveConfig_(e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-orange-600 focus:ring-orange-500"
+              />
+              <span className="text-sm text-gray-700">Save as config for future use</span>
+            </label>
+            {saveConfig_ && (
+              <div className="mt-3">
+                <input
+                  type="text"
+                  value={configName}
+                  onChange={(e) => setConfigName(e.target.value)}
+                  placeholder="Config name (e.g. My Python Handler)"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-gray-900"
+                />
+                {saveConfig_ && !configName.trim() && (
+                  <p className="text-xs text-red-500 mt-1">Config name is required</p>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Actions */}
@@ -189,7 +269,7 @@ export default function LambdaConfigModal({
             <button
               type="submit"
               className="px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-md hover:bg-orange-700 disabled:opacity-50"
-              disabled={loading || !functionName.trim()}
+              disabled={loading || !functionName.trim() || (saveConfig_ && !configName.trim())}
             >
               {loading ? "Creating..." : "Create Function"}
             </button>

--- a/localcloud-gui/src/components/LambdaConfigModal.tsx
+++ b/localcloud-gui/src/components/LambdaConfigModal.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { LambdaFunctionConfig } from "@/types";
+
+interface LambdaConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (config: LambdaFunctionConfig) => void;
+  projectName: string;
+  loading?: boolean;
+}
+
+const RUNTIMES = [
+  "python3.12",
+  "python3.11",
+  "python3.10",
+  "python3.9",
+  "nodejs20.x",
+  "nodejs18.x",
+  "java21",
+  "java17",
+  "go1.x",
+  "dotnet8",
+];
+
+export default function LambdaConfigModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectName,
+  loading = false,
+}: LambdaConfigModalProps) {
+  const [functionName, setFunctionName] = useState(`${projectName}-lambda`);
+  const [runtime, setRuntime] = useState("python3.12");
+  const [handler, setHandler] = useState("lambda_function.lambda_handler");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setFunctionName(`${projectName}-lambda`);
+      setRuntime("python3.12");
+      setHandler("lambda_function.lambda_handler");
+      setDescription("");
+    }
+  }, [isOpen, projectName]);
+
+  // Update default handler when runtime changes
+  useEffect(() => {
+    if (runtime.startsWith("node")) setHandler("index.handler");
+    else if (runtime.startsWith("python")) setHandler("lambda_function.lambda_handler");
+    else if (runtime.startsWith("go")) setHandler("main");
+    else if (runtime.startsWith("java")) setHandler("com.example.Handler::handleRequest");
+    else if (runtime.startsWith("dotnet")) setHandler("Assembly::Namespace.Handler::FunctionHandler");
+  }, [runtime]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ functionName, runtime, handler, description });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-orange-50 rounded-lg">
+              <Icon icon="logos:aws-lambda" className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Create Lambda Function</h2>
+              <p className="text-xs text-gray-500">Deploy a new Lambda function to LocalStack</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+            aria-label="Close"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* Function Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Function Name
+            </label>
+            <input
+              type="text"
+              value={functionName}
+              onChange={(e) => setFunctionName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-gray-900"
+              placeholder="my-function"
+              required
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Lowercase letters, numbers, and hyphens only
+            </p>
+          </div>
+
+          {/* Runtime */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Runtime
+            </label>
+            <select
+              value={runtime}
+              onChange={(e) => setRuntime(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-gray-900 bg-white"
+            >
+              {RUNTIMES.map((r) => (
+                <option key={r} value={r}>{r}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Handler */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Handler
+            </label>
+            <input
+              type="text"
+              value={handler}
+              onChange={(e) => setHandler(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-gray-900"
+              placeholder="lambda_function.lambda_handler"
+              required
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Format: <code className="bg-gray-100 px-1 rounded">filename.method</code>
+            </p>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500 text-gray-900"
+              placeholder="What does this function do?"
+            />
+          </div>
+
+          {/* Note */}
+          <div className="rounded-md bg-orange-50 border border-orange-200 p-3 text-xs text-orange-800">
+            LocalStack creates the function with a placeholder zip. Replace the code via the AWS CLI or SDK after creation.
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-orange-600 rounded-md hover:bg-orange-700 disabled:opacity-50"
+              disabled={loading || !functionName.trim()}
+            >
+              {loading ? "Creating..." : "Create Function"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -28,19 +28,22 @@ interface ResourceListProps {
   onAddS3?: () => void;
   onAddDynamoDB?: () => void;
   onAddSecrets?: () => void;
+  onAddLambda?: () => void;
+  onAddAPIGateway?: () => void;
+  onAddSSM?: () => void;
   refreshLoading?: boolean;
   addLoading?: boolean;
 }
 
 // AWS resource types only — platform services are excluded
-const AWS_RESOURCE_TYPES = ["s3", "dynamodb", "lambda", "apigateway", "iam", "secretsmanager"];
+const AWS_RESOURCE_TYPES = ["s3", "dynamodb", "lambda", "apigateway", "ssm", "iam", "secretsmanager"];
 
 const AWS_CATEGORIES = [
   { name: "Storage", types: ["s3"] },
   { name: "Database", types: ["dynamodb"] },
   { name: "Compute", types: ["lambda"] },
   { name: "Networking", types: ["apigateway"] },
-  { name: "Security & Identity", types: ["iam", "secretsmanager"] },
+  { name: "Security & Identity", types: ["iam", "secretsmanager", "ssm"] },
 ];
 
 const RESOURCE_ICON: Record<string, string> = {
@@ -48,6 +51,7 @@ const RESOURCE_ICON: Record<string, string> = {
   dynamodb: "logos:aws-dynamodb",
   lambda: "logos:aws-lambda",
   apigateway: "logos:aws-api-gateway",
+  ssm: "logos:aws-systems-manager",
   iam: "logos:aws-iam",
   secretsmanager: "logos:aws-secrets-manager",
 };
@@ -57,6 +61,7 @@ const RESOURCE_LABEL: Record<string, string> = {
   dynamodb: "DynamoDB Table",
   lambda: "Lambda Function",
   apigateway: "API Gateway",
+  ssm: "Parameter Store",
   iam: "IAM",
   secretsmanager: "Secrets Manager",
 };
@@ -73,6 +78,9 @@ export default function ResourceList({
   onAddS3,
   onAddDynamoDB,
   onAddSecrets,
+  onAddLambda,
+  onAddAPIGateway,
+  onAddSSM,
   refreshLoading = false,
   addLoading = false,
 }: ResourceListProps) {
@@ -160,7 +168,7 @@ export default function ResourceList({
     }
   };
 
-  const hasAddActions = onAddS3 || onAddDynamoDB || onAddSecrets;
+  const hasAddActions = onAddS3 || onAddDynamoDB || onAddSecrets || onAddLambda || onAddAPIGateway || onAddSSM;
 
   return (
     <div className="bg-white rounded-lg shadow">
@@ -213,36 +221,77 @@ export default function ResourceList({
                   <ChevronDownIcon className={`h-3.5 w-3.5 ml-1.5 transition-transform ${showAddMenu ? "rotate-180" : ""}`} />
                 </button>
                 {showAddMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
-                    {onAddS3 && (
-                      <button
-                        onClick={() => { onAddS3(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                      >
-                        <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 flex-shrink-0" />
-                        S3 Bucket
-                      </button>
+                  <div className="absolute right-0 mt-1 w-60 bg-white border border-gray-200 rounded-md shadow-lg z-50">
+                    {(onAddS3) && (
+                      <>
+                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
+                        <button
+                          onClick={() => { onAddS3(); setShowAddMenu(false); }}
+                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          S3 Bucket
+                        </button>
+                      </>
                     )}
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Database</p>
-                    {onAddDynamoDB && (
-                      <button
-                        onClick={() => { onAddDynamoDB(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                      >
-                        <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 flex-shrink-0" />
-                        DynamoDB Table
-                      </button>
+                    {(onAddDynamoDB) && (
+                      <>
+                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Database</p>
+                        <button
+                          onClick={() => { onAddDynamoDB(); setShowAddMenu(false); }}
+                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          DynamoDB Table
+                        </button>
+                      </>
                     )}
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Security & Identity</p>
-                    {onAddSecrets && (
-                      <button
-                        onClick={() => { onAddSecrets(); setShowAddMenu(false); }}
-                        className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                      >
-                        <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
-                        Secrets Manager
-                      </button>
+                    {(onAddLambda) && (
+                      <>
+                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Compute</p>
+                        <button
+                          onClick={() => { onAddLambda(); setShowAddMenu(false); }}
+                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <Icon icon="logos:aws-lambda" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          Lambda Function
+                        </button>
+                      </>
+                    )}
+                    {(onAddAPIGateway) && (
+                      <>
+                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Networking</p>
+                        <button
+                          onClick={() => { onAddAPIGateway(); setShowAddMenu(false); }}
+                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <Icon icon="logos:aws-api-gateway" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          API Gateway
+                        </button>
+                      </>
+                    )}
+                    {(onAddSecrets || onAddSSM) && (
+                      <>
+                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Security & Identity</p>
+                        {onAddSecrets && (
+                          <button
+                            onClick={() => { onAddSecrets(); setShowAddMenu(false); }}
+                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            Secrets Manager
+                          </button>
+                        )}
+                        {onAddSSM && (
+                          <button
+                            onClick={() => { onAddSSM(); setShowAddMenu(false); }}
+                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            <Icon icon="logos:aws-systems-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            Parameter Store
+                          </button>
+                        )}
+                      </>
                     )}
                   </div>
                 )}
@@ -256,13 +305,15 @@ export default function ResourceList({
       {awsResources.length === 0 ? (
         <div className="px-6 py-16 text-center">
           <div className="flex items-center justify-center space-x-4 mb-6 opacity-20">
-            <Icon icon="logos:aws-s3" className="w-12 h-12" />
-            <Icon icon="logos:aws-dynamodb" className="w-12 h-12" />
-            <Icon icon="logos:aws-secrets-manager" className="w-12 h-12" />
+            <Icon icon="logos:aws-s3" className="w-10 h-10" />
+            <Icon icon="logos:aws-dynamodb" className="w-10 h-10" />
+            <Icon icon="logos:aws-lambda" className="w-10 h-10" />
+            <Icon icon="logos:aws-api-gateway" className="w-10 h-10" />
+            <Icon icon="logos:aws-secrets-manager" className="w-10 h-10" />
           </div>
           <h4 className="text-sm font-semibold text-gray-900 mb-1">No AWS Resources Yet</h4>
           <p className="text-sm text-gray-500">
-            Use the <span className="font-medium">+ Add</span> button to create your first S3 bucket, DynamoDB table, or secret.
+            Use the <span className="font-medium">+ Add</span> button to create your first S3 bucket, DynamoDB table, Lambda function, API Gateway, or secret.
           </p>
         </div>
       ) : (

--- a/localcloud-gui/src/components/SSMConfigModal.tsx
+++ b/localcloud-gui/src/components/SSMConfigModal.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { SSMParameterConfig } from "@/types";
+
+interface SSMConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (config: SSMParameterConfig) => void;
+  projectName: string;
+  loading?: boolean;
+}
+
+export default function SSMConfigModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectName,
+  loading = false,
+}: SSMConfigModalProps) {
+  const [parameterName, setParameterName] = useState(`/${projectName}/config`);
+  const [parameterValue, setParameterValue] = useState("");
+  const [parameterType, setParameterType] = useState<"String" | "StringList" | "SecureString">("String");
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setParameterName(`/${projectName}/config`);
+      setParameterValue("");
+      setParameterType("String");
+      setDescription("");
+    }
+  }, [isOpen, projectName]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ parameterName, parameterValue, parameterType, description });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-teal-50 rounded-lg">
+              <Icon icon="logos:aws-systems-manager" className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Create Parameter</h2>
+              <p className="text-xs text-gray-500">Add a new SSM Parameter Store entry</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+            aria-label="Close"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* Parameter Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Parameter Name
+            </label>
+            <input
+              type="text"
+              value={parameterName}
+              onChange={(e) => setParameterName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-gray-900"
+              placeholder="/my-app/database/host"
+              required
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Use <code className="bg-gray-100 px-1 rounded">/</code> as a hierarchy separator
+              (e.g. <code className="bg-gray-100 px-1 rounded">/my-app/db/host</code>)
+            </p>
+          </div>
+
+          {/* Parameter Value */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Value
+            </label>
+            <textarea
+              value={parameterValue}
+              onChange={(e) => setParameterValue(e.target.value)}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-gray-900 font-mono text-sm resize-none"
+              placeholder="my-parameter-value"
+              required
+            />
+          </div>
+
+          {/* Parameter Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Type
+            </label>
+            <div className="flex gap-3">
+              {(["String", "StringList", "SecureString"] as const).map((t) => (
+                <label key={t} className="flex items-center space-x-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name="paramType"
+                    value={t}
+                    checked={parameterType === t}
+                    onChange={() => setParameterType(t)}
+                    className="h-4 w-4 text-teal-600 focus:ring-teal-500 border-gray-300"
+                  />
+                  <span className="text-sm text-gray-700">{t}</span>
+                </label>
+              ))}
+            </div>
+            {parameterType === "SecureString" && (
+              <p className="text-xs text-teal-700 mt-1 bg-teal-50 px-2 py-1 rounded">
+                LocalStack encrypts SecureString parameters using a local KMS key.
+              </p>
+            )}
+            {parameterType === "StringList" && (
+              <p className="text-xs text-gray-500 mt-1">
+                Comma-separated list of values, e.g. <code className="bg-gray-100 px-1 rounded">value1,value2,value3</code>
+              </p>
+            )}
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-gray-900"
+              placeholder="Database hostname for my-app"
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-teal-600 rounded-md hover:bg-teal-700 disabled:opacity-50"
+              disabled={loading || !parameterName.trim() || !parameterValue.trim()}
+            >
+              {loading ? "Creating..." : "Create Parameter"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -13,6 +13,7 @@ export interface Resource {
     | "dynamodb"
     | "lambda"
     | "apigateway"
+    | "ssm"
     | "iam"
     | "cache"
     | "secretsmanager"
@@ -71,6 +72,25 @@ export interface SecretsManagerConfig {
   description?: string;
   tags?: Record<string, string>;
   kmsKeyId?: string;
+}
+
+export interface LambdaFunctionConfig {
+  functionName: string;
+  runtime?: string;
+  handler?: string;
+  description?: string;
+}
+
+export interface APIGatewayConfig {
+  apiName: string;
+  description?: string;
+}
+
+export interface SSMParameterConfig {
+  parameterName: string;
+  parameterValue: string;
+  parameterType: "String" | "StringList" | "SecureString";
+  description?: string;
 }
 
 export interface ResourceTemplate {
@@ -132,10 +152,13 @@ export interface CreateResourceRequest {
 
 export interface CreateSingleResourceRequest {
   projectName: string;
-  resourceType: "s3" | "dynamodb" | "lambda" | "apigateway" | "secretsmanager";
+  resourceType: "s3" | "dynamodb" | "lambda" | "apigateway" | "secretsmanager" | "ssm";
   dynamodbConfig?: DynamoDBTableConfig;
   s3Config?: S3BucketConfig;
   secretsmanagerConfig?: SecretsManagerConfig;
+  lambdaConfig?: LambdaFunctionConfig;
+  apigatewayConfig?: APIGatewayConfig;
+  ssmConfig?: SSMParameterConfig;
 }
 
 export interface DestroyResourceRequest {

--- a/scripts/shell/create_parameter.sh
+++ b/scripts/shell/create_parameter.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# create_parameter.sh — Create an SSM Parameter Store parameter
+# Usage: ./create_parameter.sh <name> <value> [type] [description]
+#   type: String | StringList | SecureString (default: String)
+
+PARAM_NAME="${1}"
+PARAM_VALUE="${2}"
+PARAM_TYPE="${3:-String}"
+DESCRIPTION="${4:-}"
+
+if [ -z "$PARAM_NAME" ] || [ -z "$PARAM_VALUE" ]; then
+  echo '{"error":"Parameter name and value are required"}' >&2
+  exit 1
+fi
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+CMD="$AWS_CMD ssm put-parameter --name \"$PARAM_NAME\" --value \"$PARAM_VALUE\" --type \"$PARAM_TYPE\" --overwrite"
+if [ -n "$DESCRIPTION" ]; then
+  CMD="$CMD --description \"$DESCRIPTION\""
+fi
+
+eval $CMD 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo '{"error":"Failed to create parameter"}' >&2
+  exit 1
+fi
+
+echo "Parameter $PARAM_NAME created successfully"

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -488,6 +488,47 @@ EOF
 EOF
 }
 
+create_ssm_parameter() {
+  if [ -n "$RESOURCE_CONFIG" ]; then
+    PARAM_NAME=$(echo "$RESOURCE_CONFIG" | jq -r '.parameterName // empty')
+    PARAM_VALUE=$(echo "$RESOURCE_CONFIG" | jq -r '.parameterValue // "default-value"')
+    PARAM_TYPE=$(echo "$RESOURCE_CONFIG" | jq -r '.parameterType // "String"')
+    DESCRIPTION=$(echo "$RESOURCE_CONFIG" | jq -r '.description // empty')
+
+    if [ -z "$PARAM_NAME" ]; then
+      PARAM_NAME="/${PROJECT_NAME}/parameter"
+    fi
+  else
+    PARAM_NAME="/${PROJECT_NAME}/parameter"
+    PARAM_VALUE="default-value"
+    PARAM_TYPE="String"
+    DESCRIPTION="Default parameter created by LocalCloud Kit"
+  fi
+
+  CMD="$AWS_CMD ssm put-parameter --name \"$PARAM_NAME\" --value \"$PARAM_VALUE\" --type \"$PARAM_TYPE\" --overwrite"
+  if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
+    CMD="$CMD --description \"$DESCRIPTION\""
+  fi
+  eval $CMD 2>/dev/null || true
+  log "Created SSM parameter: $PARAM_NAME"
+
+  cat <<EOF
+{
+  "id": "ssm-$PARAM_NAME",
+  "name": "$PARAM_NAME",
+  "type": "ssm",
+  "status": "active",
+  "project": "$PROJECT_NAME",
+  "createdAt": "$NOW",
+  "details": {
+    "parameterName": "$PARAM_NAME",
+    "parameterType": "$PARAM_TYPE",
+    "description": "$DESCRIPTION"
+  }
+}
+EOF
+}
+
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
@@ -515,9 +556,12 @@ main() {
     secretsmanager)
       create_secrets_manager_secret
       ;;
+    ssm)
+      create_ssm_parameter
+      ;;
     *)
       echo "Unknown resource type: $RESOURCE_TYPE" >&2
-      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager" >&2
+      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm" >&2
       exit 1
       ;;
   esac

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -352,12 +352,44 @@ EOF
 }
 
 create_lambda_function() {
-  FUNCTION_NAME="${NAME_PREFIX}-lambda"
-  $AWS_CMD lambda create-function --function-name "$FUNCTION_NAME" \
-    --runtime python3.9 --role arn:aws:iam::000000000000:role/service-role/irrelevant \
-    --handler lambda_function.lambda_handler --zip-file fileb://function.zip 2>/dev/null || true
+  if [ -n "$RESOURCE_CONFIG" ]; then
+    FUNCTION_NAME=$(echo "$RESOURCE_CONFIG" | jq -r '.functionName // empty')
+    RUNTIME=$(echo "$RESOURCE_CONFIG" | jq -r '.runtime // "python3.12"')
+    HANDLER=$(echo "$RESOURCE_CONFIG" | jq -r '.handler // "lambda_function.lambda_handler"')
+    DESCRIPTION=$(echo "$RESOURCE_CONFIG" | jq -r '.description // empty')
+
+    if [ -z "$FUNCTION_NAME" ]; then
+      FUNCTION_NAME="${NAME_PREFIX}-lambda"
+    fi
+  else
+    FUNCTION_NAME="${NAME_PREFIX}-lambda"
+    RUNTIME="python3.12"
+    HANDLER="lambda_function.lambda_handler"
+    DESCRIPTION=""
+  fi
+
+  log "Creating Lambda function: $FUNCTION_NAME (runtime=$RUNTIME, handler=$HANDLER)"
+
+  # Create a minimal placeholder zip in a temp dir
+  TMPDIR_LAMBDA=$(mktemp -d)
+  echo 'def lambda_handler(event, context): return {"statusCode": 200}' > "$TMPDIR_LAMBDA/lambda_function.py"
+  (cd "$TMPDIR_LAMBDA" && zip -q function.zip lambda_function.py)
+
+  CREATE_CMD="$AWS_CMD lambda create-function \
+    --function-name \"$FUNCTION_NAME\" \
+    --runtime \"$RUNTIME\" \
+    --role arn:aws:iam::000000000000:role/service-role/irrelevant \
+    --handler \"$HANDLER\" \
+    --zip-file fileb://$TMPDIR_LAMBDA/function.zip"
+
+  if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
+    CREATE_CMD="$CREATE_CMD --description \"$DESCRIPTION\""
+  fi
+
+  eval $CREATE_CMD 2>/dev/null || true
+  rm -rf "$TMPDIR_LAMBDA"
   log "Created Lambda function: $FUNCTION_NAME"
-  
+
   # Return resource info as JSON
   cat <<EOF
 {
@@ -369,18 +401,36 @@ create_lambda_function() {
   "createdAt": "$NOW",
   "details": {
     "functionName": "$FUNCTION_NAME",
-    "runtime": "python3.9",
-    "handler": "lambda_function.lambda_handler"
+    "runtime": "$RUNTIME",
+    "handler": "$HANDLER"
   }
 }
 EOF
 }
 
 create_api_gateway() {
-  API_NAME="${NAME_PREFIX}-api"
-  $AWS_CMD apigateway create-rest-api --name "$API_NAME" 2>/dev/null || true
+  if [ -n "$RESOURCE_CONFIG" ]; then
+    API_NAME=$(echo "$RESOURCE_CONFIG" | jq -r '.apiName // empty')
+    DESCRIPTION=$(echo "$RESOURCE_CONFIG" | jq -r '.description // empty')
+
+    if [ -z "$API_NAME" ]; then
+      API_NAME="${NAME_PREFIX}-api"
+    fi
+  else
+    API_NAME="${NAME_PREFIX}-api"
+    DESCRIPTION=""
+  fi
+
+  log "Creating API Gateway: $API_NAME"
+
+  CREATE_CMD="$AWS_CMD apigateway create-rest-api --name \"$API_NAME\""
+  if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
+    CREATE_CMD="$CREATE_CMD --description \"$DESCRIPTION\""
+  fi
+
+  eval $CREATE_CMD 2>/dev/null || true
   log "Created API Gateway: $API_NAME"
-  
+
   # Return resource info as JSON
   cat <<EOF
 {
@@ -392,6 +442,7 @@ create_api_gateway() {
   "createdAt": "$NOW",
   "details": {
     "apiName": "$API_NAME",
+    "description": "$DESCRIPTION",
     "type": "REST"
   }
 }

--- a/scripts/shell/delete_parameter.sh
+++ b/scripts/shell/delete_parameter.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# delete_parameter.sh — Delete an SSM Parameter Store parameter
+# Usage: ./delete_parameter.sh <name>
+
+PARAM_NAME="${1}"
+
+if [ -z "$PARAM_NAME" ]; then
+  echo '{"error":"Parameter name is required"}' >&2
+  exit 1
+fi
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+$AWS_CMD ssm delete-parameter --name "$PARAM_NAME" 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo '{"error":"Failed to delete parameter or parameter not found"}' >&2
+  exit 1
+fi
+
+echo "Parameter $PARAM_NAME deleted successfully"

--- a/scripts/shell/destroy_single_resource.sh
+++ b/scripts/shell/destroy_single_resource.sh
@@ -111,12 +111,26 @@ destroy_secrets_manager_secret() {
       return
     fi
   fi
-  
+
   log "Destroying Secrets Manager secret: $SECRET_NAME"
   $AWS_CMD secretsmanager delete-secret --secret-id "$SECRET_NAME" --force-delete-without-recovery 2>/dev/null || true
   log "Deleted Secrets Manager secret: $SECRET_NAME"
-  
+
   echo "{\"success\": true, \"message\": \"Secrets Manager secret $SECRET_NAME destroyed successfully\"}"
+}
+
+destroy_ssm_parameter() {
+  if [ -n "$RESOURCE_NAME" ]; then
+    PARAM_NAME="$RESOURCE_NAME"
+  else
+    PARAM_NAME="/${PROJECT_NAME}/parameter"
+  fi
+
+  log "Destroying SSM parameter: $PARAM_NAME"
+  $AWS_CMD ssm delete-parameter --name "$PARAM_NAME" 2>/dev/null || true
+  log "Deleted SSM parameter: $PARAM_NAME"
+
+  echo "{\"success\": true, \"message\": \"SSM parameter $PARAM_NAME destroyed successfully\"}"
 }
 
 main() {
@@ -145,9 +159,12 @@ main() {
     secretsmanager)
       destroy_secrets_manager_secret
       ;;
+    ssm)
+      destroy_ssm_parameter
+      ;;
     *)
       echo "Unknown resource type: $RESOURCE_TYPE" >&2
-      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager" >&2
+      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm" >&2
       exit 1
       ;;
   esac

--- a/scripts/shell/get_parameter.sh
+++ b/scripts/shell/get_parameter.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# get_parameter.sh — Get an SSM Parameter Store parameter value
+# Usage: ./get_parameter.sh <name> [with_decryption]
+
+PARAM_NAME="${1}"
+WITH_DECRYPTION="${2:-false}"
+
+if [ -z "$PARAM_NAME" ]; then
+  echo '{"error":"Parameter name is required"}' >&2
+  exit 1
+fi
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+if [ "$WITH_DECRYPTION" = "true" ]; then
+  $AWS_CMD ssm get-parameter --name "$PARAM_NAME" --with-decryption 2>/dev/null
+else
+  $AWS_CMD ssm get-parameter --name "$PARAM_NAME" 2>/dev/null
+fi
+
+if [ $? -ne 0 ]; then
+  echo '{"error":"Parameter not found"}' >&2
+  exit 1
+fi

--- a/scripts/shell/list_apis.sh
+++ b/scripts/shell/list_apis.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# list_apis.sh — List API Gateway REST APIs, optionally filtered by project name prefix
+# Usage: ./list_apis.sh [project_name]
+
+PROJECT_NAME="${1:-}"
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+result=$($AWS_CMD apigateway get-rest-apis 2>/dev/null)
+if [ $? -ne 0 ]; then
+  echo '{"items":[]}'
+  exit 0
+fi
+
+if [ -n "$PROJECT_NAME" ]; then
+  echo "$result" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+prefix = '${PROJECT_NAME}-'
+apis = [a for a in data.get('items', []) if a.get('name','').startswith(prefix)]
+print(json.dumps({'items': apis}))
+" 2>/dev/null || echo "$result"
+else
+  echo "$result"
+fi

--- a/scripts/shell/list_lambda_functions.sh
+++ b/scripts/shell/list_lambda_functions.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# list_lambda_functions.sh — List Lambda functions, optionally filtered by project name prefix
+# Usage: ./list_lambda_functions.sh [project_name]
+
+PROJECT_NAME="${1:-}"
+MAX_ITEMS="${2:-100}"
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-test}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+result=$($AWS_CMD lambda list-functions --max-items "$MAX_ITEMS" 2>/dev/null)
+if [ $? -ne 0 ]; then
+  echo '{"Functions":[]}'
+  exit 0
+fi
+
+if [ -n "$PROJECT_NAME" ]; then
+  echo "$result" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+prefix = '${PROJECT_NAME}-'
+fns = [f for f in data.get('Functions', []) if f.get('FunctionName','').startswith(prefix)]
+print(json.dumps({'Functions': fns}))
+" 2>/dev/null || echo "$result"
+else
+  echo "$result"
+fi

--- a/scripts/shell/list_parameters.sh
+++ b/scripts/shell/list_parameters.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# list_parameters.sh — List SSM Parameter Store parameters, optionally filtered by path prefix
+# Usage: ./list_parameters.sh [path_prefix]
+
+PATH_PREFIX="${1:-/}"
+MAX_RESULTS="${2:-50}"
+
+AWS_ENDPOINT="${AWS_ENDPOINT_URL:-http://localstack:4566}"
+AWS_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+
+AWS_CMD="aws --endpoint-url=$AWS_ENDPOINT --region=$AWS_REGION"
+
+result=$($AWS_CMD ssm describe-parameters --max-results "$MAX_RESULTS" 2>/dev/null)
+if [ $? -ne 0 ]; then
+  echo '{"Parameters":[]}'
+  exit 0
+fi
+
+echo "$result"


### PR DESCRIPTION
Adds three new LocalStack-backed AWS services to LocalCloud Kit:

Lambda:
- LambdaConfigModal with runtime (Python/Node/Java/Go/.NET) and handler config
- /lambda doc page with TypeScript, Node.js, Python, and CLI SDK examples
- /api/lambda/functions routes (list, get, delete, invoke)
- list_lambda_functions.sh shell script

API Gateway:
- APIGatewayConfigModal for REST API creation
- /apigateway doc page with full walkthrough (resources, methods, mock/Lambda
  integrations, stage deployment, invoke URL pattern)
- /api/apigateway/apis routes (list, get, delete)
- list_apis.sh shell script

SSM Parameter Store:
- SSMConfigModal with String / StringList / SecureString type selection
- /ssm doc page with parameter types table, SDK examples, best practices
- /api/ssm/parameters CRUD routes
- list_parameters.sh, create_parameter.sh, get_parameter.sh, delete_parameter.sh

Dashboard and ResourceList:
- Resources dropdown: Compute (Lambda), Networking (API Gateway), and
  Parameter Store sections added
- Docs dropdown: Lambda, API Gateway, Parameter Store links added
- Mobile menu updated with all new entries
- ResourceList + Add dropdown: Compute, Networking, SSM sections added
- Empty state icons updated to include Lambda and API Gateway

Types:
- ssm added to Resource type union
- LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig interfaces
- CreateSingleResourceRequest extended with lambdaConfig, apigatewayConfig, ssmConfig

Shell scripts:
- create_single_resource.sh: ssm case added (create_ssm_parameter)
- destroy_single_resource.sh: ssm case added (destroy_ssm_parameter)

Docs:
- docs/LAMBDA.md, docs/API_GATEWAY.md, docs/SSM.md
- README.md: tagline, Features section, Documentation section updated
- CHANGELOG.md: [Unreleased] entry added