### PR TITLE
refactor(types): categorize platform services as instance-service or admin-tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ Entries go under `## [Unreleased]` at the top of the file. Use these subsections
 
 - **Never** include `Co-Authored-By: Claude` or any AI attribution in commit messages or footers
 - **Never** include the `🤖 Generated with [Claude Code](https://claude.com/claude-code)` line (or any variant) in PR descriptions, commit bodies, or any other output
+- **Never** commit as `Claude <noreply@anthropic.com>` — all commits must be authored by the human owner of the repository. The correct git author for this repo is `Jonathan Robinson <jonrobinson.codes@gmail.com>`. Before committing, verify `git config user.name` and `git config user.email` match this identity.
 
 ---
 

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -3,7 +3,8 @@
 import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
 import { resourceApi } from "@/services/api";
-import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig } from "@/types";
+import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig, ModalKey } from "@/types";
+import { PLATFORM_SERVICES, PLATFORM_SERVICE_KINDS, SERVICE_KIND_LABEL } from "@/constants/platformServices";
 import {
   Bars3Icon,
   BookOpenIcon,
@@ -143,6 +144,11 @@ export default function Dashboard() {
     setShowProjectMenu(false);
     setShowProfileMenu(false);
     setShowMobileMenu(false);
+  };
+
+  const handleModalOpen = (modalKey: ModalKey) => {
+    if (modalKey === "mailpit") setShowMailpit(true);
+    if (modalKey === "redis") setShowRedis(true);
   };
 
   const toggleMenu = (setter: (v: boolean) => void, current: boolean) => {
@@ -573,34 +579,50 @@ export default function Dashboard() {
                 </button>
                 {showServicesMenu && (
                   <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Identity</p>
-                    <Link href="/keycloak" onClick={() => closeAllMenus()} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Keycloak
-                    </Link>
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Email</p>
-                    <button onClick={() => { setShowMailpit(true); closeAllMenus(); }} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                      <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Mailpit Inbox
-                      {mailpit.unread > 0 && (
-                        <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
-                          {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                        </span>
-                      )}
-                    </button>
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
-                    <Link href="/postgres" onClick={() => closeAllMenus()} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      PostgreSQL
-                    </Link>
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Cache</p>
-                    <button onClick={() => { setShowRedis(true); closeAllMenus(); }} className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
-                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Redis Cache
-                    </button>
+                    {PLATFORM_SERVICE_KINDS.map((kind, i) => {
+                      const items = PLATFORM_SERVICES.filter((s) => s.kind === kind);
+                      return (
+                        <div key={kind}>
+                          {i > 0 && <div className="border-t border-gray-100 mt-1" />}
+                          <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                            {SERVICE_KIND_LABEL[kind]}
+                          </p>
+                          {items.map((service) => {
+                            const ServiceIcon = service.icon;
+                            const itemContent = (
+                              <>
+                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />
+                                {service.label}
+                                {service.id === "mailpit" && mailpit.unread > 0 && (
+                                  <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
+                                    {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                                  </span>
+                                )}
+                              </>
+                            );
+                            const action = service.action;
+                            return action.type === "link" ? (
+                              <Link
+                                key={service.id}
+                                href={action.href}
+                                onClick={() => closeAllMenus()}
+                                className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </Link>
+                            ) : (
+                              <button
+                                key={service.id}
+                                onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
+                                className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -691,38 +713,21 @@ export default function Dashboard() {
                     {/* Platform Services */}
                     <div className="border-t border-gray-100 mt-1" />
                     <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Platform Services</p>
-                    <Link
-                      href="/keycloak"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Keycloak
-                    </Link>
-                    <Link
-                      href="/mailpit"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Mailpit
-                    </Link>
-                    <Link
-                      href="/postgres"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      PostgreSQL
-                    </Link>
-                    <Link
-                      href="/redis"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Redis Cache
-                    </Link>
+                    {PLATFORM_SERVICES.map((service) => {
+                      const ServiceIcon = service.icon;
+                      const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
+                      return (
+                        <Link
+                          key={service.id}
+                          href={href}
+                          onClick={() => setShowDocsMenu(false)}
+                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <ServiceIcon className="h-4 w-4 mr-3 text-gray-400" />
+                          {service.label}
+                        </Link>
+                      );
+                    })}
                   </div>
                 )}
               </div>
@@ -866,30 +871,51 @@ export default function Dashboard() {
                 </button>
               </div>
 
-              {/* Services — categorised */}
+              {/* Services — categorised by kind */}
               <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Identity</p>
-                <Link href="/keycloak" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />Keycloak
-                </Link>
-                <p className="px-2 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Email</p>
-                <button onClick={() => { setShowMailpit(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />
-                  Mailpit Inbox
-                  {mailpit.unread > 0 && (
-                    <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
-                      {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                    </span>
-                  )}
-                </button>
-                <p className="px-2 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
-                <Link href="/postgres" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />PostgreSQL
-                </Link>
-                <p className="px-2 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Cache</p>
-                <button onClick={() => { setShowRedis(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />Redis Cache
-                </button>
+                {PLATFORM_SERVICE_KINDS.map((kind, i) => {
+                  const items = PLATFORM_SERVICES.filter((s) => s.kind === kind);
+                  return (
+                    <div key={kind}>
+                      <p className={`px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider ${i > 0 ? "pt-2" : "py-1"}`}>
+                        {SERVICE_KIND_LABEL[kind]}
+                      </p>
+                      {items.map((service) => {
+                        const ServiceIcon = service.icon;
+                        const itemContent = (
+                          <>
+                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />
+                            {service.label}
+                            {service.id === "mailpit" && mailpit.unread > 0 && (
+                              <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
+                                {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                              </span>
+                            )}
+                          </>
+                        );
+                        const action = service.action;
+                        return action.type === "link" ? (
+                          <Link
+                            key={service.id}
+                            href={action.href}
+                            onClick={closeAllMenus}
+                            className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                          >
+                            {itemContent}
+                          </Link>
+                        ) : (
+                          <button
+                            key={service.id}
+                            onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
+                            className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                          >
+                            {itemContent}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
               </div>
 
               {/* Docs */}
@@ -919,18 +945,15 @@ export default function Dashboard() {
                 <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />IAM &amp; STS
                 </Link>
-                <Link href="/mailpit" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <EnvelopeIcon className="h-4 w-4 mr-3 text-gray-400" />Mailpit
-                </Link>
-                <Link href="/redis" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />Redis Cache
-                </Link>
-                <Link href="/keycloak" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />Keycloak
-                </Link>
-                <Link href="/postgres" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <CircleStackIcon className="h-4 w-4 mr-3 text-gray-400" />PostgreSQL
-                </Link>
+                {PLATFORM_SERVICES.map((service) => {
+                  const ServiceIcon = service.icon;
+                  const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
+                  return (
+                    <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />{service.label}
+                    </Link>
+                  );
+                })}
               </div>
 
               {/* Account */}

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -43,9 +43,6 @@ interface ResourceListProps {
   addLoading?: boolean;
 }
 
-// AWS resource types only — platform services are excluded
-const AWS_RESOURCE_TYPES = ["s3", "dynamodb", "lambda", "apigateway", "ssm", "iam", "secretsmanager"];
-
 const AWS_CATEGORIES = [
   { name: "Storage", types: ["s3"] },
   { name: "Database", types: ["dynamodb"] },
@@ -168,10 +165,7 @@ export default function ResourceList({
     }
   };
 
-  // Only show AWS resources (no platform services)
-  const awsResources = resources.filter(
-    (r) => r.project === projectName && AWS_RESOURCE_TYPES.includes(r.type)
-  );
+  const awsResources = resources.filter((r) => r.project === projectName);
 
   const handleSelectAll = () => {
     if (selectedResources.length === awsResources.length) {

--- a/localcloud-gui/src/constants/platformServices.ts
+++ b/localcloud-gui/src/constants/platformServices.ts
@@ -1,0 +1,55 @@
+import {
+  CircleStackIcon,
+  EnvelopeIcon,
+  KeyIcon,
+  ServerIcon,
+} from "@heroicons/react/24/outline";
+import { ComponentType } from "react";
+import { ServiceKind, ModalKey } from "@/types";
+
+export interface PlatformServiceEntry {
+  id: "keycloak" | "mailpit" | "postgres" | "redis";
+  label: string;
+  kind: ServiceKind;
+  icon: ComponentType<{ className?: string }>;
+  action: { type: "link"; href: string } | { type: "modal"; modalKey: ModalKey };
+}
+
+// Ordered: instance-services first (what your app connects to), admin tools second.
+export const PLATFORM_SERVICES: PlatformServiceEntry[] = [
+  {
+    id: "postgres",
+    label: "PostgreSQL",
+    kind: "instance-service",
+    icon: CircleStackIcon,
+    action: { type: "link", href: "/postgres" },
+  },
+  {
+    id: "redis",
+    label: "Redis Cache",
+    kind: "instance-service",
+    icon: ServerIcon,
+    action: { type: "modal", modalKey: "redis" },
+  },
+  {
+    id: "keycloak",
+    label: "Keycloak",
+    kind: "admin-tool",
+    icon: KeyIcon,
+    action: { type: "link", href: "/keycloak" },
+  },
+  {
+    id: "mailpit",
+    label: "Mailpit",
+    kind: "admin-tool",
+    icon: EnvelopeIcon,
+    action: { type: "modal", modalKey: "mailpit" },
+  },
+];
+
+export const SERVICE_KIND_LABEL: Record<ServiceKind, string> = {
+  "instance-service": "Infrastructure",
+  "admin-tool": "Admin Tools",
+};
+
+export const PLATFORM_SERVICE_KINDS: ServiceKind[] = ["instance-service", "admin-tool"];

--- a/localcloud-gui/src/hooks/useLocalStackData.ts
+++ b/localcloud-gui/src/hooks/useLocalStackData.ts
@@ -4,7 +4,6 @@ import {
   localstackApi,
   resourceApi,
   configApi,
-  cacheApi,
 } from "@/services/api";
 
 interface LocalStackData {
@@ -40,27 +39,6 @@ export function useLocalStackData() {
 
       // Use the current project config to fetch resources
       const resources = await resourceApi.getStatus(projectConfig.projectName);
-
-      // Add cache status as a resource
-      try {
-        const cacheStatus = await cacheApi.status();
-        const cacheResource: Resource = {
-          id: "cache-redis",
-          name: "Redis Cache",
-          type: "cache",
-          status: cacheStatus.status === "running" ? "active" : "error",
-          environment: "local",
-          project: projectConfig.projectName,
-          createdAt: new Date().toISOString(),
-          details: {
-            info: cacheStatus.info,
-            status: cacheStatus.status,
-          },
-        };
-        resources.push(cacheResource);
-      } catch (error) {
-        console.warn("Failed to fetch cache status:", error);
-      }
 
       // Secrets are now included in the resourceApi.getStatus() call via list_resources.sh
       // No need to fetch them separately to avoid duplicates

--- a/localcloud-gui/src/hooks/useServicesData.ts
+++ b/localcloud-gui/src/hooks/useServicesData.ts
@@ -58,28 +58,6 @@ export function useServicesData() {
 
       const { localstackStatus, projectConfig, mailpit: mailpitStats, resources, redis } = payload;
 
-      resources.push({
-        id: "postgres-db",
-        name: "PostgreSQL",
-        type: "postgres",
-        status: postgresStatus.status === "running" ? "active" : "error",
-        environment: "local",
-        project: projectConfig.projectName,
-        createdAt: new Date().toISOString(),
-        details: { host: "localhost", port: 5432, user: "localcloud", database: "localcloud" },
-      });
-
-      resources.push({
-        id: "keycloak-idp",
-        name: "Keycloak",
-        type: "keycloak",
-        status: keycloakStatus.status === "running" ? "active" : "error",
-        environment: "local",
-        project: projectConfig.projectName,
-        createdAt: new Date().toISOString(),
-        details: { adminUrl: "http://localhost:8080", adminUser: "admin", port: 8080 },
-      });
-
       setData({
         localstack: { status: localstackStatus, projectConfig, resources },
         mailpit: mailpitStats,

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -5,6 +5,14 @@ export interface LocalStackStatus {
   uptime?: string;
 }
 
+// Categorises platform services by their relationship to the developer's app.
+// "instance-service" — always-on infrastructure the app connects to directly (Redis, PostgreSQL).
+// "admin-tool"       — developer-facing management UI (Keycloak, Mailpit, pgAdmin).
+export type ServiceKind = "instance-service" | "admin-tool";
+
+// Modal keys for platform services that open an in-app modal rather than navigating to a page.
+export type ModalKey = "mailpit" | "redis";
+
 export interface Resource {
   id: string;
   name: string;
@@ -15,11 +23,7 @@ export interface Resource {
     | "apigateway"
     | "ssm"
     | "iam"
-    | "cache"
-    | "secretsmanager"
-    | "mailpit"
-    | "postgres"
-    | "keycloak";
+    | "secretsmanager";
   status: "creating" | "active" | "deleting" | "error" | "unknown";
   environment: string;
   project: string;


### PR DESCRIPTION
Introduce ServiceKind ("instance-service" | "admin-tool") and a
PLATFORM_SERVICES registry to distinguish services the app connects
to directly (Redis, PostgreSQL) from developer admin UIs (Keycloak,
Mailpit). Key changes:

- Remove platform types ("cache", "postgres", "keycloak", "mailpit")
  from Resource.type — Resource now only describes AWS resources
- Add ServiceKind and ModalKey types to types/index.ts
- Add constants/platformServices.ts with the PLATFORM_SERVICES registry
  and SERVICE_KIND_LABEL map
- Remove synthesized fake Resource entries for Redis, Postgres, and
  Keycloak from useLocalStackData and useServicesData
- Remove now-unnecessary AWS_RESOURCE_TYPES filter from ResourceList
- Drive Desktop Services dropdown, mobile Services section, and Docs
  dropdown platform entries from the registry instead of bespoke markup