### PR TITLE
Move Dashboard link to right of title and subtitle in DocPageNav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **SecretsDetailModal**: Clicking a secret in the resource list now opens a focused single-secret modal showing name, ARN, masked value with reveal toggle, inline edit (value + description), and delete with confirmation; includes "Open in Secrets Manager →" link to the full manage page
 - **Manage links**: "Open Manager →" links added to all existing service viewer modals (BucketViewer, DynamoDBViewer, SecretsManagerViewer, LambdaCodeModal, SSMEditModal, APIGatewayConfigViewer) and to the Resources dropdown in the Dashboard
 
+### Changed
+- **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
+
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret
 

--- a/localcloud-gui/src/components/DocPageNav.tsx
+++ b/localcloud-gui/src/components/DocPageNav.tsx
@@ -45,20 +45,20 @@ export default function DocPageNav({ title, subtitle, children }: DocPageNavProp
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between py-4">
-          {/* Left: logo + dashboard link + title */}
+          {/* Left: logo + title + dashboard link */}
           <div className="flex items-center space-x-3">
             <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+            <div>
+              <h1 className="text-xl font-bold text-gray-900">{title}</h1>
+              <p className="text-xs text-gray-500">{subtitle}</p>
+            </div>
+            <div className="h-5 w-px bg-gray-200" />
             <Link
               href="/"
               className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
             >
               Dashboard
             </Link>
-            <div className="h-5 w-px bg-gray-200" />
-            <div>
-              <h1 className="text-xl font-bold text-gray-900">{title}</h1>
-              <p className="text-xs text-gray-500">{subtitle}</p>
-            </div>
           </div>
 
           {/* Right: custom actions + Docs dropdown + Profile */}


### PR DESCRIPTION
Reorders the left nav section so the page title/subtitle appears first,
followed by the divider and Dashboard link.

https://claude.ai/code/session_012ciW9LajufLPhwgHs2krqt