### PR TITLE
fix(gui): show backend errors for single resource creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Fixed
 - **GUI**: React duplicate key warnings — use unique keys for API endpoint tables (method+endpoint), ResourceList categories/details, BucketViewer objects/buckets, DynamoDBViewer rows/headers, SecretsManagerViewer secrets, LambdaCodeModal files, and external resource tables across all service pages
+- **Dashboard**: Show backend error messages in toasts when creating single resources (Lambda, API Gateway, Parameter Store) instead of generic AxiosError 500 messages
 - **API Gateway create**: Pass config to create_single_resource.sh; capture API ID from create-rest-api output for correct destroy; escape JSON config for shell
 - **SSM create**: Add ssmConfig handling in resources.js createSingleResource (was missing)
 - **SSM list**: Add list_ssm_parameters to list_resources.sh so SSM parameters appear in dashboard

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -11,7 +11,6 @@ import {
   CircleStackIcon,
   DocumentTextIcon,
   EnvelopeIcon,
-  FolderIcon,
   KeyIcon,
   ServerIcon,
   Squares2X2Icon,
@@ -271,7 +270,9 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Create Lambda error:", error);
-      toast.error(error instanceof Error ? error.message : "Failed to create Lambda function");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const apiMessage = (error as any)?.response?.data?.error;
+      toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create Lambda function"));
     } finally {
       setCreateLoading(false);
     }
@@ -290,7 +291,9 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Create API Gateway error:", error);
-      toast.error(error instanceof Error ? error.message : "Failed to create API Gateway");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const apiMessage = (error as any)?.response?.data?.error;
+      toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create API Gateway"));
     } finally {
       setCreateLoading(false);
     }
@@ -309,7 +312,9 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Create SSM parameter error:", error);
-      toast.error(error instanceof Error ? error.message : "Failed to create SSM parameter");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const apiMessage = (error as any)?.response?.data?.error;
+      toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create SSM parameter"));
     } finally {
       setCreateLoading(false);
     }


### PR DESCRIPTION
## Summary
When creating a Lambda function, API Gateway, or SSM parameter from the dashboard, a 500 from `/resources/create-single` previously showed a generic AxiosError message in the toast. The backend sends a specific `error` message in the JSON body.

## Changes
- **Dashboard**: `handleCreateLambda`, `handleCreateAPIGateway`, and `handleCreateSSMParameter` now read `error.response.data.error` and display it in the toast, falling back to `Error.message` or a generic message only when absent.
- **Changelog**: Document improved error toasts under Fixed.

## Testing
- Create a Lambda (or API Gateway / SSM) and trigger a backend error (e.g. script/config issue); the toast should show the backend message instead of "Request failed with status code 500".