### PR TITLE
feat(status): add starting and failed states; normalize nav headers

### DIFF
--- a/localcloud-api/routes/keycloak.js
+++ b/localcloud-api/routes/keycloak.js
@@ -7,12 +7,19 @@ const router = express.Router();
 router.get("/keycloak/status", async (req, res) => {
   try {
     const response = await axios.get("http://keycloak:8080/health/ready", { timeout: 5000 });
-    const healthy = response.data?.status === "UP";
-    res.json({ success: true, data: { status: healthy ? "running" : "stopped" } });
+    const kcStatus = response.data?.status;
+    if (kcStatus === "UP") {
+      res.json({ success: true, data: { status: "running" } });
+    } else {
+      // Health endpoint reachable but reporting not-UP (e.g. DOWN) — something is wrong
+      res.json({ success: true, data: { status: "failed" } });
+    }
   } catch {
+    // Health endpoint not reachable — check whether the container port is up at all
     try {
       const reachable = await checkTcpPort("keycloak", 8080);
-      res.json({ success: true, data: { status: reachable ? "running" : "stopped" } });
+      // Port is open but HTTP not ready yet → Keycloak is still booting
+      res.json({ success: true, data: { status: reachable ? "starting" : "stopped" } });
     } catch {
       res.json({ success: true, data: { status: "stopped" } });
     }

--- a/localcloud-gui/src/app/connect/page.tsx
+++ b/localcloud-gui/src/app/connect/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import ConnectionGuide from "@/components/ConnectionGuide";
-import { ArrowLeftIcon } from "@heroicons/react/24/outline";
 
 export default function ConnectPage() {
   return (
@@ -9,21 +8,19 @@ export default function ConnectPage() {
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">Connection Guide</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
               <Link
                 href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
               >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                  <p className="text-xs text-gray-500">Connection Guide</p>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/localcloud-gui/src/app/manage/apigateway/page.tsx
+++ b/localcloud-gui/src/app/manage/apigateway/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   ArrowPathIcon,
   BookOpenIcon,
@@ -103,18 +102,16 @@ export default function ManageAPIGatewayPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">API Gateway</h1>
+                <p className="text-xs text-gray-500">Manage REST APIs and endpoints</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">API Gateway</h1>
-                  <p className="text-xs text-gray-500">Manage REST APIs and endpoints</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/apigateway" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   CircleStackIcon,
   ArrowPathIcon,
@@ -154,18 +153,16 @@ export default function ManageDynamoDBPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">DynamoDB</h1>
+                <p className="text-xs text-gray-500">Manage tables and items</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">DynamoDB</h1>
-                  <p className="text-xs text-gray-500">Manage tables and items</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/dynamodb" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/manage/iam/page.tsx
+++ b/localcloud-gui/src/app/manage/iam/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   ArrowPathIcon,
   BookOpenIcon,
@@ -141,18 +140,16 @@ export default function ManageIAMPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">IAM Roles</h1>
+                <p className="text-xs text-gray-500">Manage roles and attached policies</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">IAM Roles</h1>
-                  <p className="text-xs text-gray-500">Manage roles and attached policies</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/iam" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/manage/lambda/page.tsx
+++ b/localcloud-gui/src/app/manage/lambda/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   ArrowPathIcon,
   BookOpenIcon,
@@ -114,18 +113,16 @@ export default function ManageLambdaPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">Lambda Functions</h1>
+                <p className="text-xs text-gray-500">Manage serverless functions</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Lambda Functions</h1>
-                  <p className="text-xs text-gray-500">Manage serverless functions</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/lambda" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   FolderIcon,
   DocumentIcon,
@@ -163,18 +162,16 @@ export default function ManageS3Page() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">S3 Buckets</h1>
+                <p className="text-xs text-gray-500">Browse and manage S3 buckets and objects</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">S3 Buckets</h1>
-                  <p className="text-xs text-gray-500">Browse and manage S3 buckets and objects</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/s3" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/manage/secrets/page.tsx
+++ b/localcloud-gui/src/app/manage/secrets/page.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { toast } from "react-hot-toast";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   EyeIcon,
   EyeSlashIcon,
@@ -185,21 +184,19 @@ export default function ManageSecretsPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">Secrets Manager</h1>
+                <p className="text-xs text-gray-500">Manage secrets stored in LocalStack</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
               <Link
                 href="/"
-                className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
               >
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">Secrets Manager</h1>
-                  <p className="text-xs text-gray-500">Manage secrets stored in LocalStack</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link

--- a/localcloud-gui/src/app/manage/ssm/page.tsx
+++ b/localcloud-gui/src/app/manage/ssm/page.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
 import {
-  ArrowLeftIcon,
   PlusIcon,
   ArrowPathIcon,
   BookOpenIcon,
@@ -170,18 +169,16 @@ export default function ManageSSMPage() {
       <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-4">
-              <Link href="/" className="flex items-center text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                <ArrowLeftIcon className="h-4 w-4 mr-1.5" />
+            <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">SSM Parameter Store</h1>
+                <p className="text-xs text-gray-500">Manage configuration parameters</p>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
+              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
                 Dashboard
               </Link>
-              <div className="flex items-center space-x-3">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-                <div>
-                  <h1 className="text-xl font-bold text-gray-900">SSM Parameter Store</h1>
-                  <p className="text-xs text-gray-500">Manage configuration parameters</p>
-                </div>
-              </div>
             </div>
             <div className="flex items-center space-x-3">
               <Link href="/ssm" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -2,8 +2,8 @@
 
 import { usePreferences } from "@/context/PreferencesContext";
 import { HighlightTheme, PreferredLanguage, Project } from "@/types";
+import Image from "next/image";
 import {
-  ArrowLeftIcon,
   CircleStackIcon,
   FolderIcon,
   KeyIcon,
@@ -152,14 +152,18 @@ export default function ProfilePage() {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
+              <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
+              <div className="flex items-center space-x-2">
+                <UserCircleIcon className="h-6 w-6 text-blue-600" />
+                <h1 className="text-xl font-bold text-gray-900">Profile & Preferences</h1>
+              </div>
+              <div className="h-5 w-px bg-gray-200" />
               <Link
                 href="/"
-                className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
               >
-                <ArrowLeftIcon className="h-5 w-5" />
+                Dashboard
               </Link>
-              <UserCircleIcon className="h-7 w-7 text-blue-600" />
-              <h1 className="text-xl font-bold text-gray-900">Profile & Preferences</h1>
             </div>
           </div>
         </div>

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -396,16 +396,20 @@ export default function Dashboard() {
 
   const serviceStatusClass = (status: string) => {
     if (status === "running") return "bg-green-100 text-green-800";
-    if (status === "stopped") return "bg-red-100 text-red-800";
+    if (status === "starting") return "bg-yellow-100 text-yellow-700";
+    if (status === "failed") return "bg-red-100 text-red-800";
     return "bg-gray-100 text-gray-600";
   };
   const serviceDotClass = (status: string) => {
     if (status === "running") return "bg-green-500";
-    if (status === "stopped") return "bg-red-500";
+    if (status === "starting") return "bg-yellow-400 animate-pulse";
+    if (status === "failed") return "bg-red-500";
     return "bg-gray-400";
   };
   const serviceLabel = (status: string) => {
     if (status === "running") return "Running";
+    if (status === "starting") return "Starting…";
+    if (status === "failed") return "Failed";
     if (status === "stopped") return "Stopped";
     return "Unknown";
   };

--- a/localcloud-gui/src/components/ServiceStatusBadge.tsx
+++ b/localcloud-gui/src/components/ServiceStatusBadge.tsx
@@ -16,7 +16,7 @@ export type ServiceKey =
   | "postgres"
   | "keycloak";
 
-type StatusLevel = "running" | "degraded" | "stopped" | "unknown";
+type StatusLevel = "running" | "degraded" | "starting" | "stopped" | "failed" | "unknown";
 
 interface StatusState {
   level: StatusLevel;
@@ -55,7 +55,9 @@ async function fetchStatus(service: ServiceKey): Promise<StatusState> {
       case "keycloak": {
         const s = await keycloakApi.status();
         if (s.status === "running") return { level: "running", label: "Running" };
+        if (s.status === "starting") return { level: "starting", label: "Starting" };
         if (s.status === "stopped") return { level: "stopped", label: "Stopped" };
+        if (s.status === "failed") return { level: "failed", label: "Failed" };
         return { level: "unknown", label: "Unknown" };
       }
     }
@@ -67,14 +69,18 @@ async function fetchStatus(service: ServiceKey): Promise<StatusState> {
 const dotClass: Record<StatusLevel, string> = {
   running: "bg-green-500 animate-pulse",
   degraded: "bg-yellow-500 animate-pulse",
-  stopped: "bg-red-500",
+  starting: "bg-yellow-400 animate-pulse",
+  stopped: "bg-gray-400",
+  failed: "bg-red-500",
   unknown: "bg-gray-400",
 };
 
 const badgeClass: Record<StatusLevel, string> = {
   running: "bg-green-100 text-green-800",
   degraded: "bg-yellow-100 text-yellow-800",
-  stopped: "bg-red-100 text-red-800",
+  starting: "bg-yellow-100 text-yellow-700",
+  stopped: "bg-gray-100 text-gray-600",
+  failed: "bg-red-100 text-red-800",
   unknown: "bg-gray-100 text-gray-600",
 };
 

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -136,7 +136,7 @@ export interface PostgresStatus {
 }
 
 export interface KeycloakStatus {
-  status: "running" | "stopped" | "unknown";
+  status: "running" | "starting" | "stopped" | "failed" | "unknown";
 }
 
 export interface LogEntry {


### PR DESCRIPTION
Keycloak takes time to boot — when its HTTP health endpoint is
unreachable but the TCP port is open, the API now returns "starting"
instead of "running" so the UI no longer shows a misleading Stopped
badge while Keycloak is still initialising.

A "failed" state is also added for when the health endpoint responds
but reports a non-UP status, distinguishing a real failure from a
service that is simply stopped or booting.

Dashboard helper functions and ServiceStatusBadge both gain
starting (amber pulse dot) and failed (red dot / red badge) support.
Stopped is now shown with a neutral gray dot since that is an
expected, non-error state.

All manage/* pages (S3, DynamoDB, Lambda, API Gateway, Secrets,
IAM, SSM), the Connect page, and the Profile page now use the same
logo → title → Dashboard-link layout introduced in DocPageNav,
replacing the old ← arrow-icon style for consistency.