### PR TITLE
fix(lambda): create function without zip binary; placeholder then upload later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **GUI**: Next.js rewrites to proxy /api to backend when running standalone dev (fixes 404/Network Error)
 
 ### Fixed
+- **Lambda create**: Build placeholder zip with Python when `zip` is unavailable (fixes "zip not found"); function is created with minimal placeholder and code can be uploaded later via `update-function-code`
+- **API image**: Add `zip` package to Dockerfile.api so Lambda placeholder fallback works in all environments
 - **GUI**: React duplicate key warnings — use unique keys for API endpoint tables (method+endpoint), ResourceList categories/details, BucketViewer objects/buckets, DynamoDBViewer rows/headers, SecretsManagerViewer secrets, LambdaCodeModal files, and external resource tables across all service pages
 - **Dashboard**: Show backend error messages in toasts when creating single resources (Lambda, API Gateway, Parameter Store) instead of generic AxiosError 500 messages
 - **API Gateway create**: Pass config to create_single_resource.sh; capture API ID from create-rest-api output for correct destroy; escape JSON config for shell

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -5,7 +5,7 @@ FROM node:22-alpine
 WORKDIR /app
 
 # Install AWS CLI v2, jq, redis-cli, and native build tools (required for better-sqlite3)
-RUN apk add --no-cache curl jq aws-cli redis python3 make g++ unzip
+RUN apk add --no-cache curl jq aws-cli redis python3 make g++ unzip zip
 
 # Copy package files
 COPY localcloud-api/package*.json ./

--- a/localcloud-gui/src/components/LambdaConfigModal.tsx
+++ b/localcloud-gui/src/components/LambdaConfigModal.tsx
@@ -226,7 +226,8 @@ export default function LambdaConfigModal({
 
           {/* Note */}
           <div className="rounded-md bg-orange-50 border border-orange-200 p-3 text-xs text-orange-800">
-            LocalStack creates the function with a placeholder zip. Upload your code via the AWS CLI or SDK after creation.
+            <strong>No zip required.</strong> The function is created with a minimal placeholder. Upload your real code later with{" "}
+            <code className="bg-orange-100 px-1 rounded">update-function-code</code> (AWS CLI or SDK).
           </div>
 
           {/* Save Config Toggle */}

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -370,17 +370,34 @@ create_lambda_function() {
 
   log "Creating Lambda function: $FUNCTION_NAME (runtime=$RUNTIME, handler=$HANDLER)"
 
-  # Create a minimal placeholder zip in a temp dir
+  # Create a minimal placeholder zip using Python (no zip binary required; works in Alpine)
   TMPDIR_LAMBDA=$(mktemp -d)
-  echo 'def lambda_handler(event, context): return {"statusCode": 200}' > "$TMPDIR_LAMBDA/lambda_function.py"
-  (cd "$TMPDIR_LAMBDA" && zip -q function.zip lambda_function.py)
+  PLACEHOLDER_ZIP="$TMPDIR_LAMBDA/function.zip"
+  python3 -c "
+import zipfile
+import sys
+code = '''def lambda_handler(event, context):
+    return {\"statusCode\": 200, \"body\": \"Hello from placeholder\"}
+'''
+with zipfile.ZipFile(sys.argv[1], 'w', zipfile.ZIP_DEFLATED) as z:
+    z.writestr('lambda_function.py', code)
+" "$PLACEHOLDER_ZIP" 2>/dev/null || {
+    # Fallback: try zip if available (e.g. some environments have zip but not python3)
+    echo 'def lambda_handler(event, context): return {"statusCode": 200}' > "$TMPDIR_LAMBDA/lambda_function.py"
+    (cd "$TMPDIR_LAMBDA" && zip -q -r function.zip lambda_function.py) 2>/dev/null || true
+  }
+  if [ ! -f "$PLACEHOLDER_ZIP" ] || [ ! -s "$PLACEHOLDER_ZIP" ]; then
+    echo "ERROR: Failed to create placeholder deployment package. Install python3 or zip." >&2
+    rm -rf "$TMPDIR_LAMBDA"
+    exit 1
+  fi
 
   CREATE_CMD="$AWS_CMD lambda create-function \
     --function-name \"$FUNCTION_NAME\" \
     --runtime \"$RUNTIME\" \
     --role arn:aws:iam::000000000000:role/service-role/irrelevant \
     --handler \"$HANDLER\" \
-    --zip-file fileb://$TMPDIR_LAMBDA/function.zip"
+    --zip-file fileb://$PLACEHOLDER_ZIP"
 
   if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
     CREATE_CMD="$CREATE_CMD --description \"$DESCRIPTION\""


### PR DESCRIPTION
## Summary
Fixes "zip not found" when creating a Lambda from the dashboard. Lambda is created with a minimal placeholder; no zip file is required from the user. Code can be uploaded later via `update-function-code` (AWS CLI or SDK).

## Changes
- **scripts/shell/create_single_resource.sh**: Build the placeholder deployment zip using Python's `zipfile` module (no `zip` CLI required). Fallback to `zip` if Python fails. Clear error if both fail.
- **Dockerfile.api**: Add `zip` package so the fallback works in the API container.
- **LambdaConfigModal**: Update note to "No zip required" and mention uploading code later with `update-function-code`.
- **CHANGELOG**: Document the fix and API image change.

## Testing
- Create a Lambda from the dashboard (Resources → Compute → Lambda Functions → Create); creation should succeed without requiring a zip.
- Rebuild API image if needed: `docker compose build api`.