### PR TITLE
fix(keycloak): add KC_HEALTH_ENABLED=true to enable management port health endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,7 @@ services:
       - KC_PROXY_HEADERS=xforwarded
       - KC_HOSTNAME_STRICT=false
       - KC_HOSTNAME_STRICT_HTTPS=false
+      - KC_HEALTH_ENABLED=true
     command: start-dev
     tmpfs:
       - /tmp


### PR DESCRIPTION
Keycloak 25+ requires KC_HEALTH_ENABLED=true to activate the /health/ready
endpoint on the management port (9000). Without it the endpoint returns 404,
axios throws, the TCP fallback finds port 8080 open, and the status is stuck
at "starting" indefinitely even when Keycloak is fully running.

Setting KC_HEALTH_ENABLED=true allows the health check at
http://keycloak:9000/health/ready to return {"status":"UP"} and the status
transitions correctly to "running".