### PR TITLE
feat(iam): add IAM roles creation, deletion, and management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,21 @@
-# LocalCloud Kit — Agent Context
+# LocalCloud Kit — AGENTS.md
 
-This file provides AI coding agents with project-specific context and instructions for working in this repository.
-
-## Project Overview
-
-**LocalCloud Kit** is a free, local AWS development environment. It emulates AWS cloud services using LocalStack, managed through a Next.js web GUI and an Express.js API backend, all orchestrated via Docker Compose. No AWS account is required.
-
-- **Version**: 0.11.1
-- **License**: MIT
-- **Primary URL**: https://app-local.localcloudkit.com:3030
+This file gives any AI coding agent the context and standards needed to work
+effectively in this repository. It mirrors `CLAUDE.md` and is kept in sync with
+it. When in doubt, `CLAUDE.md` is the authoritative source.
 
 ---
 
-## Build & Run Commands
+## Project Overview
 
-```bash
-make start          # Start all services (Docker Compose)
-make stop           # Stop all services
-make restart        # Restart all services
-make status         # Health check all services
-make logs           # Live log tailing
-make reset          # Stop + clean volumes
-make clean-all      # Remove all Docker resources
+**LocalCloud Kit** is a free, local AWS development environment. It emulates AWS
+cloud services using LocalStack, managed through a Next.js web GUI and an
+Express.js API backend, all orchestrated via Docker Compose. No AWS account is
+required.
 
-./scripts/setup.sh  # One-command first-time setup (mkcert, hosts, TLS)
-```
-
-**First-time setup**: Run `./scripts/setup.sh` before `make start` to configure mkcert, hosts, and TLS certificates.
+- **Version**: 0.11.0
+- **License**: MIT
+- **Primary URL**: https://app-local.localcloudkit.com:3030
 
 ---
 
@@ -34,118 +23,79 @@ make clean-all      # Remove all Docker resources
 
 ### Services (docker-compose.yml)
 
-| Service   | Container | Port | Purpose |
-|-----------|-----------|------|---------|
-| traefik   | traefik   | 3030 | Reverse proxy / TLS |
-| localstack| localstack| 4566 | AWS emulation |
-| gui       | localcloud-gui | 3030 (internal) | Next.js frontend |
-| api       | localcloud-api | 3031 | Express.js backend |
-| nginx     | localstack-nginx | 80 (internal) | Internal routing |
-| redis     | localcloud-redis | 6380 (host) | Cache |
+| Service | Container | Image | Port | Purpose |
+|---------|-----------|-------|------|---------|
+| `traefik` | traefik | traefik:v3 | 3030 (HTTPS entry) | Reverse proxy / TLS termination |
+| `localstack` | localstack | localstack/localstack:latest | 4566 | AWS services emulation |
+| `gui` | localcloud-gui | custom (Dockerfile.gui) | 3030 (internal) | Next.js frontend |
+| `api` | localcloud-api | custom (Dockerfile.api) | 3031 | Express.js backend |
+| `nginx` | localstack-nginx | nginx:alpine | 80 (internal) | Internal routing |
+| `redis` | localcloud-redis | redis:7-alpine | 6380 (host) | Cache service |
+
+All services communicate over the `localstack-network` Docker bridge network.
 
 ### Key Directories
 
 ```
-localcloud-api/     # Express.js API (server.js, Node 22)
+localcloud-api/     # Express.js API server (routes/ + server.js, Node 22)
 localcloud-gui/     # Next.js 15 frontend (App Router, TypeScript, Tailwind)
-scripts/            # Setup scripts + AWS shell automation
-traefik/            # Traefik config + TLS certs
-docs/               # Extended documentation
+scripts/            # Setup scripts + 30+ AWS shell automation scripts
+traefik/            # Traefik reverse proxy config + TLS certs
+docs/               # Extended documentation (one .md per service)
 samples/            # Sample files for S3/DynamoDB testing
 ```
 
 ### Tech Stack
 
-- **Frontend**: Next.js 15, React 18, TypeScript 5, Tailwind CSS, @iconify/react
-- **Backend**: Express.js 4, Node.js 22, Winston, Socket.IO, aws-sdk v2
-- **Infrastructure**: Docker Compose, Traefik v3, Nginx, Redis 7
+- **Frontend**: Next.js 15, React 18, TypeScript 5, Tailwind CSS, @iconify/react (AWS service icons)
+- **Backend**: Express.js 4, Node.js 22, Winston logging, Socket.IO, aws-sdk v2
+- **Infrastructure**: Docker Compose, Traefik v3, Nginx (alpine), Redis 7
+- **AWS Emulation**: LocalStack (S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager)
 
 ---
 
-## Code Conventions
+## AWS Services Emulated
 
-- **API routes**: `/api/<resource>` pattern in `server.js` or `routes/`
-- **GUI pages**: Next.js App Router under `localcloud-gui/src/app/`
-- **Shell scripts**: POSIX-compatible, in `scripts/shell/`
-- **Logging**: Winston on backend; errors → `logs/error.log`
-- **Docker images**: `node:22-alpine` base for Node services
-- **TypeScript**: Strict mode enabled in GUI
+- **S3** — bucket management, multipart uploads (up to 100MB), nested folders
+- **DynamoDB** — tables, CRUD, GSI, query/scan
+- **Lambda** — function management, runtime/handler config, placeholder zip creation; upload real code via `update-function-code`
+- **API Gateway** — REST endpoint creation with name and description
+- **IAM** — identity & access management, roles, policies
+- **STS** — temporary session credentials (GetSessionToken, AssumeRole, GetCallerIdentity)
+- **Secrets Manager** — secret storage, encryption, ARN management
+- **SSM Parameter Store** — parameter management (String, StringList, SecureString)
+- **Redis** — local cache (not AWS, but integrated into the GUI)
+
+### Saved Configs
+
+All AWS resource creation modals support **saved configs**:
+- Users can toggle "Save as config for future use" and give the config a name
+- Saved configs are stored per-project via `savedConfigsApi` and surfaced as clickable pills in the modal
+- Clicking a pill loads its values into the form
+- Config data flows: modal → `usePreferences().saveConfig()` → `savedConfigsApi.create()` → backend → SQLite
+- Resource types for saved configs: `s3`, `dynamodb`, `lambda`, `apigateway`, `secretsmanager`, `ssm`
 
 ---
 
-## Pre-Commit Build Check (Required)
-
-**Always run the GUI build before committing any changes to `localcloud-gui/`.**
+## Common Commands
 
 ```bash
-cd localcloud-gui && npm run build
+make start          # Start all services
+make stop           # Stop all services
+make restart        # Restart all services
+make status         # Health check all services
+make logs           # Live log tailing
+make reset          # Stop + clean volumes
+make clean-all      # Remove all Docker resources
+
+./scripts/setup.sh  # One-command first-time setup
 ```
-
-- The build must pass with **no type errors** before committing
-- Warnings are acceptable; errors are not — fix them before proceeding
-- If you changed only backend (`localcloud-api/`) or shell scripts, the build is not required but recommended
-
----
-
-## Commit Message Standards (Required)
-
-**All commits MUST use Angular Conventional Commits format.**
-
-```
-<type>(<scope>): <subject>
-
-[optional body]
-```
-
-**Types**: `feat` | `fix` | `docs` | `style` | `refactor` | `perf` | `test` | `build` | `ci` | `chore` | `revert`
-
-**Rules**: Subject lowercase, imperative mood, no trailing period. Scope optional (e.g. `feat(s3)`, `fix(api)`).
-
-**Examples**:
-- `feat(mailpit): add SMTP inbox modal with unread badge`
-- `fix(secrets): resolve ARN format mismatch on delete`
-- `docs(redis): update container hostname to localcloud-redis`
-
----
-
-## Changelog Standards
-
-- **Update CHANGELOG.md once per PR** — not per commit
-- **Format**: Keep a Changelog (https://keepachangelog.com)
-- **Entries**: Under `## [Unreleased]`; use `### Added`, `### Changed`, `### Fixed`, `### Removed`
-- **Bold the component/scope** for traceability: `- **DocPageNav**: ...`
-- **User-facing language** — describe what changed for users, not implementation
-
----
-
-## Adding a New Service
-
-When adding a new service (e.g., MailHog):
-
-1. **docker-compose.yml** — service block, image, ports, network, restart policy
-2. **traefik/dynamic.yml** — router and service entry if HTTPS routing needed
-3. **nginx.conf** — upstream and location block if routing through Nginx
-4. **localcloud-api** — API proxy/health-check endpoints
-5. **localcloud-gui/src/** — GUI pages/components for the service
-6. **docs/** — markdown doc for the service
-7. **Makefile** — convenience targets if applicable
-8. **README.md / CHANGELOG.md** — document the new service
-
----
-
-## Dashboard UI Architecture
-
-- **Platform Services** (Keycloak, Mailpit, PostgreSQL, Redis): Managed via their own admin UIs; not destroyable from dashboard
-- **AWS Resources** (S3, DynamoDB, Secrets Manager, etc.): Managed via dashboard modals; destroyable per project
-- **Resources dropdown**: AWS resources grouped by category (Storage, Database, Compute, Networking, Security & Identity)
-- **Services dropdown**: Platform services only, alphabetically
-- **Docs dropdown**: Documentation pages grouped by Infrastructure / AWS Resources / Platform Services
 
 ---
 
 ## Environment Variables
 
-See `env.example`. Key ones:
+See `env.example` for all variables. Key ones:
 
 ```
 AWS_DEFAULT_REGION=us-east-1
@@ -158,7 +108,305 @@ CORS_ORIGIN=https://app-local.localcloudkit.com:3030
 
 ---
 
+## Networking & Routing
+
+- Traefik listens on port 3030 (HTTPS) and routes to Nginx
+- Nginx fans traffic to the GUI (port 3030) and API (port 3031)
+- LocalStack is reachable at `http://localstack:4566` inside Docker, `http://localhost:4566` from the host
+- Redis is at `localcloud-redis:6379` inside Docker, `localhost:6380` from the host
+- TLS certificates are generated with mkcert and mounted into Traefik
+
+---
+
+## Adding a New Service
+
+When adding a new service (e.g., MailHog):
+
+1. **docker-compose.yml** — add the service block with the image, ports, network, and restart policy
+2. **traefik/dynamic.yml** — add a router and service entry if it needs HTTPS routing through Traefik
+3. **nginx.conf** — add an upstream and location block if it routes through Nginx
+4. **localcloud-api/routes/** — add an API route file; register it in `server.js`
+5. **localcloud-gui/src/** — add GUI pages/components for managing the service
+6. **docs/** — add a markdown doc describing the service and its usage
+7. **Makefile** — add convenience targets if applicable
+8. **README.md / CHANGELOG.md** — update to document the new service
+9. **Dashboard.tsx** — add to Resources, Services, and Docs dropdowns as appropriate
+
+---
+
+## Changelog Standards
+
+**CHANGELOG.md is updated once per PR — not per commit.**
+
+### When to update
+
+Update `CHANGELOG.md` as the **last step before opening a PR**, after all commits
+are ready. Never update it mid-feature or on every commit.
+
+### Format — Keep a Changelog (https://keepachangelog.com)
+
+Entries go under `## [Unreleased]` at the top of the file. Use these subsections
+(omit any that don't apply):
+
+```markdown
+## [Unreleased]
+
+### Added
+- **ComponentName**: description of new user-visible capability
+
+### Changed
+- **ComponentName**: description of changed behavior
+
+### Fixed
+- **ComponentName**: description of what was broken and is now fixed
+
+### Removed
+- **ComponentName**: what was removed and why
+
+### Security
+- description of security fix
+```
+
+### Rules
+
+- **One entry per PR** — summarize the net user-visible effect, not the implementation steps
+- **Bold the component/scope** — matches the Angular commit scope for traceability: `- **DocPageNav**: ...`
+- **User-facing language** — write for someone reading the changelog to understand what changed, not how
+- **Angular type → changelog section mapping**:
+  - `feat` → `### Added`
+  - `fix` → `### Fixed`
+  - `refactor` / `perf` → `### Changed` (only if user-visible)
+  - `docs` / `style` / `chore` / `build` / `ci` → omit unless user-facing
+  - `revert` → `### Fixed` or `### Changed` depending on impact
+- **Breaking changes** (`feat!` / `BREAKING CHANGE:`) → always appear in `### Changed` or `### Removed` with a `⚠️` prefix
+
+### Example
+
+```markdown
+## [Unreleased]
+
+### Added
+- **IAM**: doc page with IAM roles and STS session credential examples (TypeScript, Node.js, Python, CLI)
+
+### Fixed
+- **ThemeableCodeBlock**: syntax highlighting now works for bash/CLI code blocks; theme preference is persisted to user profile
+```
+
+---
+
 ## Attribution
 
-- **Never** include `Co-Authored-By: Claude` or any Claude/Anthropic attribution in commits or PRs
-- **Never** include the `🤖 Generated with [Claude Code]` line in output
+- **Never** include `Co-Authored-By: Claude` or any AI attribution in commit messages or footers
+- **Never** include the `🤖 Generated with [Claude Code](https://claude.com/claude-code)` line (or any variant) in PR descriptions, commit bodies, or any other output
+
+---
+
+## Pre-Commit Checklist
+
+Run through every applicable item before committing. Order matters: build first,
+docs second, changelog last (PR step only).
+
+### 1 — GUI Build (required for any `localcloud-gui/` change)
+
+```bash
+cd localcloud-gui && npm run build
+```
+
+- Must pass with **no type errors** — fix all errors before committing
+- Warnings are acceptable; type errors and compile failures are not
+- Skip only for backend-only or shell-script-only changes; run it when in doubt
+
+### 2 — Documentation Update
+
+Update the matching `docs/` markdown file whenever you change behaviour, add
+endpoints, rename things, or add a new service. **If the code changed, the docs
+change too.**
+
+| Change type | Files to update |
+|---|---|
+| New AWS service or platform service | `docs/<SERVICE>.md` (create if missing), `README.md` features list |
+| New or changed API endpoint | `docs/<SERVICE>.md` — endpoint reference table |
+| New GUI page or major UI change | `docs/<SERVICE>.md` — usage section |
+| Changed port, hostname, or env var | `docs/<SERVICE>.md`, `README.md` configuration section, `AGENTS.md` if it references the value |
+| New or changed shell script | `docs/SETUP_SCRIPTS.md` — script inventory |
+| New Docker service | `docker-compose.yml` comment block + `docs/DOCKER.md` |
+| Changed Makefile target | `README.md` common commands section |
+
+Docs live in `docs/` as plain markdown. Keep them concise: overview, connection
+settings or config, common operations, troubleshooting tips. Do **not** duplicate
+the SDK examples from the GUI doc pages verbatim — link to the relevant `/route`
+instead.
+
+### 3 — README Update
+
+Update `README.md` when any of the following change:
+
+- **Features list** — add a bullet for a new service or major capability
+- **Services table** — ports, image names, or purpose text
+- **Common commands** — new or renamed `make` targets
+- **Documentation section** — links to new `docs/` pages
+- **Version badge** — bump when the version in `docker-compose.yml` / `package.json` changes
+
+The README is user-facing. Write in plain, direct language. Do not include
+internal implementation details.
+
+### 4 — Changelog Update (PR step only)
+
+`CHANGELOG.md` is updated **once per PR**, as the last commit before opening the
+PR — never mid-feature. See the Changelog Standards section above.
+
+---
+
+## Commit Message Standards (Angular Conventional Commits)
+
+**ALL commits MUST follow the Angular Conventional Commits format. This is a hard
+requirement — never deviate from it.**
+
+### Format
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+| Type | When to use |
+|------|-------------|
+| `feat` | New feature or capability |
+| `fix` | Bug fix |
+| `docs` | Documentation only changes |
+| `style` | Formatting, whitespace — no logic change |
+| `refactor` | Code restructure with no feature or fix |
+| `perf` | Performance improvement |
+| `test` | Adding or updating tests |
+| `build` | Build system, Docker, dependencies |
+| `ci` | CI/CD configuration changes |
+| `chore` | Maintenance tasks (deps, tooling) |
+| `revert` | Reverts a previous commit |
+
+### Rules
+
+- **Subject line**: 72 characters max, lowercase, no trailing period, imperative mood ("add" not "added")
+- **Scope**: optional, lowercase, describes the area changed — e.g. `feat(iam)`, `fix(api)`, `docs(redis)`
+- **Body**: wrap at 100 characters; explain *why*, not *what*
+- **Breaking changes**: add `BREAKING CHANGE:` in the footer, or append `!` after the type: `feat(api)!:`
+
+### Examples
+
+```
+feat(iam): add STS session credentials and IAM doc page
+
+fix(lambda): resolve syntax highlighting failures in code blocks
+
+docs(redis): update container hostname to localcloud-redis
+
+build(docker): pin localstack image to 3.x for stability
+
+refactor(nav): extract shared DocPageNav component
+
+chore(deps): upgrade next.js to 15.2
+```
+
+---
+
+## Dashboard UI Architecture
+
+The dashboard (`localcloud-gui/src/components/Dashboard.tsx`) is organized around
+a clear two-category model:
+
+### Two Categories of Things
+
+| Category | Examples | Managed via | Can destroy? |
+|----------|----------|-------------|--------------|
+| **Platform Services** | Keycloak, Mailpit, PostgreSQL, Redis | Their own admin UIs | No — Docker Compose lifecycle |
+| **AWS Resources** | S3, DynamoDB, Lambda, API Gateway, IAM | Dashboard modals | Yes — individually, per project |
+
+### Navigation Structure
+
+- **Resources** dropdown — AWS resources grouped by service category (Storage, Database, Compute, Networking, Security & Identity). Uses Iconify AWS logos (`logos:aws-s3`, `logos:aws-dynamodb`, etc.).
+- **Services** dropdown — Platform services only, listed alphabetically.
+- **Docs** dropdown — Documentation pages grouped as Infrastructure / AWS Resources / Platform Services.
+
+### Status Bar
+
+Shows health of all platform services in alphabetical order: **Keycloak | LocalStack | Mailpit | PostgreSQL | Redis**. Clicking a service opens its management modal or links to its doc page.
+
+### ResourceList Component
+
+`localcloud-gui/src/components/ResourceList.tsx` — shows **AWS resources only** (no platform services). Resources are grouped by AWS category with official AWS SVG icons via `@iconify/react`. Supports add, destroy, and inline preview per resource type.
+
+---
+
+## Syntax Highlighting on Doc Pages
+
+All doc pages use `ThemeableCodeBlock` (`localcloud-gui/src/components/ThemeableCodeBlock.tsx`) for syntax-highlighted code examples.
+
+### How it works
+
+- **Highlighting engine**: `highlight.js` via `hljs.highlight(code, { language })` — runs client-side only (`"use client"`)
+- **Theme CSS**: Injected into `<head>` as a `<link>` tag pointing to `/public/hljs-themes/<file>.css`; available themes are declared in `highlightThemes.ts`
+- **Language mapping**: The `languageMap` object inside `ThemeableCodeBlock` translates the `language` prop (e.g. `"cli"`, `"node"`, `"bash"`) into an `hljs` language identifier. **Always add a mapping for every language string you pass as a prop.** Missing entries fall through to `"text"` (no highlighting).
+
+### Profile preferences
+
+Two fields in the user profile drive this component's behaviour:
+
+| Field | Purpose |
+|---|---|
+| `preferred_language` | Which SDK tab is active (e.g. `"typescript"`, `"node"`, `"python"`, `"cli"`) |
+| `highlight_theme` | Which syntax theme to render (e.g. `"github"`, `"atom-one-dark"`) |
+
+**Reading preferences** — initialise the active tab from `profile.preferred_language` inside a `useEffect` that watches that field:
+
+```typescript
+const { profile, updateProfile } = usePreferences();
+const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+useEffect(() => {
+  if (profile?.preferred_language) {
+    const lang = profile.preferred_language as PageTab;
+    setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+  }
+}, [profile?.preferred_language]);
+```
+
+**Saving preferences** — call `updateProfile` whenever the user switches tabs or changes the theme. `ThemeableCodeBlock` saves `highlight_theme` automatically on theme selector change. For the language tab, the page-level handler must persist it:
+
+```typescript
+const handleTabChange = (tab: PageTab) => {
+  setActiveTab(tab);
+  updateProfile({ preferred_language: tab }).catch(() => {});
+};
+```
+
+### Rules
+
+- **Always** use `language` prop values that exist in `languageMap` (`"typescript"`, `"javascript"`, `"python"`, `"bash"`, `"cli"`) — do **not** invent new strings without adding them to the map first
+- Pass `language="bash"` or `language="cli"` (both work) for shell/CLI examples
+- Pass `language="javascript"` for Node.js examples (not `"node"`)
+- Pass `showThemeSelector={false}` for inline snippets that don't need a theme picker
+- When a doc page has **multiple independent code sections**, drive all tab bars from a **single shared** `activeTab` state so switching language in one section updates all others automatically
+
+---
+
+## Code Conventions
+
+- **API routes** follow `/api/<resource>` pattern; route files live in `localcloud-api/routes/`
+- **GUI pages** use Next.js App Router under `localcloud-gui/src/app/`
+- **Shell scripts** are POSIX-compatible and live in `scripts/shell/`
+- **Logging** uses Winston on the backend; errors go to `logs/error.log`
+- **Docker images** use `node:22-alpine` as the base for Node services
+- **TypeScript** strict mode is enabled in the GUI
+
+---
+
+## Git Branch Convention
+
+- All agent work happens on branches prefixed `claude/` followed by a short description and a unique session ID suffix
+- Example: `claude/add-iam-roles-localstack-OWviN`
+- **Never push to `main` directly**
+- Always push with `git push -u origin <branch-name>`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,17 +190,51 @@ Entries go under `## [Unreleased]` at the top of the file. Use these subsections
 
 ---
 
-## Pre-Commit Build Check
+## Pre-Commit Checklist
 
-**Run the GUI build before committing any changes that touch `localcloud-gui/`.**
+Run through every applicable item below before committing. The checklist is ordered: build first, then docs, then changelog.
+
+### 1 — GUI Build (required for any `localcloud-gui/` change)
 
 ```bash
 cd localcloud-gui && npm run build
 ```
 
-- The build must pass with **no type errors** before committing — fix any errors first
+- Must pass with **no type errors** — fix all errors before committing
 - Warnings are acceptable; type errors and compile failures are not
-- For backend-only or shell-script-only changes the build is not required, but run it when in doubt
+- Skip only for backend-only or shell-script-only changes (run it when in doubt)
+
+### 2 — Documentation Update
+
+Update the matching `docs/` markdown file **whenever** you change behaviour, add endpoints, rename things, or add a new service. The rule is: **if the code changed, the docs change too.**
+
+| Change type | Files to update |
+|---|---|
+| New AWS service or platform service | `docs/<SERVICE>.md` (create if missing), `README.md` features list |
+| New or changed API endpoint | `docs/<SERVICE>.md` — endpoint reference table |
+| New GUI page or major UI change | `docs/<SERVICE>.md` — usage section |
+| Changed port, hostname, or env var | `docs/<SERVICE>.md`, `README.md` configuration section, `CLAUDE.md` if it references the value |
+| New or changed shell script | `docs/SETUP_SCRIPTS.md` — script inventory |
+| New Docker service | `docker-compose.yml` comment block + `docs/DOCKER.md` |
+| Changed Makefile target | `README.md` common commands section |
+
+Docs live in `docs/` as plain markdown. Keep them concise: overview, connection settings or config, common operations, troubleshooting tips. Do **not** duplicate the SDK examples from the GUI doc pages verbatim — link to the relevant `/route` instead.
+
+### 3 — README Update
+
+Update `README.md` when any of the following change:
+
+- **Features list** — add a bullet for a new service or major capability
+- **Services table** — ports, image names, or purpose text
+- **Common commands** — new or renamed `make` targets
+- **Documentation section** — links to new `docs/` pages
+- **Version badge** — bump when the version in `docker-compose.yml` / `package.json` changes
+
+The README is user-facing. Write in plain, direct language. Do not include internal implementation details.
+
+### 4 — Changelog Update (PR step only)
+
+`CHANGELOG.md` is updated **once per PR**, as the last commit before opening the PR — never mid-feature. See the [Changelog Standards](#changelog-standards) section for the full format and rules.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,58 @@ Shows health of all platform services in alphabetical order: **Keycloak | LocalS
 
 ---
 
+## Syntax Highlighting on Doc Pages
+
+All doc pages use `ThemeableCodeBlock` (`localcloud-gui/src/components/ThemeableCodeBlock.tsx`) for syntax-highlighted code examples.
+
+### How it works
+
+- **Highlighting engine**: `highlight.js` via `hljs.highlight(code, { language })` — runs client-side only (`"use client"`)
+- **Theme CSS**: Injected into `<head>` as a `<link>` tag pointing to `/public/hljs-themes/<file>.css`; available themes are declared in `highlightThemes.ts`
+- **Language mapping**: The `languageMap` object inside `ThemeableCodeBlock` translates the `language` prop (e.g. `"cli"`, `"node"`, `"bash"`) into an `hljs` language identifier. **Always add a mapping for every language string you pass as a prop.** Missing entries fall through to `"text"` (no highlighting).
+
+### Profile preferences
+
+Two fields in the user profile drive this component's behaviour:
+
+| Field | Purpose |
+|---|---|
+| `preferred_language` | Which SDK tab is active (e.g. `"typescript"`, `"node"`, `"python"`, `"cli"`) |
+| `highlight_theme` | Which syntax theme to render (e.g. `"github"`, `"atom-one-dark"`) |
+
+**Reading preferences** — initialise the active tab from `profile.preferred_language` inside a `useEffect` that watches that field:
+
+```typescript
+const { profile, updateProfile } = usePreferences();
+const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+
+useEffect(() => {
+  if (profile?.preferred_language) {
+    const lang = profile.preferred_language as PageTab;
+    setActiveTab(PAGE_TABS.includes(lang) ? lang : "typescript");
+  }
+}, [profile?.preferred_language]);
+```
+
+**Saving preferences** — call `updateProfile` whenever the user switches tabs or changes the theme. The `ThemeableCodeBlock` component already saves `highlight_theme` automatically when the theme selector changes. For the language tab, the page-level handler must persist it:
+
+```typescript
+const handleTabChange = (tab: PageTab) => {
+  setActiveTab(tab);
+  updateProfile({ preferred_language: tab }).catch(() => {});
+};
+```
+
+### Rules
+
+- **Always** use the `language` prop values that exist in `languageMap` (`"typescript"`, `"javascript"`, `"python"`, `"bash"`, `"cli"`) — do **not** invent new strings without adding them to the map first
+- Pass `language="bash"` or `language="cli"` (both work) for shell/CLI examples
+- For Node.js examples pass `language="javascript"` (not `"node"`)
+- The `showThemeSelector` prop defaults to `true`; pass `showThemeSelector={false}` for inline snippets that don't need a theme picker
+- When a doc page has **multiple independent code sections** (e.g. "Roles" and "Session Credentials"), drive all tab bars from a **single shared** `activeTab` state so switching language in one section updates all others automatically
+
+---
+
 ## Code Conventions
 
 - **API routes** follow `/api/<resource>` pattern in `server.js`

--- a/localcloud-api/lib/resources.js
+++ b/localcloud-api/lib/resources.js
@@ -119,6 +119,10 @@ export async function createSingleResource(projectName, resourceType, config = {
       command += ` --config '${escapeConfigForShell(JSON.stringify(config.ssmConfig))}'`;
     }
 
+    if (resourceType === "iam" && config.iamConfig) {
+      command += ` --config '${escapeConfigForShell(JSON.stringify(config.iamConfig))}'`;
+    }
+
     console.log("[DEBUG] Running command:", command);
 
     const { stdout, stderr } = await execAsync(command, {

--- a/localcloud-api/routes/iam.js
+++ b/localcloud-api/routes/iam.js
@@ -1,0 +1,214 @@
+import express from "express";
+import { execAsync, internalEndpoint, awsRegion, awsEnv } from "../lib/aws.js";
+import { addLog } from "../lib/context.js";
+
+const router = express.Router();
+
+// List IAM roles
+router.get("/iam/roles", async (req, res) => {
+  try {
+    const { pathPrefix = "" } = req.query;
+    const cmd = pathPrefix
+      ? `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-roles --path-prefix "${pathPrefix}" --output json`
+      : `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-roles --output json`;
+
+    const { stdout, stderr } = await execAsync(cmd, { env: awsEnv() });
+    if (stderr) addLog("warn", `IAM list-roles warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data: data.Roles || [] });
+  } catch (error) {
+    addLog("error", `Failed to list IAM roles: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list IAM roles", message: error.message });
+  }
+});
+
+// Get a single IAM role
+router.get("/iam/roles/:roleName", async (req, res) => {
+  try {
+    const { roleName } = req.params;
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam get-role --role-name "${roleName}" --output json`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM get-role warning: ${stderr}`, "automation");
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data: data.Role });
+  } catch (error) {
+    addLog("error", `Failed to get IAM role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get IAM role", message: error.message });
+  }
+});
+
+// Create IAM role
+router.post("/iam/roles", async (req, res) => {
+  try {
+    const { roleName, trustPolicy, description, path = "/" } = req.body;
+
+    if (!roleName || !trustPolicy) {
+      return res.status(400).json({ success: false, error: "roleName and trustPolicy are required" });
+    }
+
+    // Validate trustPolicy is valid JSON
+    let trustPolicyStr;
+    try {
+      trustPolicyStr = typeof trustPolicy === "string" ? trustPolicy : JSON.stringify(trustPolicy);
+      JSON.parse(trustPolicyStr); // validate
+    } catch {
+      return res.status(400).json({ success: false, error: "trustPolicy must be valid JSON" });
+    }
+
+    let cmd = `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam create-role --role-name "${roleName}" --assume-role-policy-document '${trustPolicyStr.replace(/'/g, "'\"'\"'")}'`;
+    if (description) cmd += ` --description "${description}"`;
+    if (path && path !== "/") cmd += ` --path "${path}"`;
+
+    const { stdout, stderr } = await execAsync(cmd, { env: awsEnv() });
+    if (stderr) addLog("warn", `IAM create-role warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    addLog("success", `IAM role ${roleName} created`, "automation");
+    res.json({ success: true, data: data.Role });
+  } catch (error) {
+    addLog("error", `Failed to create IAM role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to create IAM role", message: error.message });
+  }
+});
+
+// Attach managed policy to role
+router.post("/iam/roles/:roleName/policies", async (req, res) => {
+  try {
+    const { roleName } = req.params;
+    const { policyArn } = req.body;
+
+    if (!policyArn) {
+      return res.status(400).json({ success: false, error: "policyArn is required" });
+    }
+
+    const { stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam attach-role-policy --role-name "${roleName}" --policy-arn "${policyArn}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM attach-role-policy warning: ${stderr}`, "automation");
+
+    addLog("success", `Policy ${policyArn} attached to role ${roleName}`, "automation");
+    res.json({ success: true, data: { roleName, policyArn, message: "Policy attached successfully" } });
+  } catch (error) {
+    addLog("error", `Failed to attach policy to role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to attach policy", message: error.message });
+  }
+});
+
+// List policies attached to a role
+router.get("/iam/roles/:roleName/policies", async (req, res) => {
+  try {
+    const { roleName } = req.params;
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-attached-role-policies --role-name "${roleName}" --output json`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM list-attached-role-policies warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data: data.AttachedPolicies || [] });
+  } catch (error) {
+    addLog("error", `Failed to list role policies: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list role policies", message: error.message });
+  }
+});
+
+// Detach managed policy from role
+router.delete("/iam/roles/:roleName/policies/:policyName", async (req, res) => {
+  try {
+    const { roleName, policyName } = req.params;
+    const { policyArn } = req.query;
+
+    if (!policyArn) {
+      return res.status(400).json({ success: false, error: "policyArn query parameter is required" });
+    }
+
+    const { stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam detach-role-policy --role-name "${roleName}" --policy-arn "${policyArn}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM detach-role-policy warning: ${stderr}`, "automation");
+
+    addLog("success", `Policy ${policyArn} detached from role ${roleName}`, "automation");
+    res.json({ success: true, data: { roleName, policyArn, message: "Policy detached successfully" } });
+  } catch (error) {
+    addLog("error", `Failed to detach policy from role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to detach policy", message: error.message });
+  }
+});
+
+// Delete IAM role (detaches policies first)
+router.delete("/iam/roles/:roleName", async (req, res) => {
+  try {
+    const { roleName } = req.params;
+
+    // Detach all managed policies first
+    try {
+      const { stdout } = await execAsync(
+        `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-attached-role-policies --role-name "${roleName}" --output json`,
+        { env: awsEnv() }
+      );
+      const policies = JSON.parse(stdout).AttachedPolicies || [];
+      for (const policy of policies) {
+        await execAsync(
+          `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam detach-role-policy --role-name "${roleName}" --policy-arn "${policy.PolicyArn}"`,
+          { env: awsEnv() }
+        );
+      }
+    } catch {
+      // Ignore errors during cleanup
+    }
+
+    const { stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam delete-role --role-name "${roleName}"`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM delete-role warning: ${stderr}`, "automation");
+
+    addLog("success", `IAM role ${roleName} deleted`, "automation");
+    res.json({ success: true, data: { roleName, message: `IAM role ${roleName} deleted successfully` } });
+  } catch (error) {
+    addLog("error", `Failed to delete IAM role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to delete IAM role", message: error.message });
+  }
+});
+
+// List IAM users
+router.get("/iam/users", async (req, res) => {
+  try {
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-users --output json`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM list-users warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data: data.Users || [] });
+  } catch (error) {
+    addLog("error", `Failed to list IAM users: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list IAM users", message: error.message });
+  }
+});
+
+// List managed policies
+router.get("/iam/policies", async (req, res) => {
+  try {
+    const { scope = "Local" } = req.query;
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} iam list-policies --scope ${scope} --output json`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `IAM list-policies warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data: data.Policies || [] });
+  } catch (error) {
+    addLog("error", `Failed to list IAM policies: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to list IAM policies", message: error.message });
+  }
+});
+
+export default router;

--- a/localcloud-api/routes/iam.js
+++ b/localcloud-api/routes/iam.js
@@ -211,4 +211,72 @@ router.get("/iam/policies", async (req, res) => {
   }
 });
 
+// ── STS Session Credentials ──────────────────────────────────────────────────
+
+// Get temporary session credentials (sts:GetSessionToken)
+router.post("/iam/sessions/token", async (req, res) => {
+  try {
+    const { durationSeconds = 3600, serialNumber, tokenCode } = req.body;
+
+    let cmd = `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} sts get-session-token --duration-seconds ${durationSeconds} --output json`;
+    if (serialNumber) cmd += ` --serial-number "${serialNumber}"`;
+    if (tokenCode) cmd += ` --token-code "${tokenCode}"`;
+
+    const { stdout, stderr } = await execAsync(cmd, { env: awsEnv() });
+    if (stderr) addLog("warn", `STS get-session-token warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    addLog("success", "STS session token generated", "automation");
+    res.json({ success: true, data: data.Credentials });
+  } catch (error) {
+    addLog("error", `Failed to get session token: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get session token", message: error.message });
+  }
+});
+
+// Assume a role and get temporary credentials (sts:AssumeRole)
+router.post("/iam/sessions/assume-role", async (req, res) => {
+  try {
+    const { roleArn, sessionName, durationSeconds = 3600, externalId, policy } = req.body;
+
+    if (!roleArn || !sessionName) {
+      return res.status(400).json({ success: false, error: "roleArn and sessionName are required" });
+    }
+
+    let cmd = `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} sts assume-role --role-arn "${roleArn}" --role-session-name "${sessionName}" --duration-seconds ${durationSeconds} --output json`;
+    if (externalId) cmd += ` --external-id "${externalId}"`;
+    if (policy) {
+      const policyStr = typeof policy === "string" ? policy : JSON.stringify(policy);
+      cmd += ` --policy '${policyStr.replace(/'/g, "'\"'\"'")}'`;
+    }
+
+    const { stdout, stderr } = await execAsync(cmd, { env: awsEnv() });
+    if (stderr) addLog("warn", `STS assume-role warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    addLog("success", `STS assumed role ${roleArn} as session "${sessionName}"`, "automation");
+    res.json({ success: true, data: { credentials: data.Credentials, assumedRoleUser: data.AssumedRoleUser } });
+  } catch (error) {
+    addLog("error", `Failed to assume role: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to assume role", message: error.message });
+  }
+});
+
+// Get caller identity (sts:GetCallerIdentity)
+router.get("/iam/sessions/identity", async (req, res) => {
+  try {
+    const { stdout, stderr } = await execAsync(
+      `aws --endpoint-url=${internalEndpoint} --region=${awsRegion} sts get-caller-identity --output json`,
+      { env: awsEnv() }
+    );
+    if (stderr) addLog("warn", `STS get-caller-identity warning: ${stderr}`, "automation");
+
+    const data = JSON.parse(stdout);
+    res.json({ success: true, data });
+  } catch (error) {
+    addLog("error", `Failed to get caller identity: ${error.message}`, "automation");
+    res.status(500).json({ success: false, error: "Failed to get caller identity", message: error.message });
+  }
+});
+
 export default router;

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -27,6 +27,7 @@ import keycloakRouter from "./routes/keycloak.js";
 import lambdaRouter from "./routes/lambda.js";
 import apigatewayRouter from "./routes/apigateway.js";
 import ssmRouter from "./routes/ssm.js";
+import iamRouter from "./routes/iam.js";
 
 const app = express();
 const server = http.createServer(app);
@@ -69,6 +70,7 @@ app.use(keycloakRouter);
 app.use(lambdaRouter);
 app.use(apigatewayRouter);
 app.use(ssmRouter);
+app.use(iamRouter);
 
 // Socket.IO connection handling
 io.on("connection", (socket) => {

--- a/localcloud-gui/package-lock.json
+++ b/localcloud-gui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "localcloud-gui",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "localcloud-gui",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "@iconify/react": "^6.0.2",
@@ -30,7 +30,7 @@
         "eslint-config-next": "15.5.12",
         "postcss": "^8.5.8",
         "tailwindcss": "^4.2.1",
-        "typescript": "^5"
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1377,20 +1377,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
-      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.0.tgz",
+      "integrity": "sha512-qeu4rTHR3/IaFORbD16gmjq9+rEs9fGKdX0kF6BKSfi+gCuG3RCKLlSBYzn/bGsY9Tj7KE/DAQStbp8AHJGHEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/type-utils": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/type-utils": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1400,9 +1400,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.35.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "@typescript-eslint/parser": "^8.57.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1410,21 +1410,23 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
-      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1434,19 +1436,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
-      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.1",
-        "@typescript-eslint/types": "^8.35.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1456,17 +1459,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
-      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1"
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1477,10 +1481,11 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
-      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1489,19 +1494,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
-      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.0.tgz",
+      "integrity": "sha512-yjgh7gmDcJ1+TcEg8x3uWQmn8ifvSupnPfjP21twPKrDP/pTHlEQgmKcitzF/rzPSmv7QjJ90vRpN4U+zoUjwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.1",
-        "@typescript-eslint/utils": "8.35.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1511,15 +1518,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
-      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1529,21 +1537,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
-      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.1",
-        "@typescript-eslint/tsconfig-utils": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/visitor-keys": "8.35.1",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1553,72 +1561,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
-      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.1",
-        "@typescript-eslint/types": "8.35.1",
-        "@typescript-eslint/typescript-estree": "8.35.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1628,18 +1623,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
-      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1650,12 +1646,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2486,9 +2483,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3642,13 +3639,6 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -5914,14 +5904,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5931,11 +5921,14 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -5946,9 +5939,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5971,10 +5964,11 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -6093,9 +6087,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/localcloud-gui/package.json
+++ b/localcloud-gui/package.json
@@ -31,6 +31,6 @@
     "eslint-config-next": "15.5.12",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.1",
-    "typescript": "^5"
+    "typescript": "5.9.3"
   }
 }

--- a/localcloud-gui/src/app/iam/page.tsx
+++ b/localcloud-gui/src/app/iam/page.tsx
@@ -1,0 +1,555 @@
+"use client";
+
+import { ArrowTopRightOnSquareIcon, ShieldCheckIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import DocPageNav from "@/components/DocPageNav";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+import ServiceStatusBadge from "@/components/ServiceStatusBadge";
+
+const PAGE_TABS = ["typescript", "node", "python", "cli"] as const;
+type PageTab = (typeof PAGE_TABS)[number];
+
+// ── IAM Roles examples ────────────────────────────────────────────────────────
+
+const roleExamples = {
+  typescript: `// npm install @aws-sdk/client-iam
+import {
+  IAMClient,
+  CreateRoleCommand,
+  GetRoleCommand,
+  ListRolesCommand,
+  DeleteRoleCommand,
+  AttachRolePolicyCommand,
+  DetachRolePolicyCommand,
+  ListAttachedRolePoliciesCommand,
+} from "@aws-sdk/client-iam";
+
+const iam = new IAMClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Create a role that Lambda can assume
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [{
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  }],
+});
+
+const { Role } = await iam.send(new CreateRoleCommand({
+  RoleName: "my-lambda-execution-role",
+  AssumeRolePolicyDocument: trustPolicy,
+  Description: "Execution role for my Lambda function",
+}));
+console.log(Role?.Arn);
+
+// Attach a managed policy
+await iam.send(new AttachRolePolicyCommand({
+  RoleName: "my-lambda-execution-role",
+  PolicyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+}));
+
+// List attached policies
+const { AttachedPolicies } = await iam.send(new ListAttachedRolePoliciesCommand({
+  RoleName: "my-lambda-execution-role",
+}));
+AttachedPolicies?.forEach((p) => console.log(p.PolicyName, p.PolicyArn));
+
+// List all roles
+const { Roles } = await iam.send(new ListRolesCommand({}));
+Roles?.forEach((r) => console.log(r.RoleName, r.Arn));
+
+// Delete a role (detach policies first)
+await iam.send(new DetachRolePolicyCommand({
+  RoleName: "my-lambda-execution-role",
+  PolicyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+}));
+await iam.send(new DeleteRoleCommand({ RoleName: "my-lambda-execution-role" }));`,
+
+  node: `// npm install @aws-sdk/client-iam
+import {
+  IAMClient,
+  CreateRoleCommand,
+  ListRolesCommand,
+  DeleteRoleCommand,
+  AttachRolePolicyCommand,
+  DetachRolePolicyCommand,
+} from "@aws-sdk/client-iam";
+
+const iam = new IAMClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+const trustPolicy = JSON.stringify({
+  Version: "2012-10-17",
+  Statement: [{
+    Effect: "Allow",
+    Principal: { Service: "lambda.amazonaws.com" },
+    Action: "sts:AssumeRole",
+  }],
+});
+
+// Create role
+const { Role } = await iam.send(new CreateRoleCommand({
+  RoleName: "my-lambda-execution-role",
+  AssumeRolePolicyDocument: trustPolicy,
+}));
+console.log(Role.Arn);
+
+// Attach policy
+await iam.send(new AttachRolePolicyCommand({
+  RoleName: "my-lambda-execution-role",
+  PolicyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+}));
+
+// List roles
+const { Roles } = await iam.send(new ListRolesCommand({}));
+console.log(Roles.map((r) => r.RoleName));`,
+
+  python: `# pip install boto3
+import boto3
+import json
+
+iam = boto3.client(
+    "iam",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+trust_policy = json.dumps({
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Service": "lambda.amazonaws.com"},
+        "Action": "sts:AssumeRole",
+    }],
+})
+
+# Create a role
+response = iam.create_role(
+    RoleName="my-lambda-execution-role",
+    AssumeRolePolicyDocument=trust_policy,
+    Description="Execution role for my Lambda function",
+)
+print(response["Role"]["Arn"])
+
+# Attach a managed policy
+iam.attach_role_policy(
+    RoleName="my-lambda-execution-role",
+    PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+)
+
+# List roles
+roles = iam.list_roles()["Roles"]
+for r in roles:
+    print(r["RoleName"], r["Arn"])
+
+# Delete a role (detach policies first)
+iam.detach_role_policy(
+    RoleName="my-lambda-execution-role",
+    PolicyArn="arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+)
+iam.delete_role(RoleName="my-lambda-execution-role")`,
+
+  cli: `# Create a role (save trust policy to a file)
+cat > /tmp/trust-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": "lambda.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+
+aws --endpoint-url=http://localhost:4566 \\
+  iam create-role \\
+  --role-name my-lambda-execution-role \\
+  --assume-role-policy-document file:///tmp/trust-policy.json \\
+  --description "Execution role for my Lambda function"
+
+# Attach a managed policy
+aws --endpoint-url=http://localhost:4566 \\
+  iam attach-role-policy \\
+  --role-name my-lambda-execution-role \\
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+# List attached policies
+aws --endpoint-url=http://localhost:4566 \\
+  iam list-attached-role-policies \\
+  --role-name my-lambda-execution-role
+
+# List all roles
+aws --endpoint-url=http://localhost:4566 iam list-roles
+
+# Delete a role
+aws --endpoint-url=http://localhost:4566 \\
+  iam detach-role-policy \\
+  --role-name my-lambda-execution-role \\
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+aws --endpoint-url=http://localhost:4566 \\
+  iam delete-role \\
+  --role-name my-lambda-execution-role`,
+};
+
+// ── STS Session Credentials examples ─────────────────────────────────────────
+
+const sessionExamples = {
+  typescript: `// npm install @aws-sdk/client-sts
+import { STSClient, GetSessionTokenCommand, AssumeRoleCommand, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
+
+const sts = new STSClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Get temporary session credentials
+const { Credentials } = await sts.send(new GetSessionTokenCommand({
+  DurationSeconds: 3600, // 1 hour
+}));
+console.log(Credentials?.AccessKeyId);
+console.log(Credentials?.SecretAccessKey);
+console.log(Credentials?.SessionToken);
+console.log(Credentials?.Expiration);
+
+// Assume a role and get temporary credentials
+const result = await sts.send(new AssumeRoleCommand({
+  RoleArn: "arn:aws:iam::000000000000:role/my-lambda-execution-role",
+  RoleSessionName: "my-session",
+  DurationSeconds: 3600,
+}));
+const { AccessKeyId, SecretAccessKey, SessionToken } = result.Credentials!;
+
+// Use the temporary credentials with another client
+import { S3Client, ListBucketsCommand } from "@aws-sdk/client-s3";
+const s3AsRole = new S3Client({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: AccessKeyId!, secretAccessKey: SecretAccessKey!, sessionToken: SessionToken },
+});
+const { Buckets } = await s3AsRole.send(new ListBucketsCommand({}));
+console.log(Buckets);
+
+// Get the current caller identity
+const identity = await sts.send(new GetCallerIdentityCommand({}));
+console.log(identity.Account, identity.UserId, identity.Arn);`,
+
+  node: `// npm install @aws-sdk/client-sts
+import { STSClient, GetSessionTokenCommand, AssumeRoleCommand } from "@aws-sdk/client-sts";
+
+const sts = new STSClient({
+  region: "us-east-1",
+  endpoint: "http://localhost:4566",
+  credentials: { accessKeyId: "test", secretAccessKey: "test" },
+});
+
+// Get temporary session credentials (valid for 1 hour)
+const { Credentials } = await sts.send(new GetSessionTokenCommand({ DurationSeconds: 3600 }));
+console.log("AccessKeyId:", Credentials.AccessKeyId);
+console.log("Expires:", Credentials.Expiration);
+
+// Assume a role
+const { Credentials: roleCreds, AssumedRoleUser } = await sts.send(new AssumeRoleCommand({
+  RoleArn: "arn:aws:iam::000000000000:role/my-lambda-execution-role",
+  RoleSessionName: "my-session",
+}));
+console.log("Assumed role ARN:", AssumedRoleUser.Arn);
+console.log("Session AccessKeyId:", roleCreds.AccessKeyId);`,
+
+  python: `# pip install boto3
+import boto3
+
+sts = boto3.client(
+    "sts",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test",
+)
+
+# Get temporary session credentials
+response = sts.get_session_token(DurationSeconds=3600)
+creds = response["Credentials"]
+print("AccessKeyId:", creds["AccessKeyId"])
+print("SecretAccessKey:", creds["SecretAccessKey"])
+print("SessionToken:", creds["SessionToken"])
+print("Expiration:", creds["Expiration"])
+
+# Assume a role
+response = sts.assume_role(
+    RoleArn="arn:aws:iam::000000000000:role/my-lambda-execution-role",
+    RoleSessionName="my-session",
+    DurationSeconds=3600,
+)
+role_creds = response["Credentials"]
+assumed_user = response["AssumedRoleUser"]
+print("Assumed role ARN:", assumed_user["Arn"])
+
+# Use the temporary credentials
+s3_as_role = boto3.client(
+    "s3",
+    region_name="us-east-1",
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id=role_creds["AccessKeyId"],
+    aws_secret_access_key=role_creds["SecretAccessKey"],
+    aws_session_token=role_creds["SessionToken"],
+)
+buckets = s3_as_role.list_buckets()["Buckets"]
+print(buckets)
+
+# Get caller identity
+identity = sts.get_caller_identity()
+print(identity["Account"], identity["UserId"], identity["Arn"])`,
+
+  cli: `# Get temporary session credentials
+aws --endpoint-url=http://localhost:4566 \\
+  sts get-session-token \\
+  --duration-seconds 3600
+
+# Output:
+# {
+#   "Credentials": {
+#     "AccessKeyId": "...",
+#     "SecretAccessKey": "...",
+#     "SessionToken": "...",
+#     "Expiration": "2026-01-01T00:00:00+00:00"
+#   }
+# }
+
+# Assume a role and get temporary credentials
+aws --endpoint-url=http://localhost:4566 \\
+  sts assume-role \\
+  --role-arn arn:aws:iam::000000000000:role/my-lambda-execution-role \\
+  --role-session-name my-session \\
+  --duration-seconds 3600
+
+# Use assumed-role credentials in subsequent commands
+export AWS_ACCESS_KEY_ID=<AccessKeyId from above>
+export AWS_SECRET_ACCESS_KEY=<SecretAccessKey from above>
+export AWS_SESSION_TOKEN=<SessionToken from above>
+
+aws --endpoint-url=http://localhost:4566 s3 ls
+
+# Verify caller identity
+aws --endpoint-url=http://localhost:4566 sts get-caller-identity
+
+# LocalCloud Kit API endpoints
+# GET  session credentials: POST /api/iam/sessions/token
+# Assume role credentials:  POST /api/iam/sessions/assume-role
+# Caller identity:          GET  /api/iam/sessions/identity`,
+};
+
+const externalResources = [
+  { name: "AWS IAM Docs", url: "https://docs.aws.amazon.com/IAM/latest/UserGuide/", description: "Official IAM user guide" },
+  { name: "AWS STS Docs", url: "https://docs.aws.amazon.com/STS/latest/APIReference/", description: "Security Token Service API reference" },
+  { name: "LocalStack IAM", url: "https://docs.localstack.cloud/references/coverage/coverage_iam/", description: "LocalStack IAM feature coverage" },
+  { name: "LocalStack STS", url: "https://docs.localstack.cloud/references/coverage/coverage_sts/", description: "LocalStack STS feature coverage" },
+  { name: "@aws-sdk/client-iam", url: "https://www.npmjs.com/package/@aws-sdk/client-iam", description: "AWS SDK v3 IAM client" },
+  { name: "@aws-sdk/client-sts", url: "https://www.npmjs.com/package/@aws-sdk/client-sts", description: "AWS SDK v3 STS client" },
+];
+
+export default function IAMDocPage() {
+  const { profile, updateProfile } = usePreferences();
+  const [activeTab, setActiveTab] = useState<PageTab>("typescript");
+  const [activeSessionTab, setActiveSessionTab] = useState<PageTab>("typescript");
+
+  useEffect(() => {
+    if (profile?.preferred_language) {
+      const lang = profile.preferred_language as PageTab;
+      const resolved = PAGE_TABS.includes(lang) ? lang : "typescript";
+      setActiveTab(resolved);
+      setActiveSessionTab(resolved);
+    }
+  }, [profile?.preferred_language]);
+
+  const handleTabChange = (tab: PageTab) => {
+    setActiveTab(tab);
+    setActiveSessionTab(tab);
+    updateProfile({ preferred_language: tab }).catch(() => {});
+  };
+
+  const tabBar = (current: PageTab, onChange: (t: PageTab) => void) => (
+    <div className="flex space-x-1 mb-4 border-b border-gray-200">
+      {([
+        { key: "typescript" as const, label: "TypeScript" },
+        { key: "node" as const, label: "Node.js" },
+        { key: "python" as const, label: "Python" },
+        { key: "cli" as const, label: "AWS CLI" },
+      ]).map(({ key, label }) => (
+        <button
+          key={key}
+          onClick={() => onChange(key)}
+          className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
+            current === key
+              ? "border-red-600 text-red-600"
+              : "border-transparent text-gray-500 hover:text-gray-700"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-red-50 to-orange-100">
+      <DocPageNav title="IAM & STS" subtitle="Roles, policies, and session credentials via LocalStack">
+        <ServiceStatusBadge service="localstack" name="LocalStack" />
+        <Link
+          href="/"
+          className="flex items-center px-3 py-1.5 text-sm font-medium text-red-700 bg-red-50 rounded-lg hover:bg-red-100 transition-colors"
+        >
+          <ShieldCheckIcon className="h-4 w-4 mr-1.5" />
+          Manage IAM
+        </Link>
+      </DocPageNav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+
+        {/* Overview */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">About IAM &amp; STS</h2>
+          <p className="text-sm text-gray-600 leading-relaxed">
+            LocalCloud Kit emulates <strong>AWS Identity and Access Management (IAM)</strong> and
+            the <strong>Security Token Service (STS)</strong> via LocalStack. IAM lets you create
+            roles and attach policies that define what AWS services and resources can be accessed.
+            STS lets you generate temporary, short-lived credentials for those roles.
+          </p>
+          <p className="text-sm text-gray-600 leading-relaxed mt-2">
+            Use IAM roles when you need to delegate access between services — for example, granting
+            a Lambda function permission to read from S3 or write to DynamoDB. Use STS to assume
+            those roles programmatically and receive temporary credentials with a configurable
+            expiry.
+          </p>
+        </section>
+
+        {/* Connection Settings */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Connection Settings</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Setting</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Value</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                <tr><td className="px-4 py-2.5 text-gray-600">Endpoint (host)</td><td className="px-4 py-2.5 font-mono text-gray-900">http://localhost:4566</td></tr>
+                <tr><td className="px-4 py-2.5 text-gray-600">Endpoint (Docker)</td><td className="px-4 py-2.5 font-mono text-gray-900">http://localstack:4566</td></tr>
+                <tr><td className="px-4 py-2.5 text-gray-600">Region</td><td className="px-4 py-2.5 font-mono text-gray-900">us-east-1</td></tr>
+                <tr><td className="px-4 py-2.5 text-gray-600">Access Key ID</td><td className="px-4 py-2.5 font-mono text-gray-900">test</td></tr>
+                <tr><td className="px-4 py-2.5 text-gray-600">Secret Access Key</td><td className="px-4 py-2.5 font-mono text-gray-900">test</td></tr>
+                <tr><td className="px-4 py-2.5 text-gray-600">Account ID (LocalStack)</td><td className="px-4 py-2.5 font-mono text-gray-900">000000000000</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* IAM Roles */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">IAM Roles</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Create roles with trust policies, attach managed policies, and delete roles.
+          </p>
+          {tabBar(activeTab, handleTabChange)}
+          {activeTab === "typescript" && <ThemeableCodeBlock code={roleExamples.typescript} language="typescript" />}
+          {activeTab === "node" && <ThemeableCodeBlock code={roleExamples.node} language="javascript" />}
+          {activeTab === "python" && <ThemeableCodeBlock code={roleExamples.python} language="python" />}
+          {activeTab === "cli" && <ThemeableCodeBlock code={roleExamples.cli} language="bash" />}
+        </section>
+
+        {/* STS Session Credentials */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">Session Credentials</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Use STS to get temporary credentials via <code className="bg-gray-100 px-1 rounded font-mono text-xs">GetSessionToken</code> or
+            assume an IAM role with <code className="bg-gray-100 px-1 rounded font-mono text-xs">AssumeRole</code>.
+          </p>
+          {tabBar(activeSessionTab, handleTabChange)}
+          {activeSessionTab === "typescript" && <ThemeableCodeBlock code={sessionExamples.typescript} language="typescript" />}
+          {activeSessionTab === "node" && <ThemeableCodeBlock code={sessionExamples.node} language="javascript" />}
+          {activeSessionTab === "python" && <ThemeableCodeBlock code={sessionExamples.python} language="python" />}
+          {activeSessionTab === "cli" && <ThemeableCodeBlock code={sessionExamples.cli} language="bash" />}
+        </section>
+
+        {/* LocalCloud Kit API Endpoints */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">LocalCloud Kit API</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Method</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Path</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white font-mono text-xs">
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/roles</td><td className="px-4 py-2.5 font-sans text-gray-600">List all IAM roles</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/roles/:roleName</td><td className="px-4 py-2.5 font-sans text-gray-600">Get a single IAM role</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-blue-700 font-semibold">POST</span></td><td className="px-4 py-2.5">/api/iam/roles</td><td className="px-4 py-2.5 font-sans text-gray-600">Create an IAM role</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-red-700 font-semibold">DELETE</span></td><td className="px-4 py-2.5">/api/iam/roles/:roleName</td><td className="px-4 py-2.5 font-sans text-gray-600">Delete an IAM role (auto-detaches policies)</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/roles/:roleName/policies</td><td className="px-4 py-2.5 font-sans text-gray-600">List attached policies on a role</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-blue-700 font-semibold">POST</span></td><td className="px-4 py-2.5">/api/iam/roles/:roleName/policies</td><td className="px-4 py-2.5 font-sans text-gray-600">Attach a managed policy to a role</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-red-700 font-semibold">DELETE</span></td><td className="px-4 py-2.5">/api/iam/roles/:roleName/policies/:name</td><td className="px-4 py-2.5 font-sans text-gray-600">Detach a managed policy from a role</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/users</td><td className="px-4 py-2.5 font-sans text-gray-600">List IAM users</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/policies</td><td className="px-4 py-2.5 font-sans text-gray-600">List managed policies</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-blue-700 font-semibold">POST</span></td><td className="px-4 py-2.5">/api/iam/sessions/token</td><td className="px-4 py-2.5 font-sans text-gray-600">Get temporary session credentials (GetSessionToken)</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-blue-700 font-semibold">POST</span></td><td className="px-4 py-2.5">/api/iam/sessions/assume-role</td><td className="px-4 py-2.5 font-sans text-gray-600">Assume a role and get credentials (AssumeRole)</td></tr>
+                <tr><td className="px-4 py-2.5"><span className="text-green-700 font-semibold">GET</span></td><td className="px-4 py-2.5">/api/iam/sessions/identity</td><td className="px-4 py-2.5 font-sans text-gray-600">Get caller identity (GetCallerIdentity)</td></tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Resources */}
+        <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">Resources</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {externalResources.map((r, idx) => (
+                  <tr key={`${r.name}-${idx}`}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={r.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-red-600 hover:underline font-medium"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        {r.name}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{r.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+      </div>
+    </main>
+  );
+}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -650,6 +650,14 @@ export default function Dashboard() {
                       <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                       Parameter Store
                     </Link>
+                    <Link
+                      href="/iam"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />
+                      IAM &amp; STS
+                    </Link>
 
                     {/* Platform Services */}
                     <div className="border-t border-gray-100 mt-1" />
@@ -878,6 +886,9 @@ export default function Dashboard() {
                 </Link>
                 <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
+                </Link>
+                <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />IAM &amp; STS
                 </Link>
                 <Link href="/mailpit" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />Mailpit

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@
 import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
 import { resourceApi } from "@/services/api";
-import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig } from "@/types";
+import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig } from "@/types";
 import {
   Bars3Icon,
   BookOpenIcon,
@@ -41,6 +41,7 @@ import APIGatewayConfigModal from "./APIGatewayConfigModal";
 import APIGatewayConfigViewer from "./APIGatewayConfigViewer";
 import SSMConfigModal from "./SSMConfigModal";
 import SSMEditModal from "./SSMEditModal";
+import IAMConfigModal from "./IAMConfigModal";
 import LambdaCodeModal from "./LambdaCodeModal";
 
 export default function Dashboard() {
@@ -67,6 +68,8 @@ export default function Dashboard() {
   const [showAPIGatewayConfig, setShowAPIGatewayConfig] = useState(false);
   const [showSSMConfig, setShowSSMConfig] = useState(false);
   const [showSSMEdit, setShowSSMEdit] = useState(false);
+  const [showIAMConfig, setShowIAMConfig] = useState(false);
+  const [viewingIAMRole, setViewingIAMRole] = useState<string>("");
   const [editingSSMParameter, setEditingSSMParameter] = useState<string>("");
   const [showLambdaCode, setShowLambdaCode] = useState(false);
   const [viewingLambdaFunction, setViewingLambdaFunction] = useState<string>("");
@@ -315,6 +318,27 @@ export default function Dashboard() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const apiMessage = (error as any)?.response?.data?.error;
       toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create SSM parameter"));
+    } finally {
+      setCreateLoading(false);
+    }
+  };
+
+  const handleCreateIAMRole = async (iamConfig: IAMRoleConfig) => {
+    setCreateLoading(true);
+    try {
+      const response = await resourceApi.createSingleWithConfig(projectName, "iam", { iamConfig });
+      if (response.success) {
+        toast.success("IAM role created successfully");
+        setShowIAMConfig(false);
+        setTimeout(async () => { await loadInitialData(); }, 1000);
+      } else {
+        toast.error(response.error || "Failed to create IAM role");
+      }
+    } catch (error) {
+      console.error("Create IAM role error:", error);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const apiMessage = (error as any)?.response?.data?.error;
+      toast.error(apiMessage || (error instanceof Error ? error.message : "Failed to create IAM role"));
     } finally {
       setCreateLoading(false);
     }
@@ -987,6 +1011,7 @@ export default function Dashboard() {
               onAddLambda={() => handleCreateSingleResource("lambda")}
               onAddAPIGateway={() => handleCreateSingleResource("apigateway")}
               onAddSSM={() => handleCreateSingleResource("ssm")}
+              onAddIAM={() => setShowIAMConfig(true)}
               refreshLoading={loading}
               addLoading={createLoading}
               onViewS3={(bucketName) => {
@@ -1007,6 +1032,7 @@ export default function Dashboard() {
                 setShowLambdaCode(true);
               }}
               onConfigureAPIGateway={(apiId, apiName) => setConfiguringAPIGateway({ apiId, apiName })}
+              onViewIAMRole={(roleName) => { setViewingIAMRole(roleName); }}
             />
           ) : (
             <div className="bg-white rounded-lg shadow border border-gray-200">
@@ -1161,6 +1187,16 @@ export default function Dashboard() {
           isOpen={showSSMConfig}
           onClose={() => setShowSSMConfig(false)}
           onSubmit={handleCreateSSMParameter}
+          projectName={projectName}
+          loading={createLoading}
+        />
+      )}
+
+      {showIAMConfig && (
+        <IAMConfigModal
+          isOpen={showIAMConfig}
+          onClose={() => setShowIAMConfig(false)}
+          onSubmit={handleCreateIAMRole}
           projectName={projectName}
           loading={createLoading}
         />

--- a/localcloud-gui/src/components/IAMConfigModal.tsx
+++ b/localcloud-gui/src/components/IAMConfigModal.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { IAMRoleConfig } from "@/types";
+
+// Common AWS service principals that can assume roles
+const TRUST_SERVICE_OPTIONS = [
+  { value: "lambda", label: "Lambda" },
+  { value: "ec2", label: "EC2" },
+  { value: "ecs-tasks", label: "ECS Tasks" },
+  { value: "apigateway", label: "API Gateway" },
+  { value: "states", label: "Step Functions" },
+  { value: "firehose", label: "Kinesis Firehose" },
+  { value: "s3", label: "S3" },
+];
+
+interface IAMConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (config: IAMRoleConfig) => void;
+  projectName: string;
+  loading?: boolean;
+}
+
+export default function IAMConfigModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  projectName,
+  loading = false,
+}: IAMConfigModalProps) {
+  const [roleName, setRoleName] = useState(`${projectName}-role`);
+  const [trustService, setTrustService] = useState("lambda");
+  const [description, setDescription] = useState("");
+  const [path, setPath] = useState("/");
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setRoleName(`${projectName}-role`);
+      setTrustService("lambda");
+      setDescription("");
+      setPath("/");
+    }
+  }, [isOpen, projectName]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ roleName, trustService, description, path });
+  };
+
+  const previewTrustPolicy = JSON.stringify(
+    {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: `${trustService}.amazonaws.com` },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    },
+    null,
+    2
+  );
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-red-50 rounded-lg">
+              <Icon icon="logos:aws-iam" className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Create IAM Role</h2>
+              <p className="text-xs text-gray-500">Add a new IAM role with a trust policy</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+            aria-label="Close"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+
+          {/* Role Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Role Name
+            </label>
+            <input
+              type="text"
+              value={roleName}
+              onChange={(e) => setRoleName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 text-gray-900"
+              placeholder="my-lambda-execution-role"
+              required
+            />
+          </div>
+
+          {/* Trusted Service */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Trusted AWS Service
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {TRUST_SERVICE_OPTIONS.map((opt) => (
+                <label
+                  key={opt.value}
+                  className={`flex items-center space-x-2 px-3 py-2 border rounded-md cursor-pointer transition-colors ${
+                    trustService === opt.value
+                      ? "border-red-500 bg-red-50 text-red-700"
+                      : "border-gray-300 hover:border-gray-400 text-gray-700"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="trustService"
+                    value={opt.value}
+                    checked={trustService === opt.value}
+                    onChange={() => setTrustService(opt.value)}
+                    className="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300"
+                  />
+                  <span className="text-sm">{opt.label}</span>
+                </label>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 mt-1">
+              The AWS service that can assume this role via <code className="bg-gray-100 px-1 rounded">sts:AssumeRole</code>.
+            </p>
+          </div>
+
+          {/* Trust Policy Preview */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Trust Policy Preview
+            </label>
+            <pre className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-md text-xs font-mono text-gray-700 overflow-x-auto whitespace-pre-wrap">
+              {previewTrustPolicy}
+            </pre>
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 text-gray-900"
+              placeholder="Execution role for my Lambda function"
+            />
+          </div>
+
+          {/* Path */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Path <span className="text-gray-400 font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 text-gray-900"
+              placeholder="/"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              IAM path for the role (e.g. <code className="bg-gray-100 px-1 rounded">/service-role/</code>). Defaults to <code className="bg-gray-100 px-1 rounded">/</code>.
+            </p>
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end space-x-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+              disabled={loading}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
+              disabled={loading || !roleName.trim()}
+            >
+              {loading ? "Creating..." : "Create Role"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -30,6 +30,7 @@ interface ResourceListProps {
   onEditSSM?: (parameterName: string) => void;
   onViewLambdaCode?: (functionName: string) => void;
   onConfigureAPIGateway?: (apiId: string, apiName: string) => void;
+  onViewIAMRole?: (roleName: string) => void;
   onRefresh?: () => void;
   onAddS3?: () => void;
   onAddDynamoDB?: () => void;
@@ -37,6 +38,7 @@ interface ResourceListProps {
   onAddLambda?: () => void;
   onAddAPIGateway?: () => void;
   onAddSSM?: () => void;
+  onAddIAM?: () => void;
   refreshLoading?: boolean;
   addLoading?: boolean;
 }
@@ -83,6 +85,7 @@ export default function ResourceList({
   onEditSSM,
   onViewLambdaCode,
   onConfigureAPIGateway,
+  onViewIAMRole,
   onRefresh,
   onAddS3,
   onAddDynamoDB,
@@ -90,6 +93,7 @@ export default function ResourceList({
   onAddLambda,
   onAddAPIGateway,
   onAddSSM,
+  onAddIAM,
   refreshLoading = false,
   addLoading = false,
 }: ResourceListProps) {
@@ -179,7 +183,7 @@ export default function ResourceList({
 
   const getApiId = (r: Resource) => r.details?.apiId || r.id.replace(/^apigateway-/, "");
 
-  const hasAddActions = onAddS3 || onAddDynamoDB || onAddSecrets || onAddLambda || onAddAPIGateway || onAddSSM;
+  const hasAddActions = onAddS3 || onAddDynamoDB || onAddSecrets || onAddLambda || onAddAPIGateway || onAddSSM || onAddIAM;
 
   return (
     <div className="bg-white rounded-lg shadow">
@@ -281,7 +285,7 @@ export default function ResourceList({
                         </button>
                       </>
                     )}
-                    {(onAddSecrets || onAddSSM) && (
+                    {(onAddSecrets || onAddSSM || onAddIAM) && (
                       <>
                         <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Security & Identity</p>
                         {onAddSecrets && (
@@ -300,6 +304,15 @@ export default function ResourceList({
                           >
                             <Icon icon="logos:aws-systems-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
                             Parameter Store
+                          </button>
+                        )}
+                        {onAddIAM && (
+                          <button
+                            onClick={() => { onAddIAM(); setShowAddMenu(false); }}
+                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            <Icon icon="logos:aws-iam" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            IAM Role
                           </button>
                         )}
                       </>
@@ -456,6 +469,16 @@ export default function ResourceList({
                                   Code
                                 </button>
                               )}
+                              {resource.type === "iam" && onViewIAMRole && (
+                                <button
+                                  onClick={() => onViewIAMRole(resource.name)}
+                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
+                                  title="View role policies"
+                                >
+                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  Policies
+                                </button>
+                              )}
                               {resource.type === "apigateway" && onConfigureAPIGateway && (
                                 <button
                                   onClick={() => onConfigureAPIGateway(getApiId(resource), resource.name)}
@@ -541,7 +564,50 @@ export default function ResourceList({
                               </>
                             )}
 
-                            {resource.type !== "secretsmanager" &&
+                            {resource.type === "iam" && resource.details && (
+                              <>
+                                {resource.details.arn && (
+                                  <div>
+                                    <dt className="font-medium text-gray-500">ARN</dt>
+                                    <dd className="text-gray-900 font-mono text-sm break-all">
+                                      <div className="flex items-center space-x-2">
+                                        <code className="flex-1 min-w-0">{resource.details.arn}</code>
+                                        <button
+                                          onClick={() => resource.details?.arn && copyArnToClipboard(resource.details.arn)}
+                                          className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                                          title="Copy ARN"
+                                        >
+                                          <ClipboardDocumentIcon className="h-4 w-4" />
+                                        </button>
+                                      </div>
+                                      {copiedArn === resource.details.arn && (
+                                        <p className="text-xs text-green-600 mt-1">✓ Copied to clipboard</p>
+                                      )}
+                                    </dd>
+                                  </div>
+                                )}
+                                {resource.details.trustService && (
+                                  <div>
+                                    <dt className="font-medium text-gray-500">Trusted Service</dt>
+                                    <dd className="text-gray-900 font-mono text-sm">{resource.details.trustService}.amazonaws.com</dd>
+                                  </div>
+                                )}
+                                {resource.details.description && (
+                                  <div>
+                                    <dt className="font-medium text-gray-500">Description</dt>
+                                    <dd className="text-gray-900">{resource.details.description}</dd>
+                                  </div>
+                                )}
+                                {resource.details.path && (
+                                  <div>
+                                    <dt className="font-medium text-gray-500">Path</dt>
+                                    <dd className="text-gray-900 font-mono text-sm">{resource.details.path}</dd>
+                                  </div>
+                                )}
+                              </>
+                            )}
+
+                            {resource.type !== "secretsmanager" && resource.type !== "iam" &&
                               resource.details &&
                               Object.entries(resource.details).map(([key, value], detailIdx) => (
                                 <div key={`${resource.id}-detail-${key}-${detailIdx}`}>

--- a/localcloud-gui/src/components/ThemeableCodeBlock.tsx
+++ b/localcloud-gui/src/components/ThemeableCodeBlock.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import hljs from "highlight.js";
 import { highlightThemes, HighlightTheme } from "./highlightThemes";
 import { usePreferences } from "@/context/PreferencesContext";
+import type { HighlightTheme as ProfileHighlightTheme } from "@/types";
 import { ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { toast } from "react-hot-toast";
 
@@ -21,6 +22,8 @@ const languageMap: Record<string, string> = {
   javascript: "javascript",
   python: "python",
   cli: "bash",
+  bash: "bash",
+  shell: "bash",
   nodemailer: "javascript",
   sendgrid: "javascript",
   laravel: "php",
@@ -39,7 +42,7 @@ export default function ThemeableCodeBlock({
   language,
   showThemeSelector = true,
 }: ThemeableCodeBlockProps) {
-  const { profile } = usePreferences();
+  const { profile, updateProfile } = usePreferences();
   const defaultTheme = (profile?.highlight_theme as HighlightTheme) || "github";
   const [selectedTheme, setSelectedTheme] = useState<HighlightTheme>(defaultTheme);
 
@@ -95,9 +98,11 @@ export default function ThemeableCodeBlock({
             <select
               id="samples-theme-select"
               value={selectedTheme}
-              onChange={(e) =>
-                setSelectedTheme(e.target.value as HighlightTheme)
-              }
+              onChange={(e) => {
+                const theme = e.target.value as HighlightTheme;
+                setSelectedTheme(theme);
+                updateProfile({ highlight_theme: theme as ProfileHighlightTheme }).catch(() => {});
+              }}
               className="text-sm border border-gray-300 rounded px-2 py-1 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {Object.keys(highlightThemes).map((key) => (

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -93,6 +93,13 @@ export interface SSMParameterConfig {
   description?: string;
 }
 
+export interface IAMRoleConfig {
+  roleName: string;
+  trustService: string;
+  description?: string;
+  path?: string;
+}
+
 export interface ResourceTemplate {
   id: string;
   name: string;
@@ -152,13 +159,14 @@ export interface CreateResourceRequest {
 
 export interface CreateSingleResourceRequest {
   projectName: string;
-  resourceType: "s3" | "dynamodb" | "lambda" | "apigateway" | "secretsmanager" | "ssm";
+  resourceType: "s3" | "dynamodb" | "lambda" | "apigateway" | "secretsmanager" | "ssm" | "iam";
   dynamodbConfig?: DynamoDBTableConfig;
   s3Config?: S3BucketConfig;
   secretsmanagerConfig?: SecretsManagerConfig;
   lambdaConfig?: LambdaFunctionConfig;
   apigatewayConfig?: APIGatewayConfig;
   ssmConfig?: SSMParameterConfig;
+  iamConfig?: IAMRoleConfig;
 }
 
 export interface DestroyResourceRequest {

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -601,6 +601,72 @@ create_ssm_parameter() {
 EOF
 }
 
+create_iam_role() {
+  if [ -n "$RESOURCE_CONFIG" ]; then
+    ROLE_NAME=$(echo "$RESOURCE_CONFIG" | jq -r '.roleName // empty')
+    DESCRIPTION=$(echo "$RESOURCE_CONFIG" | jq -r '.description // empty')
+    TRUST_SERVICE=$(echo "$RESOURCE_CONFIG" | jq -r '.trustService // "lambda"')
+    PATH_PREFIX=$(echo "$RESOURCE_CONFIG" | jq -r '.path // "/"')
+
+    if [ -z "$ROLE_NAME" ]; then
+      ROLE_NAME="${NAME_PREFIX}-role"
+    fi
+  else
+    ROLE_NAME="${NAME_PREFIX}-role"
+    DESCRIPTION="Default IAM role created by LocalCloud Kit"
+    TRUST_SERVICE="lambda"
+    PATH_PREFIX="/"
+  fi
+
+  # Build trust policy document for the given service principal
+  TRUST_POLICY=$(cat <<TRUST
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "${TRUST_SERVICE}.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+TRUST
+)
+
+  CMD="$AWS_CMD iam create-role --role-name \"$ROLE_NAME\" --assume-role-policy-document '$TRUST_POLICY'"
+  if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
+    CMD="$CMD --description \"$DESCRIPTION\""
+  fi
+  if [ -n "$PATH_PREFIX" ] && [ "$PATH_PREFIX" != "null" ] && [ "$PATH_PREFIX" != "/" ]; then
+    CMD="$CMD --path \"$PATH_PREFIX\""
+  fi
+
+  eval $CMD 2>/dev/null || true
+  log "Created IAM role: $ROLE_NAME"
+
+  ARN="arn:aws:iam::000000000000:role${PATH_PREFIX}${ROLE_NAME}"
+
+  cat <<EOF
+{
+  "id": "iam-$ROLE_NAME",
+  "name": "$ROLE_NAME",
+  "type": "iam",
+  "status": "active",
+  "project": "$PROJECT_NAME",
+  "createdAt": "$NOW",
+  "details": {
+    "roleName": "$ROLE_NAME",
+    "arn": "$ARN",
+    "trustService": "$TRUST_SERVICE",
+    "path": "$PATH_PREFIX",
+    "description": "$DESCRIPTION"
+  }
+}
+EOF
+}
+
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
@@ -631,9 +697,12 @@ main() {
     ssm)
       create_ssm_parameter
       ;;
+    iam)
+      create_iam_role
+      ;;
     *)
       echo "Unknown resource type: $RESOURCE_TYPE" >&2
-      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm" >&2
+      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm, iam" >&2
       exit 1
       ;;
   esac

--- a/scripts/shell/destroy_single_resource.sh
+++ b/scripts/shell/destroy_single_resource.sh
@@ -133,6 +133,26 @@ destroy_ssm_parameter() {
   echo "{\"success\": true, \"message\": \"SSM parameter $PARAM_NAME destroyed successfully\"}"
 }
 
+destroy_iam_role() {
+  if [ -n "$RESOURCE_NAME" ]; then
+    ROLE_NAME="$RESOURCE_NAME"
+  else
+    ROLE_NAME="${NAME_PREFIX}-role"
+  fi
+
+  log "Detaching policies from IAM role: $ROLE_NAME"
+  POLICIES=$($AWS_CMD iam list-attached-role-policies --role-name "$ROLE_NAME" --query "AttachedPolicies[].PolicyArn" --output text 2>/dev/null) || POLICIES=""
+  for ARN in $POLICIES; do
+    $AWS_CMD iam detach-role-policy --role-name "$ROLE_NAME" --policy-arn "$ARN" 2>/dev/null || true
+  done
+
+  log "Destroying IAM role: $ROLE_NAME"
+  $AWS_CMD iam delete-role --role-name "$ROLE_NAME" 2>/dev/null || true
+  log "Deleted IAM role: $ROLE_NAME"
+
+  echo "{\"success\": true, \"message\": \"IAM role $ROLE_NAME destroyed successfully\"}"
+}
+
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   
@@ -162,9 +182,12 @@ main() {
     ssm)
       destroy_ssm_parameter
       ;;
+    iam)
+      destroy_iam_role
+      ;;
     *)
       echo "Unknown resource type: $RESOURCE_TYPE" >&2
-      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm" >&2
+      echo "Supported types: s3, dynamodb, lambda, apigateway, secretsmanager, ssm, iam" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
Add full IAM role support to LocalCloud Kit via LocalStack:

- New API route (routes/iam.js): CRUD endpoints for roles, policy
  attach/detach, list users, list managed policies
- Register iamRouter in server.js
- create_single_resource.sh: create_iam_role() with configurable role
  name, trusted service principal, description, and path
- destroy_single_resource.sh: destroy_iam_role() detaches all managed
  policies before deleting the role
- resources.js: pass iamConfig to the shell script via --config flag
- types/index.ts: IAMRoleConfig interface; add "iam" to
  CreateSingleResourceRequest resourceType union
- IAMConfigModal.tsx: modal with role name, trusted service picker
  (Lambda, EC2, ECS, API Gateway, Step Functions, Firehose, S3),
  live trust-policy JSON preview, description, and path fields
- ResourceList.tsx: onAddIAM prop wired into the Security & Identity
  section of the Add dropdown; onViewIAMRole action button shows "Policies";
  dedicated IAM details section with ARN clipboard copy
- Dashboard.tsx: showIAMConfig state, handleCreateIAMRole handler,
  IAMConfigModal rendered in the modals section