### PR TITLE
fix(api): API Gateway and SSM create/list/destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to LocalCloud Kit will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **API Gateway create**: Pass config to create_single_resource.sh; capture API ID from create-rest-api output for correct destroy; escape JSON config for shell
+- **SSM create**: Add ssmConfig handling in resources.js createSingleResource (was missing)
+- **SSM list**: Add list_ssm_parameters to list_resources.sh so SSM parameters appear in dashboard
+- **SSM destroy**: Add SSM parameter deletion to destroy_resources.sh (specific and bulk)
+- **LocalStack**: Enable SSM service in docker-compose SERVICES
 - **Docker**: Add `.dockerignore` to exclude `node_modules` and build artifacts — prevents host `node_modules` from being copied into Docker builds so `npm ci` runs fresh
 - **API**: Replace Express 4 `:name(*)` route syntax with Express 5–compatible `*name` splat in SSM and S3 routes — fixes path-to-regexp v8 TypeError with parameter names containing slashes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "4566:4566"
     environment:
-      - SERVICES=s3,dynamodb,lambda,apigateway,iam,secretsmanager
+      - SERVICES=s3,dynamodb,lambda,apigateway,iam,secretsmanager,ssm
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/localcloud-api/lib/resources.js
+++ b/localcloud-api/lib/resources.js
@@ -87,28 +87,36 @@ export async function createResources(request) {
   }
 }
 
+function escapeConfigForShell(jsonStr) {
+  return jsonStr.replace(/'/g, "'\"'\"'");
+}
+
 export async function createSingleResource(projectName, resourceType, config = {}) {
   try {
     let command = `./create_single_resource.sh ${projectName} ${resourceType}`;
 
     if (resourceType === "dynamodb" && config.dynamodbConfig) {
-      command += ` --config '${JSON.stringify(config.dynamodbConfig)}'`;
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.dynamodbConfig))}'`;
     }
 
     if (resourceType === "s3" && config.s3Config) {
-      command += ` --config '${JSON.stringify(config.s3Config)}'`;
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.s3Config))}'`;
     }
 
     if (resourceType === "secretsmanager" && config.secretsmanagerConfig) {
-      command += ` --config '${JSON.stringify(config.secretsmanagerConfig)}'`;
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.secretsmanagerConfig))}'`;
     }
 
     if (resourceType === "lambda" && config.lambdaConfig) {
-      command += ` --config '${JSON.stringify(config.lambdaConfig)}'`;
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.lambdaConfig))}'`;
     }
 
     if (resourceType === "apigateway" && config.apigatewayConfig) {
-      command += ` --config '${JSON.stringify(config.apigatewayConfig)}'`;
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.apigatewayConfig))}'`;
+    }
+
+    if (resourceType === "ssm" && config.ssmConfig) {
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.ssmConfig))}'`;
     }
 
     console.log("[DEBUG] Running command:", command);

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -423,18 +423,21 @@ create_api_gateway() {
 
   log "Creating API Gateway: $API_NAME"
 
-  CREATE_CMD="$AWS_CMD apigateway create-rest-api --name \"$API_NAME\""
   if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
-    CREATE_CMD="$CREATE_CMD --description \"$DESCRIPTION\""
+    CREATE_OUTPUT=$($AWS_CMD apigateway create-rest-api --name "$API_NAME" --description "$DESCRIPTION" --output json 2>/dev/null) || CREATE_OUTPUT=""
+  else
+    CREATE_OUTPUT=$($AWS_CMD apigateway create-rest-api --name "$API_NAME" --output json 2>/dev/null) || CREATE_OUTPUT=""
   fi
+  API_ID=$(echo "$CREATE_OUTPUT" | jq -r '.id // empty')
+  if [ -z "$API_ID" ]; then
+    API_ID="$API_NAME"
+  fi
+  log "Created API Gateway: $API_NAME (id: $API_ID)"
 
-  eval $CREATE_CMD 2>/dev/null || true
-  log "Created API Gateway: $API_NAME"
-
-  # Return resource info as JSON
+  # Return resource info as JSON (id must use API_ID for destroy to work)
   cat <<EOF
 {
-  "id": "apigateway-$API_NAME",
+  "id": "apigateway-$API_ID",
   "name": "$API_NAME",
   "type": "apigateway",
   "status": "active",
@@ -442,6 +445,7 @@ create_api_gateway() {
   "createdAt": "$NOW",
   "details": {
     "apiName": "$API_NAME",
+    "apiId": "$API_ID",
     "description": "$DESCRIPTION",
     "type": "REST"
   }

--- a/scripts/shell/destroy_resources.sh
+++ b/scripts/shell/destroy_resources.sh
@@ -86,6 +86,11 @@ if [ -n "$SPECIFIC_RESOURCES" ]; then
                 $AWS_CMD secretsmanager delete-secret --secret-id $resource_name --force-delete-without-recovery 2>/dev/null || true
                 log "Deleted Secrets Manager secret: $resource_name"
                 ;;
+            "ssm")
+                log "Destroying SSM parameter: $resource_name"
+                $AWS_CMD ssm delete-parameter --name "$resource_name" 2>/dev/null || true
+                log "Deleted SSM parameter: $resource_name"
+                ;;
             *)
                 log "Unknown resource type: $resource_type for resource: $resource_id"
                 ;;
@@ -128,6 +133,13 @@ else
     for SECRET in $SECRETS; do
         $AWS_CMD secretsmanager delete-secret --secret-id $SECRET --force-delete-without-recovery 2>/dev/null || true
         log "Deleted Secrets Manager secret: $SECRET"
+    done
+
+    # Destroy SSM Parameters (path-based, under /$NAME_PREFIX)
+    PARAMS=$($AWS_CMD ssm describe-parameters --query "Parameters[?starts_with(Name, '/$NAME_PREFIX')].Name" --output text 2>/dev/null || true)
+    for PARAM in $PARAMS; do
+        $AWS_CMD ssm delete-parameter --name "$PARAM" 2>/dev/null || true
+        log "Deleted SSM parameter: $PARAM"
     done
 fi
 

--- a/scripts/shell/list_resources.sh
+++ b/scripts/shell/list_resources.sh
@@ -137,6 +137,20 @@ list_secrets_manager_secrets() {
   done
 }
 
+list_ssm_parameters() {
+  params=$($AWS_CMD ssm describe-parameters --query "Parameters[].{Name:Name,Type:Type,LastModifiedDate:LastModifiedDate}" --output json 2>/dev/null) || params="[]"
+  echo "$params" | jq -c '.[]' | while read row; do
+    name=$(echo "$row" | jq -r .Name)
+    param_type=$(echo "$row" | jq -r '.Type // "String"')
+    lastModified=$(echo "$row" | jq -r '.LastModifiedDate // ""')
+    if [ "$SHOW_ALL" = true ] || [ -z "$NAME_PREFIX" ] || case "$name" in "/${NAME_PREFIX}"*) true ;; *) false ;; esac; then
+      id="ssm-$name"
+      obj=$(jq -nc --arg id "$id" --arg name "$name" --arg type ssm --arg status active --arg project "$PROJECT_NAME" --arg createdAt "$lastModified" --arg paramType "$param_type" '{id:$id,name:$name,type:$type,status:$status,project:$project,createdAt:$createdAt,details:{parameterType:$paramType}}')
+      tmp_add_resource "$obj"
+    fi
+  done
+}
+
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
@@ -151,6 +165,7 @@ main() {
   list_iam_roles
   list_api_gateways
   list_secrets_manager_secrets
+  list_ssm_parameters
   # Output JSON array
   if [ -s "$TMPFILE" ]; then
     printf '[%s]\n' "$(paste -sd, "$TMPFILE")"


### PR DESCRIPTION
- Add ssmConfig handling in createSingleResource (was missing)
- Add list_ssm_parameters to list_resources.sh for dashboard
- Add SSM destroy to destroy_resources.sh (specific + bulk)
- Enable SSM service in LocalStack docker-compose
- Fix API Gateway create: capture API ID for correct destroy
- Add escapeConfigForShell for all config types

## Summary

<!-- What does this PR do? 1–3 bullets on the user-visible change. -->

-
-

## Type of change

<!-- Check all that apply -->

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [ ] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [ ] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [ ] No hardcoded secrets, credentials, or localhost-only assumptions
- [ ] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [ ] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

<!-- Paste the exact lines you added to CHANGELOG.md [Unreleased] here -->

```markdown
### Added / Changed / Fixed
- **ComponentName**: ...
```
