### PR TITLE
Documentation and resources experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **Manage pages**: Dedicated `/manage/[service]` pages for all AWS services — S3, DynamoDB, Secrets Manager, Lambda, API Gateway, IAM, and SSM Parameter Store — each with full CRUD, list view, inline detail/edit, and delete confirmation
 - **SecretsDetailModal**: Clicking a secret in the resource list now opens a focused single-secret modal showing name, ARN, masked value with reveal toggle, inline edit (value + description), and delete with confirmation; includes "Open in Secrets Manager →" link to the full manage page
 - **Manage links**: "Open Manager →" links added to all existing service viewer modals (BucketViewer, DynamoDBViewer, SecretsManagerViewer, LambdaCodeModal, SSMEditModal, APIGatewayConfigViewer) and to the Resources dropdown in the Dashboard
+- **Docs Hub**: New `/docs` page that centralizes all documentation links, quick verification checklists, and direct manager/admin tool links
 
 ### Changed
 - **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
 - **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now use short service labels
+- **Dashboard menus**: Resources and Services dropdowns now include an **Inspect** option that opens a quick modal with verification checks plus docs/manager/admin links
 
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 ### Changed
 - **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
 - **Non-dashboard headers**: Title next to the logo is now consistent as "LocalCloud Kit" and subtitles now use short service labels
-- **Dashboard menus**: Resources and Services dropdowns now include an **Inspect** option that opens a quick modal with verification checks plus docs/manager/admin links
+- **Dashboard menus**: Resources and Services dropdowns now include an **Inspect** option that opens a quick modal with verification checks plus docs/manager/admin links, with full desktop + mobile parity
 
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret

--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ The header contains three primary dropdowns:
 | Dropdown | Contents |
 |----------|----------|
 | **Resources** | AWS resources organized by category (Storage, Database, Compute, Networking, Security & Identity) — things you create and destroy in LocalStack |
-| **Services** | Platform services (Keycloak, Mailpit, PostgreSQL, Redis) — always-running infrastructure managed via their own admin UIs |
-| **Docs** | Reference documentation for all services and AWS resources |
+| **Services** | Platform services (Keycloak, Mailpit, PostgreSQL, Redis) with quick **Inspect** actions and links to manager/admin tools |
+| **Docs** | Opens the **Docs Hub** (`/docs`) with all documentation pages, verification checklists, and manager/admin links |
 
 ### AWS Service Emulation
 

--- a/localcloud-gui/src/app/docs/page.tsx
+++ b/localcloud-gui/src/app/docs/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import QuickInspectModal, { QuickInspectAction } from "@/components/QuickInspectModal";
+import {
+  DOCS_CATEGORY_LABEL,
+  DOCS_CATEGORY_ORDER,
+  DOCS_HUB_ENTRIES,
+  EXTERNAL_DOCS_LINKS,
+  type DocsHubEntry,
+} from "@/constants/docsHub";
+import {
+  ArrowTopRightOnSquareIcon,
+  BookOpenIcon,
+  CircleStackIcon,
+  ServerIcon,
+  Squares2X2Icon,
+} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+type InspectEntryId = DocsHubEntry["id"] | null;
+
+function CategoryIcon({ category }: { category: DocsHubEntry["category"] }) {
+  if (category === "infrastructure") return <Squares2X2Icon className="h-5 w-5 text-gray-500" />;
+  if (category === "platform-services") return <ServerIcon className="h-5 w-5 text-gray-500" />;
+  return <CircleStackIcon className="h-5 w-5 text-gray-500" />;
+}
+
+export default function DocsHubPage() {
+  const [selectedInspect, setSelectedInspect] = useState<InspectEntryId>(null);
+
+  const selectedEntry = useMemo(
+    () => DOCS_HUB_ENTRIES.find((entry) => entry.id === selectedInspect) ?? null,
+    [selectedInspect]
+  );
+
+  const inspectActions: QuickInspectAction[] = useMemo(() => {
+    if (!selectedEntry) return [];
+    const actions: QuickInspectAction[] = [
+      { label: "Open Docs", href: selectedEntry.docsPath },
+    ];
+    if (selectedEntry.managerPath) {
+      actions.push({
+        label: selectedEntry.managerLabel || "Open Manager",
+        href: selectedEntry.managerPath,
+      });
+    }
+    if (selectedEntry.adminUrl) {
+      actions.push({
+        label: selectedEntry.adminLabel || "Open Admin UI",
+        href: selectedEntry.adminUrl,
+        external: true,
+      });
+    }
+    return actions;
+  }, [selectedEntry]);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="py-4 flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <BookOpenIcon className="h-7 w-7 text-indigo-600" />
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">Documentation Hub</h1>
+                <p className="text-xs text-gray-500">Quick verification + docs + manager/admin links</p>
+              </div>
+            </div>
+            <Link
+              href="/"
+              className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors"
+            >
+              Back to Dashboard
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        <section className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-2">Quick Smoke Checks</h2>
+          <p className="text-sm text-gray-600">
+            Pick any resource/service to open an inspect modal with verification checks and direct links
+            to docs and manager/admin tools.
+          </p>
+        </section>
+
+        {DOCS_CATEGORY_ORDER.map((category) => {
+          const entries = DOCS_HUB_ENTRIES.filter((entry) => entry.category === category);
+          return (
+            <section key={category} className="space-y-3">
+              <h2 className="text-lg font-semibold text-gray-900">{DOCS_CATEGORY_LABEL[category]}</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                {entries.map((entry) => (
+                  <article key={entry.id} className="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+                    <div className="flex items-center justify-between mb-3">
+                      <div className="flex items-center space-x-2">
+                        {entry.icon ? (
+                          <Icon icon={entry.icon} className="w-5 h-5" />
+                        ) : (
+                          <CategoryIcon category={entry.category} />
+                        )}
+                        <h3 className="text-base font-semibold text-gray-900">{entry.title}</h3>
+                      </div>
+                    </div>
+
+                    <p className="text-sm text-gray-600 mb-3">{entry.summary}</p>
+
+                    <div className="mb-4">
+                      <p className="text-xs uppercase tracking-wide text-gray-400 font-semibold mb-1.5">
+                        Verify quickly
+                      </p>
+                      <ul className="space-y-1">
+                        {entry.quickChecks.map((check, idx) => (
+                          <li key={`${entry.id}-check-${idx}`} className="text-sm text-gray-700">
+                            • {check}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="flex items-center flex-wrap gap-2">
+                      <button
+                        onClick={() => setSelectedInspect(entry.id)}
+                        className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+                      >
+                        Inspect
+                      </button>
+                      <Link
+                        href={entry.docsPath}
+                        className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors"
+                      >
+                        Docs
+                      </Link>
+                      {entry.managerPath && (
+                        <Link
+                          href={entry.managerPath}
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors"
+                        >
+                          {entry.managerLabel || "Open Manager"}
+                        </Link>
+                      )}
+                      {entry.adminUrl && (
+                        <a
+                          href={entry.adminUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-50 border border-gray-200 rounded-md hover:bg-gray-100 transition-colors"
+                        >
+                          {entry.adminLabel || "Open Admin UI"}
+                          <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 ml-1.5" />
+                        </a>
+                      )}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+
+        <section className="bg-white rounded-lg border border-gray-200 shadow-sm p-6">
+          <h2 className="text-lg font-semibold text-gray-900 mb-4">External references</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Link</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-gray-500">Description</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {EXTERNAL_DOCS_LINKS.map((link) => (
+                  <tr key={link.href}>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center font-medium text-blue-600 hover:underline"
+                      >
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5" />
+                        {link.title}
+                      </a>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600">{link.description}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+
+      <QuickInspectModal
+        isOpen={!!selectedEntry}
+        onClose={() => setSelectedInspect(null)}
+        title={selectedEntry?.title || "Inspect"}
+        subtitle="Verification checklist and quick links"
+        quickChecks={selectedEntry?.quickChecks || []}
+        actions={inspectActions}
+      />
+    </main>
+  );
+}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -1138,24 +1138,62 @@ export default function Dashboard() {
               {/* Resources */}
               <div className="pt-3 px-2">
                 <p className="px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
-                <button onClick={() => { setShowBuckets(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />S3 Buckets
-                </button>
-                <button onClick={() => { setShowDynamoDB(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB Tables
-                </button>
-                <button onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda Functions
-                </button>
-                <button onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
-                </button>
-                <button onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
-                </button>
-                <button onClick={() => { setShowSSMConfig(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
-                </button>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowBuckets(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />S3 Buckets
+                  </button>
+                  <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowDynamoDB(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB Tables
+                  </button>
+                  <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda Functions
+                  </button>
+                  <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
+                  </button>
+                  <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
+                  </button>
+                  <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowSSMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
+                  </button>
+                  <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => { setShowIAMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />IAM Roles
+                  </button>
+                  <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
               </div>
 
               {/* Services — categorised by kind */}
@@ -1181,23 +1219,31 @@ export default function Dashboard() {
                           </>
                         );
                         const action = service.action;
-                        return action.type === "link" ? (
-                          <Link
-                            key={service.id}
-                            href={action.href}
-                            onClick={closeAllMenus}
-                            className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-                          >
-                            {itemContent}
-                          </Link>
-                        ) : (
-                          <button
-                            key={service.id}
-                            onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
-                            className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-                          >
-                            {itemContent}
-                          </button>
+                        return (
+                          <div key={service.id} className="flex items-center gap-1">
+                            {action.type === "link" ? (
+                              <Link
+                                href={action.href}
+                                onClick={closeAllMenus}
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </Link>
+                            ) : (
+                              <button
+                                onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </button>
+                            )}
+                            <button
+                              onClick={() => openInspectTarget(service.id)}
+                              className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                            >
+                              Inspect
+                            </button>
+                          </div>
                         );
                       })}
                     </div>

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -41,6 +41,21 @@ import SSMConfigModal from "./SSMConfigModal";
 import SSMEditModal from "./SSMEditModal";
 import IAMConfigModal from "./IAMConfigModal";
 import LambdaCodeModal from "./LambdaCodeModal";
+import QuickInspectModal, { QuickInspectAction } from "./QuickInspectModal";
+
+type InspectTargetId =
+  | "localstack"
+  | "s3"
+  | "dynamodb"
+  | "lambda"
+  | "apigateway"
+  | "secretsmanager"
+  | "ssm"
+  | "iam"
+  | "postgres"
+  | "redis"
+  | "keycloak"
+  | "mailpit";
 
 export default function Dashboard() {
   const {
@@ -78,6 +93,7 @@ export default function Dashboard() {
   const [selectedSecretName, setSelectedSecretName] = useState<string>("");
   const [showMailpit, setShowMailpit] = useState(false);
   const [showRedis, setShowRedis] = useState(false);
+  const [inspectTarget, setInspectTarget] = useState<InspectTargetId | null>(null);
 
   const [selectedDynamoDBTable, setSelectedDynamoDBTable] = useState<string>("");
   const [selectedS3Bucket, setSelectedS3Bucket] = useState<string>("");
@@ -140,6 +156,11 @@ export default function Dashboard() {
     setShowProjectMenu(false);
     setShowProfileMenu(false);
     setShowMobileMenu(false);
+  };
+
+  const openInspectTarget = (target: InspectTargetId) => {
+    closeAllMenus();
+    setInspectTarget(target);
   };
 
   const handleModalOpen = (modalKey: ModalKey) => {
@@ -414,6 +435,198 @@ export default function Dashboard() {
     return "Unknown";
   };
 
+  const inspectConfig = (() => {
+    if (!inspectTarget) return null;
+
+    const baseActions: QuickInspectAction[] = [];
+    const withDocs = (href: string) => [...baseActions, { label: "Open Docs", href }];
+    const withManager = (href: string, label = "Open Manager") => [...baseActions, { label, href }];
+    const withAdmin = (href: string, label = "Open Admin UI"): QuickInspectAction => ({
+      label,
+      href,
+      external: true,
+    });
+
+    switch (inspectTarget) {
+      case "localstack":
+        return {
+          title: "LocalStack",
+          subtitle: localstackStatus.running ? "AWS emulator is running locally" : "LocalStack is not running",
+          quickChecks: [
+            "Service health is healthy in the status bar",
+            "Endpoint http://localhost:4566 is reachable",
+            "AWS resources refresh successfully",
+          ],
+          actions: withDocs("/localstack"),
+        };
+      case "s3":
+        return {
+          title: "S3 Buckets",
+          subtitle: "Inspect bucket/object flow quickly",
+          quickChecks: [
+            "Bucket exists in active project",
+            "Recent object keys match expected path format",
+            "Object metadata/content type looks correct",
+          ],
+          actions: [
+            { label: "Open Viewer", onClick: () => setShowBuckets(true) },
+            ...withManager("/manage/s3"),
+            ...withDocs("/s3"),
+          ],
+        };
+      case "dynamodb":
+        return {
+          title: "DynamoDB",
+          subtitle: "Inspect local table data and value types",
+          quickChecks: [
+            "Table exists and is active",
+            "Recent items include required keys",
+            "Numeric/date fields have expected types",
+          ],
+          actions: [
+            { label: "Open Viewer", onClick: () => setShowDynamoDB(true) },
+            ...withManager("/manage/dynamodb"),
+            ...withDocs("/dynamodb"),
+          ],
+        };
+      case "lambda":
+        return {
+          title: "Lambda",
+          subtitle: "Check function setup and local invocation flow",
+          quickChecks: [
+            "Function exists with expected runtime/handler",
+            "Invocation returns expected payload structure",
+            "Function appears in the manager list",
+          ],
+          actions: [
+            { label: "Create / Configure", onClick: () => setShowLambdaConfig(true) },
+            ...withManager("/manage/lambda"),
+            ...withDocs("/lambda"),
+          ],
+        };
+      case "apigateway":
+        return {
+          title: "API Gateway",
+          subtitle: "Validate routes and local invoke URLs",
+          quickChecks: [
+            "API and stage exist",
+            "Route method/path match caller behavior",
+            "Invoke URL responds with expected status",
+          ],
+          actions: [
+            { label: "Create / Configure", onClick: () => setShowAPIGatewayConfig(true) },
+            ...withManager("/manage/apigateway"),
+            ...withDocs("/apigateway"),
+          ],
+        };
+      case "secretsmanager":
+        return {
+          title: "Secrets Manager",
+          subtitle: "Verify secret names and local reads",
+          quickChecks: [
+            "Secret name/path matches application config",
+            "Latest value can be read locally",
+            "ARN and metadata look correct",
+          ],
+          actions: [
+            { label: "Create / Configure", onClick: () => setShowSecretsConfig(true) },
+            ...withManager("/manage/secrets"),
+            ...withDocs("/secrets"),
+          ],
+        };
+      case "ssm":
+        return {
+          title: "Parameter Store",
+          subtitle: "Validate local parameter values and types",
+          quickChecks: [
+            "Expected path exists",
+            "Parameter type matches intended usage",
+            "Consumer app reads latest local value",
+          ],
+          actions: [
+            { label: "Create / Configure", onClick: () => setShowSSMConfig(true) },
+            ...withManager("/manage/ssm"),
+            ...withDocs("/ssm"),
+          ],
+        };
+      case "iam":
+        return {
+          title: "IAM & STS",
+          subtitle: "Inspect role setup and local identity flow",
+          quickChecks: [
+            "Role exists with expected trust policy",
+            "Policies match intended permissions",
+            "STS calls return expected identity values",
+          ],
+          actions: [
+            { label: "Create / Configure", onClick: () => setShowIAMConfig(true) },
+            ...withManager("/manage/iam"),
+            ...withDocs("/iam"),
+          ],
+        };
+      case "postgres":
+        return {
+          title: "PostgreSQL",
+          subtitle: postgres.status === "running" ? "Database is running locally" : "Database is not running",
+          quickChecks: [
+            "Service status is running",
+            "Connection works on localhost:5432",
+            "Recent writes are visible in expected tables",
+          ],
+          actions: [
+            { label: "Open Docs", href: "/postgres" },
+            withAdmin("https://pgadmin.localcloudkit.com:3030"),
+          ],
+        };
+      case "redis":
+        return {
+          title: "Redis Cache",
+          subtitle: redis.status === "running" ? "Redis is running locally" : "Redis is unavailable",
+          quickChecks: [
+            "Redis status is running",
+            "Expected key prefixes appear",
+            "TTL/value structure is correct",
+          ],
+          actions: [
+            { label: "Open Inspector", onClick: () => setShowRedis(true) },
+            ...withManager("/cache", "Open Cache Manager"),
+            ...withDocs("/redis"),
+          ],
+        };
+      case "keycloak":
+        return {
+          title: "Keycloak",
+          subtitle: keycloak.status === "running" ? "Identity provider is running" : "Identity provider is not running",
+          quickChecks: [
+            "Realm and client IDs match app config",
+            "Login/token flows succeed locally",
+            "Role mappings are present",
+          ],
+          actions: [
+            { label: "Open Docs", href: "/keycloak" },
+            withAdmin("https://keycloak.localcloudkit.com:3030"),
+          ],
+        };
+      case "mailpit":
+        return {
+          title: "Mailpit",
+          subtitle: mailpit.status === "healthy" ? "Mailpit inbox is available" : "Mailpit inbox is unavailable",
+          quickChecks: [
+            "SMTP test emails are received",
+            "To/from/subject values are correct",
+            "Unread count increases after send",
+          ],
+          actions: [
+            { label: "Open Inbox Preview", onClick: () => setShowMailpit(true) },
+            { label: "Open Docs", href: "/mailpit" },
+            withAdmin("https://mailpit.localcloudkit.com:3030"),
+          ],
+        };
+      default:
+        return null;
+    }
+  })();
+
   if (error) {
     return (
       <AnimatePresence mode="wait">
@@ -479,7 +692,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />
                         S3 Buckets
                       </button>
-                      <Link href="/manage/s3" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("s3")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/s3" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
 
                     {/* Database */}
@@ -493,7 +714,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />
                         DynamoDB
                       </button>
-                      <Link href="/manage/dynamodb" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("dynamodb")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/dynamodb" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
 
                     {/* Compute */}
@@ -507,7 +736,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Lambda
                       </button>
-                      <Link href="/manage/lambda" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("lambda")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/lambda" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
 
                     {/* Networking */}
@@ -521,7 +758,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
                         API Gateway
                       </button>
-                      <Link href="/manage/apigateway" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("apigateway")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/apigateway" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
 
                     {/* Security & Identity */}
@@ -535,7 +780,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Secrets Manager
                       </button>
-                      <Link href="/manage/secrets" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("secretsmanager")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/secrets" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
                     <div className="flex items-center justify-between px-2">
                       <button
@@ -545,7 +798,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Parameter Store
                       </button>
-                      <Link href="/manage/ssm" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("ssm")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/ssm" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
                     <div className="flex items-center justify-between px-2">
                       <button
@@ -555,7 +816,15 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />
                         IAM Roles
                       </button>
-                      <Link href="/manage/iam" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => openInspectTarget("iam")}
+                          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                        >
+                          Inspect
+                        </button>
+                        <Link href="/manage/iam" onClick={closeAllMenus} className="px-2 py-1 text-xs text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded whitespace-nowrap">Manage →</Link>
+                      </div>
                     </div>
 
                   </div>
@@ -601,23 +870,31 @@ export default function Dashboard() {
                               </>
                             );
                             const action = service.action;
-                            return action.type === "link" ? (
-                              <Link
-                                key={service.id}
-                                href={action.href}
-                                onClick={() => closeAllMenus()}
-                                className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                              >
-                                {itemContent}
-                              </Link>
-                            ) : (
-                              <button
-                                key={service.id}
-                                onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
-                                className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                              >
-                                {itemContent}
-                              </button>
+                            return (
+                              <div key={service.id} className="flex items-center justify-between px-2">
+                                {action.type === "link" ? (
+                                  <Link
+                                    href={action.href}
+                                    onClick={() => closeAllMenus()}
+                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                  >
+                                    {itemContent}
+                                  </Link>
+                                ) : (
+                                  <button
+                                    onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
+                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                  >
+                                    {itemContent}
+                                  </button>
+                                )}
+                                <button
+                                  onClick={() => openInspectTarget(service.id)}
+                                  className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                                >
+                                  Inspect
+                                </button>
+                              </div>
                             );
                           })}
                         </div>
@@ -639,7 +916,17 @@ export default function Dashboard() {
                 </button>
                 {showDocsMenu && (
                   <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    <Link
+                      href="/docs"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center w-full px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
+                    >
+                      <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+                      Docs Hub
+                    </Link>
+
                     {/* Infrastructure */}
+                    <div className="border-t border-gray-100 mt-1" />
                     <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
                     <Link
                       href="/localstack"
@@ -921,6 +1208,9 @@ export default function Dashboard() {
               {/* Docs */}
               <div className="pt-2 px-2 border-t border-gray-100 mt-2">
                 <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Docs</p>
+                <Link href="/docs" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm font-medium text-indigo-700 rounded-lg hover:bg-indigo-50 transition-colors">
+                  <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />Docs Hub
+                </Link>
                 <Link href="/localstack" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
                   <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />LocalStack
                 </Link>
@@ -1132,6 +1422,17 @@ export default function Dashboard() {
       </div>
 
       {/* Modals */}
+
+      {inspectConfig && (
+        <QuickInspectModal
+          isOpen={!!inspectConfig}
+          onClose={() => setInspectTarget(null)}
+          title={inspectConfig.title}
+          subtitle={inspectConfig.subtitle}
+          quickChecks={inspectConfig.quickChecks}
+          actions={inspectConfig.actions}
+        />
+      )}
 
       {showDynamoDBConfig && (
         <DynamoDBConfigModal

--- a/localcloud-gui/src/components/DocPageNav.tsx
+++ b/localcloud-gui/src/components/DocPageNav.tsx
@@ -83,7 +83,17 @@ export default function DocPageNav({ title, subtitle, children }: DocPageNavProp
               </button>
               {showDocsMenu && (
                 <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                  <Link
+                    href="/docs"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
+                  >
+                    <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+                    Docs Hub
+                  </Link>
+
                   {/* Infrastructure */}
+                  <div className="border-t border-gray-100 mt-1" />
                   <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
                     Infrastructure
                   </p>
@@ -102,6 +112,15 @@ export default function DocPageNav({ title, subtitle, children }: DocPageNavProp
                     AWS Resources
                   </p>
                   <Link
+                    href="/connect"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <BookOpenIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Connect
+                  </Link>
+
+                  <Link
                     href="/s3"
                     onClick={() => setShowDocsMenu(false)}
                     className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
@@ -118,12 +137,44 @@ export default function DocPageNav({ title, subtitle, children }: DocPageNavProp
                     DynamoDB
                   </Link>
                   <Link
+                    href="/lambda"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                    Lambda
+                  </Link>
+                  <Link
+                    href="/apigateway"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                    API Gateway
+                  </Link>
+                  <Link
                     href="/secrets"
                     onClick={() => setShowDocsMenu(false)}
                     className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                   >
                     <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
                     Secrets Manager
+                  </Link>
+                  <Link
+                    href="/ssm"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <ServerIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    Parameter Store
+                  </Link>
+                  <Link
+                    href="/iam"
+                    onClick={() => setShowDocsMenu(false)}
+                    className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                  >
+                    <KeyIcon className="h-4 w-4 mr-3 text-gray-400" />
+                    IAM &amp; STS
                   </Link>
 
                   {/* Services */}

--- a/localcloud-gui/src/components/QuickInspectModal.tsx
+++ b/localcloud-gui/src/components/QuickInspectModal.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { ArrowTopRightOnSquareIcon, CheckCircleIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { useEffect } from "react";
+
+export interface QuickInspectAction {
+  label: string;
+  href?: string;
+  external?: boolean;
+  onClick?: () => void;
+}
+
+interface QuickInspectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  subtitle: string;
+  quickChecks: string[];
+  actions: QuickInspectAction[];
+}
+
+export default function QuickInspectModal({
+  isOpen,
+  onClose,
+  title,
+  subtitle,
+  quickChecks,
+  actions,
+}: QuickInspectModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleActionClick = (callback?: () => void) => {
+    onClose();
+    if (callback) {
+      setTimeout(() => callback(), 0);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onClose}>
+      <div
+        className="w-full max-w-xl bg-white rounded-xl shadow-2xl overflow-hidden"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+            <p className="text-sm text-gray-500 mt-0.5">{subtitle}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
+            aria-label="Close inspect modal"
+          >
+            <XMarkIcon className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="px-6 py-5">
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">Quick verification checklist</h3>
+          <ul className="space-y-2">
+            {quickChecks.map((item, idx) => (
+              <li key={`${item}-${idx}`} className="flex items-start text-sm text-gray-700">
+                <CheckCircleIcon className="h-4 w-4 text-green-500 mt-0.5 mr-2 flex-shrink-0" />
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 flex items-center flex-wrap gap-2">
+          {actions.map((action, idx) => {
+            if (action.href && action.external) {
+              return (
+                <a
+                  key={`${action.label}-${idx}`}
+                  href={action.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={onClose}
+                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+                >
+                  {action.label}
+                  <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 ml-1.5" />
+                </a>
+              );
+            }
+
+            if (action.href) {
+              return (
+                <Link
+                  key={`${action.label}-${idx}`}
+                  href={action.href}
+                  onClick={onClose}
+                  className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+                >
+                  {action.label}
+                </Link>
+              );
+            }
+
+            return (
+              <button
+                key={`${action.label}-${idx}`}
+                onClick={() => handleActionClick(action.onClick)}
+                className="inline-flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 border border-indigo-200 rounded-md hover:bg-indigo-100 transition-colors"
+              >
+                {action.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/constants/docsHub.ts
+++ b/localcloud-gui/src/constants/docsHub.ts
@@ -1,0 +1,261 @@
+export type DocsCategory = "infrastructure" | "aws-resources" | "platform-services";
+
+export interface DocsHubEntry {
+  id:
+    | "localstack"
+    | "connect"
+    | "s3"
+    | "dynamodb"
+    | "lambda"
+    | "apigateway"
+    | "secrets"
+    | "ssm"
+    | "iam"
+    | "redis"
+    | "mailpit"
+    | "postgres"
+    | "keycloak";
+  title: string;
+  category: DocsCategory;
+  docsPath: string;
+  summary: string;
+  quickChecks: string[];
+  managerPath?: string;
+  managerLabel?: string;
+  adminUrl?: string;
+  adminLabel?: string;
+  icon?: string;
+}
+
+export interface ExternalDocsLink {
+  title: string;
+  href: string;
+  description: string;
+}
+
+export const DOCS_CATEGORY_LABEL: Record<DocsCategory, string> = {
+  infrastructure: "Infrastructure",
+  "aws-resources": "AWS Resources",
+  "platform-services": "Platform Services",
+};
+
+export const DOCS_CATEGORY_ORDER: DocsCategory[] = [
+  "infrastructure",
+  "aws-resources",
+  "platform-services",
+];
+
+export const DOCS_HUB_ENTRIES: DocsHubEntry[] = [
+  {
+    id: "localstack",
+    title: "LocalStack",
+    category: "infrastructure",
+    docsPath: "/localstack",
+    summary: "Core AWS emulation runtime used by all AWS resource workflows.",
+    quickChecks: [
+      "LocalStack status is healthy",
+      "Endpoint http://localhost:4566 is reachable",
+      "Resources list updates after create/destroy actions",
+    ],
+  },
+  {
+    id: "connect",
+    title: "Connect",
+    category: "infrastructure",
+    docsPath: "/connect",
+    summary: "SDK endpoint configuration reference for local integration.",
+    quickChecks: [
+      "AWS endpoint points to LocalStack",
+      "Credentials are test/test in local mode",
+      "Region is set consistently across services",
+    ],
+  },
+  {
+    id: "s3",
+    title: "S3 Buckets",
+    category: "aws-resources",
+    docsPath: "/s3",
+    summary: "Verify object uploads, key paths, and metadata quickly.",
+    quickChecks: [
+      "Bucket exists in active project",
+      "Latest object key matches expected pattern",
+      "Object metadata/type looks correct",
+    ],
+    managerPath: "/manage/s3",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-s3",
+  },
+  {
+    id: "dynamodb",
+    title: "DynamoDB",
+    category: "aws-resources",
+    docsPath: "/dynamodb",
+    summary: "Inspect table records and confirm value/type shape.",
+    quickChecks: [
+      "Target table exists and is ACTIVE",
+      "Recent items include expected keys",
+      "Numeric/date fields use expected types",
+    ],
+    managerPath: "/manage/dynamodb",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-dynamodb",
+  },
+  {
+    id: "lambda",
+    title: "Lambda",
+    category: "aws-resources",
+    docsPath: "/lambda",
+    summary: "Confirm function config and invocation response shape.",
+    quickChecks: [
+      "Function exists and shows active state",
+      "Handler/runtime match your deployment",
+      "Invocation output has expected keys/types",
+    ],
+    managerPath: "/manage/lambda",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-lambda",
+  },
+  {
+    id: "apigateway",
+    title: "API Gateway",
+    category: "aws-resources",
+    docsPath: "/apigateway",
+    summary: "Validate routes/integrations and local invoke URLs.",
+    quickChecks: [
+      "API/stage exists in project",
+      "Route method/path match application calls",
+      "Invoke URL returns expected status and payload",
+    ],
+    managerPath: "/manage/apigateway",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-api-gateway",
+  },
+  {
+    id: "secrets",
+    title: "Secrets Manager",
+    category: "aws-resources",
+    docsPath: "/secrets",
+    summary: "Verify secret names, values, and retrieval behavior locally.",
+    quickChecks: [
+      "Secret name/path matches app config",
+      "Latest value is available",
+      "Consumer app can read secret without cloud calls",
+    ],
+    managerPath: "/manage/secrets",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-secrets-manager",
+  },
+  {
+    id: "ssm",
+    title: "Parameter Store",
+    category: "aws-resources",
+    docsPath: "/ssm",
+    summary: "Check parameter paths, types, and current values.",
+    quickChecks: [
+      "Expected parameter path exists",
+      "Type is String/StringList/SecureString as intended",
+      "Runtime reads local value correctly",
+    ],
+    managerPath: "/manage/ssm",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-systems-manager",
+  },
+  {
+    id: "iam",
+    title: "IAM & STS",
+    category: "aws-resources",
+    docsPath: "/iam",
+    summary: "Inspect role setup and local credential/assume-role flows.",
+    quickChecks: [
+      "Role exists with expected trust service",
+      "Policy attachment matches intended access",
+      "STS call returns expected identity/session data",
+    ],
+    managerPath: "/manage/iam",
+    managerLabel: "Open Manager",
+    icon: "logos:aws-iam",
+  },
+  {
+    id: "redis",
+    title: "Redis Cache",
+    category: "platform-services",
+    docsPath: "/redis",
+    summary: "Quickly verify cache keys, value format, and service health.",
+    quickChecks: [
+      "Redis service status is running",
+      "Expected key prefixes appear after app action",
+      "TTL/value structure looks correct",
+    ],
+    managerPath: "/cache",
+    managerLabel: "Open Manager",
+    icon: "logos:redis",
+  },
+  {
+    id: "mailpit",
+    title: "Mailpit",
+    category: "platform-services",
+    docsPath: "/mailpit",
+    summary: "Confirm local email delivery and payload content.",
+    quickChecks: [
+      "SMTP submissions are received",
+      "To/from/subject values are correct",
+      "Unread count updates after test send",
+    ],
+    adminUrl: "https://mailpit.localcloudkit.com:3030",
+    adminLabel: "Open Admin UI",
+    icon: "mdi:email-outline",
+  },
+  {
+    id: "postgres",
+    title: "PostgreSQL",
+    category: "platform-services",
+    docsPath: "/postgres",
+    summary: "Verify DB availability and inspect local SQL data paths.",
+    quickChecks: [
+      "Postgres status is running",
+      "Client can connect on localhost:5432",
+      "Recent writes appear in expected table",
+    ],
+    adminUrl: "https://pgadmin.localcloudkit.com:3030",
+    adminLabel: "Open Admin UI",
+    icon: "logos:postgresql",
+  },
+  {
+    id: "keycloak",
+    title: "Keycloak",
+    category: "platform-services",
+    docsPath: "/keycloak",
+    summary: "Validate realms/clients and local auth token flows.",
+    quickChecks: [
+      "Keycloak service is running",
+      "Realm and client IDs match app config",
+      "Token issue/refresh works in local auth flow",
+    ],
+    adminUrl: "https://keycloak.localcloudkit.com:3030",
+    adminLabel: "Open Admin UI",
+    icon: "simple-icons:keycloak",
+  },
+];
+
+export const EXTERNAL_DOCS_LINKS: ExternalDocsLink[] = [
+  {
+    title: "AWS LocalStack Coverage",
+    href: "https://docs.localstack.cloud/references/coverage/",
+    description: "Service-by-service coverage details for AWS APIs in LocalStack.",
+  },
+  {
+    title: "AWS SDK Endpoint Configuration",
+    href: "https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html",
+    description: "Reference for overriding SDK endpoints in local development.",
+  },
+  {
+    title: "Redis CLI Reference",
+    href: "https://redis.io/docs/latest/commands/",
+    description: "Quick lookup for Redis commands used during local verification.",
+  },
+  {
+    title: "Mailpit Docs",
+    href: "https://mailpit.axllent.org/docs/",
+    description: "Mailpit UI and SMTP behavior reference.",
+  },
+];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Introduced a new `/docs` hub page for centralized verification, quick checks, and links to documentation and manager/admin tools.
- Added "Inspect" actions to Dashboard resource and service entries, opening a quick-inspect modal for status, recent data, and type checks.
- Consolidated documentation and resource links into a single, shared registry.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [x] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [x] `README.md` updated if access URLs or features changed
- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Added
- **Docs**: Introduced a new `/docs` hub page for centralized verification, quick checks, and links to documentation and manager/admin tools.
- **Dashboard**: Added "Inspect" actions to resource and service entries, opening a quick-inspect modal for status, recent data, and type checks.
```

<div><a href="https://cursor.com/agents/bc-306f4498-5927-49da-b471-ab464776fd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-306f4498-5927-49da-b471-ab464776fd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->