### PR TITLE
Page service descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Changed
 - **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
-- **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now describe each page's service
+- **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now use short service labels
 
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Changed
 - **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
+- **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now describe each page's service
 
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret

--- a/localcloud-gui/src/app/apigateway/page.tsx
+++ b/localcloud-gui/src/app/apigateway/page.tsx
@@ -286,7 +286,7 @@ export default function APIGatewayDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-pink-50 to-rose-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="REST API management service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="API Gateway">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/apigateway"

--- a/localcloud-gui/src/app/apigateway/page.tsx
+++ b/localcloud-gui/src/app/apigateway/page.tsx
@@ -286,7 +286,7 @@ export default function APIGatewayDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-pink-50 to-rose-100">
-      <DocPageNav title="API Gateway" subtitle="REST API management via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="REST API management service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/apigateway"

--- a/localcloud-gui/src/app/cache/page.tsx
+++ b/localcloud-gui/src/app/cache/page.tsx
@@ -199,7 +199,7 @@ export default function CachePage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="Cache" subtitle="Redis">
+      <DocPageNav title="LocalCloud Kit" subtitle="Redis caching service">
         <ServiceStatusBadge service="redis" name="Redis" />
         <div className="relative" ref={connectionRef}>
           <button

--- a/localcloud-gui/src/app/cache/page.tsx
+++ b/localcloud-gui/src/app/cache/page.tsx
@@ -199,7 +199,7 @@ export default function CachePage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Redis caching service">
+      <DocPageNav title="LocalCloud Kit" subtitle="Redis">
         <ServiceStatusBadge service="redis" name="Redis" />
         <div className="relative" ref={connectionRef}>
           <button

--- a/localcloud-gui/src/app/connect/page.tsx
+++ b/localcloud-gui/src/app/connect/page.tsx
@@ -12,7 +12,7 @@ export default function ConnectPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Connection Guide</p>
+                <p className="text-xs text-gray-500">Service connection guide</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/connect/page.tsx
+++ b/localcloud-gui/src/app/connect/page.tsx
@@ -12,7 +12,7 @@ export default function ConnectPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Service connection guide</p>
+                <p className="text-xs text-gray-500">Connections</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -196,7 +196,7 @@ export default function DynamoDBDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="DynamoDB Tables" subtitle="Local NoSQL database via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="NoSQL database service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/dynamodb"

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -196,7 +196,7 @@ export default function DynamoDBDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="NoSQL database service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="DynamoDB">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/dynamodb"

--- a/localcloud-gui/src/app/iam/page.tsx
+++ b/localcloud-gui/src/app/iam/page.tsx
@@ -406,7 +406,7 @@ export default function IAMDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-red-50 to-orange-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="IAM and STS identity service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="IAM & STS">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/iam"

--- a/localcloud-gui/src/app/iam/page.tsx
+++ b/localcloud-gui/src/app/iam/page.tsx
@@ -406,7 +406,7 @@ export default function IAMDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-red-50 to-orange-100">
-      <DocPageNav title="IAM & STS" subtitle="Roles, policies, and session credentials via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="IAM and STS identity service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/iam"

--- a/localcloud-gui/src/app/keycloak/page.tsx
+++ b/localcloud-gui/src/app/keycloak/page.tsx
@@ -143,7 +143,7 @@ export default function KeycloakPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Identity and access management service">
+      <DocPageNav title="LocalCloud Kit" subtitle="Keycloak">
         <ServiceStatusBadge service="keycloak" name="Keycloak" />
         <a
           href={keycloakAdminUrl}

--- a/localcloud-gui/src/app/keycloak/page.tsx
+++ b/localcloud-gui/src/app/keycloak/page.tsx
@@ -143,7 +143,7 @@ export default function KeycloakPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="Keycloak" subtitle="Local identity and access management (maps to AWS Cognito)">
+      <DocPageNav title="LocalCloud Kit" subtitle="Identity and access management service">
         <ServiceStatusBadge service="keycloak" name="Keycloak" />
         <a
           href={keycloakAdminUrl}

--- a/localcloud-gui/src/app/lambda/page.tsx
+++ b/localcloud-gui/src/app/lambda/page.tsx
@@ -221,7 +221,7 @@ export default function LambdaDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-orange-50 to-amber-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Serverless compute service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="Lambda">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/lambda"

--- a/localcloud-gui/src/app/lambda/page.tsx
+++ b/localcloud-gui/src/app/lambda/page.tsx
@@ -221,7 +221,7 @@ export default function LambdaDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-orange-50 to-amber-100">
-      <DocPageNav title="Lambda" subtitle="Serverless functions via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="Serverless compute service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/lambda"

--- a/localcloud-gui/src/app/localstack/page.tsx
+++ b/localcloud-gui/src/app/localstack/page.tsx
@@ -73,7 +73,7 @@ alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalStack Integration" subtitle="Local AWS service emulation">
+      <DocPageNav title="LocalCloud Kit" subtitle="AWS service emulation platform">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
       </DocPageNav>
 

--- a/localcloud-gui/src/app/localstack/page.tsx
+++ b/localcloud-gui/src/app/localstack/page.tsx
@@ -73,7 +73,7 @@ alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="AWS service emulation platform">
+      <DocPageNav title="LocalCloud Kit" subtitle="LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
       </DocPageNav>
 

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -187,7 +187,7 @@ export default function MailpitIntegrationPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="Mailpit Inbox" subtitle="Local email testing for development">
+      <DocPageNav title="LocalCloud Kit" subtitle="Email capture and SMTP testing service">
         <ServiceStatusBadge service="mailpit" name="Mailpit" />
         <a
           href={MAILPIT_UI_URL}

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -187,7 +187,7 @@ export default function MailpitIntegrationPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Email capture and SMTP testing service">
+      <DocPageNav title="LocalCloud Kit" subtitle="Mailpit">
         <ServiceStatusBadge service="mailpit" name="Mailpit" />
         <a
           href={MAILPIT_UI_URL}

--- a/localcloud-gui/src/app/manage/apigateway/page.tsx
+++ b/localcloud-gui/src/app/manage/apigateway/page.tsx
@@ -105,8 +105,8 @@ export default function ManageAPIGatewayPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">API Gateway</h1>
-                <p className="text-xs text-gray-500">Manage REST APIs and endpoints</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">API Gateway service for managing REST APIs and endpoints</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/apigateway/page.tsx
+++ b/localcloud-gui/src/app/manage/apigateway/page.tsx
@@ -106,7 +106,7 @@ export default function ManageAPIGatewayPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">API Gateway service for managing REST APIs and endpoints</p>
+                <p className="text-xs text-gray-500">Manage APIs</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -156,8 +156,8 @@ export default function ManageDynamoDBPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">DynamoDB</h1>
-                <p className="text-xs text-gray-500">Manage tables and items</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">DynamoDB service for managing tables and items</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -157,7 +157,7 @@ export default function ManageDynamoDBPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">DynamoDB service for managing tables and items</p>
+                <p className="text-xs text-gray-500">Manage tables</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/iam/page.tsx
+++ b/localcloud-gui/src/app/manage/iam/page.tsx
@@ -143,8 +143,8 @@ export default function ManageIAMPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">IAM Roles</h1>
-                <p className="text-xs text-gray-500">Manage roles and attached policies</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">IAM service for managing roles and attached policies</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/iam/page.tsx
+++ b/localcloud-gui/src/app/manage/iam/page.tsx
@@ -144,7 +144,7 @@ export default function ManageIAMPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">IAM service for managing roles and attached policies</p>
+                <p className="text-xs text-gray-500">Manage roles</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/lambda/page.tsx
+++ b/localcloud-gui/src/app/manage/lambda/page.tsx
@@ -116,8 +116,8 @@ export default function ManageLambdaPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">Lambda Functions</h1>
-                <p className="text-xs text-gray-500">Manage serverless functions</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">Lambda service for managing serverless functions</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/lambda/page.tsx
+++ b/localcloud-gui/src/app/manage/lambda/page.tsx
@@ -117,7 +117,7 @@ export default function ManageLambdaPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Lambda service for managing serverless functions</p>
+                <p className="text-xs text-gray-500">Manage functions</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -165,8 +165,8 @@ export default function ManageS3Page() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">S3 Buckets</h1>
-                <p className="text-xs text-gray-500">Browse and manage S3 buckets and objects</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">S3 service for managing buckets and objects</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -166,7 +166,7 @@ export default function ManageS3Page() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">S3 service for managing buckets and objects</p>
+                <p className="text-xs text-gray-500">Manage buckets</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/secrets/page.tsx
+++ b/localcloud-gui/src/app/manage/secrets/page.tsx
@@ -188,7 +188,7 @@ export default function ManageSecretsPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Secrets Manager service for managing LocalStack secrets</p>
+                <p className="text-xs text-gray-500">Manage secrets</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/manage/secrets/page.tsx
+++ b/localcloud-gui/src/app/manage/secrets/page.tsx
@@ -187,8 +187,8 @@ export default function ManageSecretsPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">Secrets Manager</h1>
-                <p className="text-xs text-gray-500">Manage secrets stored in LocalStack</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">Secrets Manager service for managing LocalStack secrets</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/manage/ssm/page.tsx
+++ b/localcloud-gui/src/app/manage/ssm/page.tsx
@@ -172,8 +172,8 @@ export default function ManageSSMPage() {
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
-                <h1 className="text-xl font-bold text-gray-900">SSM Parameter Store</h1>
-                <p className="text-xs text-gray-500">Manage configuration parameters</p>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">SSM Parameter Store service for configuration parameters</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/manage/ssm/page.tsx
+++ b/localcloud-gui/src/app/manage/ssm/page.tsx
@@ -173,7 +173,7 @@ export default function ManageSSMPage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">SSM Parameter Store service for configuration parameters</p>
+                <p className="text-xs text-gray-500">Manage parameters</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">

--- a/localcloud-gui/src/app/postgres/page.tsx
+++ b/localcloud-gui/src/app/postgres/page.tsx
@@ -142,7 +142,7 @@ export default function PostgresPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="PostgreSQL relational database service">
+      <DocPageNav title="LocalCloud Kit" subtitle="PostgreSQL">
         <ServiceStatusBadge service="postgres" name="PostgreSQL" />
         <a
           href={PGADMIN_DIRECT_URL}

--- a/localcloud-gui/src/app/postgres/page.tsx
+++ b/localcloud-gui/src/app/postgres/page.tsx
@@ -142,7 +142,7 @@ export default function PostgresPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="PostgreSQL" subtitle="Local relational database with pgAdmin GUI">
+      <DocPageNav title="LocalCloud Kit" subtitle="PostgreSQL relational database service">
         <ServiceStatusBadge service="postgres" name="PostgreSQL" />
         <a
           href={PGADMIN_DIRECT_URL}

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -9,7 +9,6 @@ import {
   KeyIcon,
   PlusIcon,
   TrashIcon,
-  UserCircleIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useState } from "react";
@@ -153,9 +152,9 @@ export default function ProfilePage() {
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
-              <div className="flex items-center space-x-2">
-                <UserCircleIcon className="h-6 w-6 text-blue-600" />
-                <h1 className="text-xl font-bold text-gray-900">Profile & Preferences</h1>
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">Profile and preferences service</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -154,7 +154,7 @@ export default function ProfilePage() {
               <Image src="/logo.svg" alt="LocalCloud Kit" width={36} height={36} />
               <div>
                 <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Profile and preferences service</p>
+                <p className="text-xs text-gray-500">Profile</p>
               </div>
               <div className="h-5 w-px bg-gray-200" />
               <Link

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -132,7 +132,7 @@ export default function RedisDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="In-memory Redis caching service">
+      <DocPageNav title="LocalCloud Kit" subtitle="Redis">
         <ServiceStatusBadge service="redis" name="Redis" />
         <button
           onClick={() => setShowModal(true)}

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -132,7 +132,7 @@ export default function RedisDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="Redis Cache" subtitle="Local in-memory cache for development">
+      <DocPageNav title="LocalCloud Kit" subtitle="In-memory Redis caching service">
         <ServiceStatusBadge service="redis" name="Redis" />
         <button
           onClick={() => setShowModal(true)}

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -184,7 +184,7 @@ export default function S3DocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="S3 Buckets" subtitle="Local object storage via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="Object storage service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/s3"

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -184,7 +184,7 @@ export default function S3DocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Object storage service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="S3">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/s3"

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -217,7 +217,7 @@ export default function SecretsDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="Secrets Manager" subtitle="Local secret storage via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="Secrets management service via LocalStack">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/secrets"

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -217,7 +217,7 @@ export default function SecretsDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="Secrets management service via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="Secrets Manager">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/secrets"

--- a/localcloud-gui/src/app/ssm/page.tsx
+++ b/localcloud-gui/src/app/ssm/page.tsx
@@ -233,7 +233,7 @@ export default function SSMDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="SSM Parameter Store configuration service">
+      <DocPageNav title="LocalCloud Kit" subtitle="Parameter Store">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/ssm"

--- a/localcloud-gui/src/app/ssm/page.tsx
+++ b/localcloud-gui/src/app/ssm/page.tsx
@@ -233,7 +233,7 @@ export default function SSMDocPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100">
-      <DocPageNav title="Parameter Store" subtitle="SSM configuration management via LocalStack">
+      <DocPageNav title="LocalCloud Kit" subtitle="SSM Parameter Store configuration service">
         <ServiceStatusBadge service="localstack" name="LocalStack" />
         <Link
           href="/manage/ssm"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Standardized the main title next to the logo on all non-dashboard pages to "LocalCloud Kit".
- Updated subtitles on non-dashboard pages to explicitly describe the service of each page.

## Type of change

- [x] `fix` — bug fix

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [ ] No hardcoded secrets, credentials, or localhost-only assumptions
- [ ] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Changed
- **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now describe each page's service
```

<div><a href="https://cursor.com/agents/bc-15365995-95be-4c19-a3e0-50e0b160fe09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15365995-95be-4c19-a3e0-50e0b160fe09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->