### PR TITLE
fix(keycloak): use management port 9000 for health check

### DIFF
--- a/localcloud-api/routes/keycloak.js
+++ b/localcloud-api/routes/keycloak.js
@@ -6,7 +6,7 @@ const router = express.Router();
 
 router.get("/keycloak/status", async (req, res) => {
   try {
-    const response = await axios.get("http://keycloak:8080/health/ready", { timeout: 5000 });
+    const response = await axios.get("http://keycloak:9000/health/ready", { timeout: 5000 });
     const kcStatus = response.data?.status;
     if (kcStatus === "UP") {
       res.json({ success: true, data: { status: "running" } });


### PR DESCRIPTION
Keycloak 22+ moved /health/ready to the management port (9000) away
from the main HTTP port (8080). Calling the old URL caused axios to
fail, the TCP fallback found port 8080 open, and the status was stuck
at "starting" indefinitely even when Keycloak was fully up.

Point the health check at http://keycloak:9000/health/ready so the
"UP" response is received correctly and status transitions to "running".