### PR TITLE
fix(dashboard): remove false resource count and replace nav arrow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,18 @@ Entries go under `## [Unreleased]` at the top of the file. Use these subsections
 Run through every applicable item before committing. Order matters: build first,
 docs second, changelog last (PR step only).
 
-### 1 — GUI Build (required for any `localcloud-gui/` change)
+### 1 — GUI Lint (required for any `localcloud-gui/` change)
+
+```bash
+cd localcloud-gui && npm run lint
+```
+
+- Must pass with **zero errors** — fix all errors before committing
+- `@typescript-eslint/no-unused-vars` is set to **error**: remove every unused import, variable, and function before committing
+- Warnings (e.g. `no-explicit-any`, `react-hooks/exhaustive-deps`) are acceptable; errors are not
+- Skip only for backend-only or shell-script-only changes; run it when in doubt
+
+### 2 — GUI Build (required for any `localcloud-gui/` change)
 
 ```bash
 cd localcloud-gui && npm run build
@@ -216,7 +227,7 @@ cd localcloud-gui && npm run build
 - Warnings are acceptable; type errors and compile failures are not
 - Skip only for backend-only or shell-script-only changes; run it when in doubt
 
-### 2 — Documentation Update
+### 3 — Documentation Update
 
 Update the matching `docs/` markdown file whenever you change behaviour, add
 endpoints, rename things, or add a new service. **If the code changed, the docs
@@ -237,7 +248,7 @@ settings or config, common operations, troubleshooting tips. Do **not** duplicat
 the SDK examples from the GUI doc pages verbatim — link to the relevant `/route`
 instead.
 
-### 3 — README Update
+### 4 — README Update
 
 Update `README.md` when any of the following change:
 
@@ -250,7 +261,7 @@ Update `README.md` when any of the following change:
 The README is user-facing. Write in plain, direct language. Do not include
 internal implementation details.
 
-### 4 — Changelog Update (PR step only)
+### 5 — Changelog Update (PR step only)
 
 `CHANGELOG.md` is updated **once per PR**, as the last commit before opening the
 PR — never mid-feature. See the Changelog Standards section above.

--- a/localcloud-gui/eslint.config.mjs
+++ b/localcloud-gui/eslint.config.mjs
@@ -14,7 +14,7 @@ const eslintConfig = [
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": "error",
       "react-hooks/exhaustive-deps": "warn",
     },
   },

--- a/localcloud-gui/src/app/localstack/page.tsx
+++ b/localcloud-gui/src/app/localstack/page.tsx
@@ -8,8 +8,7 @@ import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 import { usePreferences } from "@/context/PreferencesContext";
 import ServiceStatusBadge from "@/components/ServiceStatusBadge";
 
-const PAGE_TABS = ["node", "python", "cli"] as const;
-type PageTab = (typeof PAGE_TABS)[number];
+type PageTab = "node" | "python" | "cli";
 
 // Maps PreferredLanguage → localstack tab (no typescript tab here — node is equivalent)
 const LANG_TO_TAB: Record<string, PageTab> = {
@@ -22,7 +21,7 @@ const LANG_TO_TAB: Record<string, PageTab> = {
 };
 
 export default function LocalStackIntegrationPage() {
-  const { status, projectConfig, loading } = useLocalStackStatus();
+  const { status, projectConfig } = useLocalStackStatus();
   const { profile } = usePreferences();
   const [activeTab, setActiveTab] = useState<PageTab>("node");
 

--- a/localcloud-gui/src/app/postgres/page.tsx
+++ b/localcloud-gui/src/app/postgres/page.tsx
@@ -3,7 +3,6 @@
 import {
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import DocPageNav from "@/components/DocPageNav";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { usePreferences } from "@/context/PreferencesContext";
-import { projectsApi, savedConfigsApi } from "@/services/api";
 import { HighlightTheme, PreferredLanguage, Project } from "@/types";
 import {
   ArrowLeftIcon,

--- a/localcloud-gui/src/components/BucketViewer.tsx
+++ b/localcloud-gui/src/components/BucketViewer.tsx
@@ -227,22 +227,6 @@ export default function BucketViewer({
     }
   };
 
-  const getParentPath = (key: string) => {
-    // Get the parent path for navigation
-    if (key.endsWith("/")) {
-      // Remove the trailing slash and get parent
-      const trimmed = key.slice(0, -1);
-      const parts = trimmed.split("/");
-      parts.pop(); // Remove the last part
-      return parts.length > 0 ? parts.join("/") + "/" : "";
-    } else {
-      // Get the directory path
-      const parts = key.split("/");
-      parts.pop(); // Remove the filename
-      return parts.length > 0 ? parts.join("/") + "/" : "";
-    }
-  };
-
   const handleViewFile = (objectKey: string) => {
     if (!selectedBucket) return;
     setSelectedFile({ bucketName: selectedBucket, objectKey });

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -9,10 +9,7 @@ import {
   Bars3Icon,
   BookOpenIcon,
   ChevronDownIcon,
-  CircleStackIcon,
   DocumentTextIcon,
-  EnvelopeIcon,
-  KeyIcon,
   ServerIcon,
   Squares2X2Icon,
   UserCircleIcon,
@@ -70,7 +67,6 @@ export default function Dashboard() {
   const [showSSMConfig, setShowSSMConfig] = useState(false);
   const [showSSMEdit, setShowSSMEdit] = useState(false);
   const [showIAMConfig, setShowIAMConfig] = useState(false);
-  const [viewingIAMRole, setViewingIAMRole] = useState<string>("");
   const [editingSSMParameter, setEditingSSMParameter] = useState<string>("");
   const [showLambdaCode, setShowLambdaCode] = useState(false);
   const [viewingLambdaFunction, setViewingLambdaFunction] = useState<string>("");
@@ -1098,7 +1094,7 @@ export default function Dashboard() {
                 setShowLambdaCode(true);
               }}
               onConfigureAPIGateway={(apiId, apiName) => setConfiguringAPIGateway({ apiId, apiName })}
-              onViewIAMRole={(roleName) => { setViewingIAMRole(roleName); }}
+              onViewIAMRole={() => {}}
             />
           ) : (
             <div className="bg-white rounded-lg shadow border border-gray-200">

--- a/localcloud-gui/src/components/DocPageNav.tsx
+++ b/localcloud-gui/src/components/DocPageNav.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowLeftIcon,
   BookOpenIcon,
   ChevronDownIcon,
   CircleStackIcon,
@@ -46,21 +45,19 @@ export default function DocPageNav({ title, subtitle, children }: DocPageNavProp
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between py-4">
-          {/* Left: back link + logo + title */}
-          <div className="flex items-center space-x-4">
+          {/* Left: logo + dashboard link + title */}
+          <div className="flex items-center space-x-3">
+            <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
             <Link
               href="/"
-              className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
             >
-              <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
               Dashboard
             </Link>
-            <div className="flex items-center space-x-3">
-              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">{title}</h1>
-                <p className="text-xs text-gray-500">{subtitle}</p>
-              </div>
+            <div className="h-5 w-px bg-gray-200" />
+            <div>
+              <h1 className="text-xl font-bold text-gray-900">{title}</h1>
+              <p className="text-xs text-gray-500">{subtitle}</p>
             </div>
           </div>
 

--- a/localcloud-gui/src/components/FileViewerModal.tsx
+++ b/localcloud-gui/src/components/FileViewerModal.tsx
@@ -7,21 +7,6 @@ import { highlightThemes, HighlightTheme } from "./highlightThemes";
 import { marked } from "marked";
 import Papa from "papaparse";
 
-// Helper function to encode Unicode strings to base64
-function encodeUnicodeToBase64(str: string): string {
-  try {
-    // First try the standard btoa for ASCII content
-    return btoa(str);
-  } catch (error) {
-    // If btoa fails due to Unicode characters, use a more robust approach
-    const encoder = new TextEncoder();
-    const bytes = encoder.encode(str);
-    const binaryString = Array.from(bytes, (byte) =>
-      String.fromCharCode(byte)
-    ).join("");
-    return btoa(binaryString);
-  }
-}
 // Register highlight.js languages
 import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -151,7 +136,6 @@ export default function FileViewerModal({
   projectName,
   bucketName,
   objectKey,
-  objectSize,
   theme = "github",
 }: FileViewerModalProps) {
   const [fileContent, setFileContent] = useState<FileContent | null>(null);
@@ -179,7 +163,7 @@ export default function FileViewerModal({
       } else {
         setError(data.error || "Failed to load file content");
       }
-    } catch (err) {
+    } catch {
       setError("Failed to load file content");
     } finally {
       setLoading(false);

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -165,7 +165,8 @@ export default function ResourceList({
     }
   };
 
-  const awsResources = resources.filter((r) => r.project === projectName);
+  const awsTypes = new Set(AWS_CATEGORIES.flatMap((c) => c.types));
+  const awsResources = resources.filter((r) => r.project === projectName && awsTypes.has(r.type));
 
   const handleSelectAll = () => {
     if (selectedResources.length === awsResources.length) {

--- a/localcloud-gui/src/components/SecretsManagerViewer.tsx
+++ b/localcloud-gui/src/components/SecretsManagerViewer.tsx
@@ -100,24 +100,6 @@ export default function SecretsManagerViewer({
     }
   };
 
-  const loadSecretDetails = async (secretName: string) => {
-    try {
-      const response = await fetch(
-        `/api/secrets/${encodeURIComponent(secretName)}?includeValue=false`
-      );
-      const result = await response.json();
-
-      if (result.success) {
-        setSecretDetails((prev) => ({
-          ...prev,
-          [secretName]: result.data,
-        }));
-      }
-    } catch (error) {
-      console.error("Error loading secret details:", error);
-    }
-  };
-
   const revealSecret = async (secretName: string) => {
     try {
       const response = await fetch(
@@ -147,55 +129,6 @@ export default function SecretsManagerViewer({
       newSet.delete(secretName);
       return newSet;
     });
-  };
-
-  const handleCreateSecret = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    try {
-      const tags = formData.tags
-        ? Object.fromEntries(
-            formData.tags.split(",").map((tag) => {
-              const [key, value] = tag.split("=").map((s) => s.trim());
-              return [key, value];
-            })
-          )
-        : {};
-
-      const response = await fetch("/api/secrets", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          secretName: formData.secretName,
-          secretValue: formData.secretValue,
-          description: formData.description || undefined,
-          tags: Object.keys(tags).length > 0 ? tags : undefined,
-          kmsKeyId: formData.kmsKeyId || undefined,
-        }),
-      });
-
-      const result = await response.json();
-
-      if (result.success) {
-        toast.success("Secret created successfully");
-        setShowCreateModal(false);
-        setFormData({
-          secretName: "",
-          secretValue: "",
-          description: "",
-          tags: "",
-          kmsKeyId: "",
-        });
-        loadSecrets();
-      } else {
-        toast.error(result.error || "Failed to create secret");
-      }
-    } catch (error) {
-      console.error("Error creating secret:", error);
-      toast.error("Failed to create secret");
-    }
   };
 
   const handleUpdateSecret = async (e: React.FormEvent) => {


### PR DESCRIPTION
ResourceList counted platform-service entries (cache, mailpit) injected
by the dashboard API into the resources array, showing "2 resources in
default" on a fresh install with no AWS resources created. Filter now
restricts awsResources to types declared in AWS_CATEGORIES so only real
AWS resources contribute to the count and the empty-state view.

DocPageNav replaced the ← Dashboard arrow link (left of logo) with a
plain "Dashboard" text link placed directly to the right of the logo,
matching the requested layout.