### PR TITLE
Other AWS resource modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **SecretsDetailModal**: Clicking a secret in the resource list now opens a focused single-secret modal showing name, ARN, masked value with reveal toggle, inline edit (value + description), and delete with confirmation; includes "Open in Secrets Manager →" link to the full manage page
 - **Manage links**: "Open Manager →" links added to all existing service viewer modals (BucketViewer, DynamoDBViewer, SecretsManagerViewer, LambdaCodeModal, SSMEditModal, APIGatewayConfigViewer) and to the Resources dropdown in the Dashboard
 - **Docs Hub**: New `/docs` page that centralizes all documentation links, quick verification checklists, and direct manager/admin tool links
+- **IAMRolePoliciesModal**: Added a dashboard IAM role viewer modal that shows role metadata and attached policies with copy-ARN support
+- **docs/LOCAL_WORKFLOW.md**: Added a dashboard preview section listing viewer modals for all supported AWS resource types
 
 ### Changed
 - **DocPageNav**: Dashboard link now appears to the right of the page title and subtitle in the nav header
@@ -16,6 +18,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **Dashboard menus**: Resources and Services dropdowns now include an **Inspect** option that opens a quick modal with verification checks plus docs/manager/admin links, with full desktop + mobile parity
 - **Dashboard + ResourceList**: Docs dropdown is now grouped into three columns, resource dropdown rows have roomier spacing with icon-first preview/manage controls, and AWS resource rows show less text truncation
 - **Dashboard actions**: Resource dropdown icons now map by intent — eye opens viewers (where available), checklist opens inspect checks, and external-link opens full manage pages
+- **Dashboard resources**: Added viewer action wiring for Lambda, API Gateway, Secrets Manager, SSM, and IAM from the Resources dropdown and resource list
 
 ### Fixed
 - **SecretsDetailModal**: Clicking a secret from the resource list previously opened all secrets; now correctly opens only the clicked secret

--- a/docs/LOCAL_WORKFLOW.md
+++ b/docs/LOCAL_WORKFLOW.md
@@ -168,6 +168,20 @@ make start
 make restart
 ```
 
+### Preview AWS Resources from Dashboard
+
+From the Dashboard **Resources** panel, you can now open resource-specific viewer modals directly for:
+
+- S3 buckets
+- DynamoDB tables
+- Lambda functions (code viewer)
+- API Gateway APIs (configuration viewer)
+- Secrets Manager secrets
+- SSM parameters
+- IAM roles (role + attached policies viewer)
+
+If no active resource exists yet for a type, create one first from **+ Add**.
+
 ### Regenerate Certificates
 
 If certificates expire or need regeneration:

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -3,7 +3,7 @@
 import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
 import { resourceApi } from "@/services/api";
-import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig, ModalKey } from "@/types";
+import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig, ModalKey, Resource } from "@/types";
 import { PLATFORM_SERVICES, PLATFORM_SERVICE_KINDS, SERVICE_KIND_LABEL } from "@/constants/platformServices";
 import {
   ArrowTopRightOnSquareIcon,
@@ -44,6 +44,7 @@ import SSMConfigModal from "./SSMConfigModal";
 import SSMEditModal from "./SSMEditModal";
 import IAMConfigModal from "./IAMConfigModal";
 import LambdaCodeModal from "./LambdaCodeModal";
+import IAMRolePoliciesModal from "./IAMRolePoliciesModal";
 import QuickInspectModal, { QuickInspectAction } from "./QuickInspectModal";
 
 type InspectTargetId =
@@ -85,9 +86,11 @@ export default function Dashboard() {
   const [showSSMConfig, setShowSSMConfig] = useState(false);
   const [showSSMEdit, setShowSSMEdit] = useState(false);
   const [showIAMConfig, setShowIAMConfig] = useState(false);
+  const [showIAMRolePolicies, setShowIAMRolePolicies] = useState(false);
   const [editingSSMParameter, setEditingSSMParameter] = useState<string>("");
   const [showLambdaCode, setShowLambdaCode] = useState(false);
   const [viewingLambdaFunction, setViewingLambdaFunction] = useState<string>("");
+  const [viewingIAMRole, setViewingIAMRole] = useState<string>("");
   const [configuringAPIGateway, setConfiguringAPIGateway] = useState<{ apiId: string; apiName: string } | null>(null);
   const [showLogs, setShowLogs] = useState(false);
   const [showBuckets, setShowBuckets] = useState(false);
@@ -468,6 +471,69 @@ export default function Dashboard() {
     }
   };
 
+  const getFirstActiveResourceByType = (type: Resource["type"]) =>
+    resources.find((resource) => resource.project === projectName && resource.type === type && resource.status === "active");
+
+  const getApiIdFromResource = (resource: Resource) => resource.details?.apiId || resource.id.replace(/^apigateway-/, "");
+
+  const openLambdaViewer = (functionName?: string) => {
+    const targetName = functionName || getFirstActiveResourceByType("lambda")?.name;
+    if (!targetName) {
+      toast.error("No active Lambda functions available");
+      return;
+    }
+    setViewingLambdaFunction(targetName);
+    setShowLambdaCode(true);
+  };
+
+  const openAPIGatewayViewer = (apiId?: string, apiName?: string) => {
+    if (apiId && apiName) {
+      setConfiguringAPIGateway({ apiId, apiName });
+      return;
+    }
+
+    const resource = getFirstActiveResourceByType("apigateway");
+    if (!resource) {
+      toast.error("No active API Gateway resources available");
+      return;
+    }
+
+    setConfiguringAPIGateway({
+      apiId: getApiIdFromResource(resource),
+      apiName: resource.name,
+    });
+  };
+
+  const openSecretsViewer = (secretName?: string) => {
+    const targetName = secretName || getFirstActiveResourceByType("secretsmanager")?.name;
+    if (!targetName) {
+      toast.error("No active secrets available");
+      return;
+    }
+    setSelectedSecretName(targetName);
+    setShowSecretsManager(true);
+  };
+
+  const openSSMViewer = (parameterName?: string) => {
+    const targetName = parameterName || getFirstActiveResourceByType("ssm")?.name;
+    if (!targetName) {
+      toast.error("No active SSM parameters available");
+      return;
+    }
+    setEditingSSMParameter(targetName);
+    setShowSSMEdit(true);
+  };
+
+  const openIAMRoleViewer = (roleName?: string) => {
+    const targetName = roleName || getFirstActiveResourceByType("iam")?.name;
+    if (!targetName) {
+      toast.error("No active IAM roles available");
+      return;
+    }
+    setViewingIAMRole(targetName);
+    setShowIAMRolePolicies(true);
+  };
+
   const serviceStatusClass = (status: string) => {
     if (status === "running") return "bg-green-100 text-green-800";
     if (status === "starting") return "bg-yellow-100 text-yellow-700";
@@ -779,7 +845,10 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Lambda
                       </button>
-                      {renderResourceActions("Lambda", "lambda", "/manage/lambda")}
+                      {renderResourceActions("Lambda", "lambda", "/manage/lambda", () => {
+                        openLambdaViewer();
+                        closeAllMenus();
+                      })}
                     </div>
 
                     {/* Networking */}
@@ -793,7 +862,10 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
                         API Gateway
                       </button>
-                      {renderResourceActions("API Gateway", "apigateway", "/manage/apigateway")}
+                      {renderResourceActions("API Gateway", "apigateway", "/manage/apigateway", () => {
+                        openAPIGatewayViewer();
+                        closeAllMenus();
+                      })}
                     </div>
 
                     {/* Security & Identity */}
@@ -807,7 +879,10 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Secrets Manager
                       </button>
-                      {renderResourceActions("Secrets Manager", "secretsmanager", "/manage/secrets")}
+                      {renderResourceActions("Secrets Manager", "secretsmanager", "/manage/secrets", () => {
+                        openSecretsViewer();
+                        closeAllMenus();
+                      })}
                     </div>
                     <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
                       <button
@@ -817,7 +892,10 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
                         Parameter Store
                       </button>
-                      {renderResourceActions("Parameter Store", "ssm", "/manage/ssm")}
+                      {renderResourceActions("Parameter Store", "ssm", "/manage/ssm", () => {
+                        openSSMViewer();
+                        closeAllMenus();
+                      })}
                     </div>
                     <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
                       <button
@@ -827,7 +905,10 @@ export default function Dashboard() {
                         <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />
                         IAM Roles
                       </button>
-                      {renderResourceActions("IAM Roles", "iam", "/manage/iam")}
+                      {renderResourceActions("IAM Roles", "iam", "/manage/iam", () => {
+                        openIAMRoleViewer();
+                        closeAllMenus();
+                      })}
                     </div>
 
                   </div>
@@ -1422,19 +1503,16 @@ export default function Dashboard() {
                 setShowDynamoDB(true);
               }}
               onViewSecretsManager={(name) => {
-                setSelectedSecretName(name);
-                setShowSecretsManager(true);
+                openSecretsViewer(name);
               }}
               onEditSSM={(name) => {
-                setEditingSSMParameter(name);
-                setShowSSMEdit(true);
+                openSSMViewer(name);
               }}
               onViewLambdaCode={(name) => {
-                setViewingLambdaFunction(name);
-                setShowLambdaCode(true);
+                openLambdaViewer(name);
               }}
-              onConfigureAPIGateway={(apiId, apiName) => setConfiguringAPIGateway({ apiId, apiName })}
-              onViewIAMRole={() => {}}
+              onConfigureAPIGateway={(apiId, apiName) => openAPIGatewayViewer(apiId, apiName)}
+              onViewIAMRole={(name) => openIAMRoleViewer(name)}
             />
           ) : (
             <div className="bg-white rounded-lg shadow border border-gray-200">
@@ -1585,6 +1663,14 @@ export default function Dashboard() {
           isOpen={showLambdaCode}
           onClose={() => { setShowLambdaCode(false); setViewingLambdaFunction(""); }}
           functionName={viewingLambdaFunction}
+        />
+      )}
+
+      {showIAMRolePolicies && viewingIAMRole && (
+        <IAMRolePoliciesModal
+          isOpen={showIAMRolePolicies}
+          onClose={() => { setShowIAMRolePolicies(false); setViewingIAMRole(""); }}
+          roleName={viewingIAMRole}
         />
       )}
 

--- a/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
+++ b/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  ArrowTopRightOnSquareIcon,
+  CheckIcon,
+  ClipboardDocumentIcon,
+  ShieldCheckIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import Link from "next/link";
+import { Icon } from "@iconify/react";
+
+interface IAMRole {
+  RoleName: string;
+  Arn?: string;
+  Description?: string;
+  CreateDate?: string;
+  Path?: string;
+}
+
+interface IAMPolicy {
+  PolicyName: string;
+  PolicyArn?: string;
+}
+
+interface IAMRolePoliciesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  roleName: string;
+}
+
+export default function IAMRolePoliciesModal({
+  isOpen,
+  onClose,
+  roleName,
+}: IAMRolePoliciesModalProps) {
+  const [role, setRole] = useState<IAMRole | null>(null);
+  const [policies, setPolicies] = useState<IAMPolicy[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copiedArn, setCopiedArn] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen || !roleName) return;
+
+    const loadRoleData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [roleRes, policiesRes] = await Promise.all([
+          fetch(`/api/iam/roles/${encodeURIComponent(roleName)}`),
+          fetch(`/api/iam/roles/${encodeURIComponent(roleName)}/policies`),
+        ]);
+
+        const [roleData, policiesData] = await Promise.all([
+          roleRes.json(),
+          policiesRes.json(),
+        ]);
+
+        if (!roleData.success) {
+          throw new Error(roleData.error || "Failed to load IAM role");
+        }
+
+        setRole(roleData.data || null);
+        setPolicies(policiesData.success ? policiesData.data || [] : []);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load IAM role");
+        setRole(null);
+        setPolicies([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadRoleData();
+  }, [isOpen, roleName]);
+
+  if (!isOpen) return null;
+
+  const handleCopyArn = () => {
+    if (!role?.Arn) return;
+    navigator.clipboard.writeText(role.Arn).then(() => {
+      setCopiedArn(true);
+      setTimeout(() => setCopiedArn(false), 2000);
+    });
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center space-x-3">
+            <div className="p-2 bg-indigo-50 rounded-lg">
+              <Icon icon="logos:aws-iam" className="w-5 h-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">IAM Role Details</h2>
+              <p className="text-xs text-gray-500 font-mono">{roleName}</p>
+            </div>
+          </div>
+          <div className="flex items-center space-x-2">
+            <Link
+              href="/manage/iam"
+              className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors"
+            >
+              <span>Open Manager</span>
+              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+            </Link>
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
+              aria-label="Close"
+            >
+              <XMarkIcon className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="p-6 overflow-y-auto space-y-5">
+          {loading ? (
+            <div className="text-center text-gray-500 py-8">Loading role details...</div>
+          ) : error ? (
+            <div className="text-center py-6">
+              <p className="text-red-600">{error}</p>
+              <button
+                onClick={onClose}
+                className="mt-4 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200"
+              >
+                Close
+              </button>
+            </div>
+          ) : (
+            <>
+              {role && (
+                <div className="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100">
+                  {role.Arn && (
+                    <div className="flex items-center px-5 py-3">
+                      <dt className="w-24 text-xs font-medium text-gray-500 flex-shrink-0">ARN</dt>
+                      <dd className="flex items-center space-x-2 flex-1 min-w-0">
+                        <code className="text-xs font-mono text-gray-700 truncate flex-1">{role.Arn}</code>
+                        <button
+                          onClick={handleCopyArn}
+                          className="flex-shrink-0 text-gray-400 hover:text-gray-600"
+                          title="Copy ARN"
+                        >
+                          {copiedArn ? (
+                            <CheckIcon className="h-4 w-4 text-green-500" />
+                          ) : (
+                            <ClipboardDocumentIcon className="h-4 w-4" />
+                          )}
+                        </button>
+                      </dd>
+                    </div>
+                  )}
+                  {role.Path && (
+                    <div className="flex items-center px-5 py-3">
+                      <dt className="w-24 text-xs font-medium text-gray-500">Path</dt>
+                      <dd className="text-sm font-mono text-gray-700">{role.Path}</dd>
+                    </div>
+                  )}
+                  {role.CreateDate && (
+                    <div className="flex items-center px-5 py-3">
+                      <dt className="w-24 text-xs font-medium text-gray-500">Created</dt>
+                      <dd className="text-sm text-gray-700">{new Date(role.CreateDate).toLocaleString()}</dd>
+                    </div>
+                  )}
+                  {role.Description && (
+                    <div className="flex items-center px-5 py-3">
+                      <dt className="w-24 text-xs font-medium text-gray-500">Description</dt>
+                      <dd className="text-sm text-gray-700">{role.Description}</dd>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div>
+                <h3 className="text-sm font-semibold text-gray-900 mb-3">Attached Policies</h3>
+                {policies.length === 0 ? (
+                  <div className="bg-white border border-gray-200 rounded-lg p-5 text-center">
+                    <p className="text-sm text-gray-400">No policies attached</p>
+                  </div>
+                ) : (
+                  <div className="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100">
+                    {policies.map((policy) => (
+                      <div key={policy.PolicyName} className="flex items-center px-5 py-3">
+                        <ShieldCheckIcon className="h-4 w-4 text-indigo-400 mr-3" />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-medium text-gray-900">{policy.PolicyName}</p>
+                          {policy.PolicyArn && (
+                            <p className="text-xs text-gray-400 font-mono truncate">{policy.PolicyArn}</p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Added "view" modals for Lambda, API Gateway, Secrets Manager, SSM Parameter Store, and IAM resources from the dashboard.
- Fixed the non-functional "Policies" button for IAM in the dashboard resource list to open a dedicated viewer modal.
- Introduced a new `IAMRolePoliciesModal` to display IAM role metadata and attached policies.

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [x] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
- [x] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Added
- **Dashboard**: Added "view" modals for Lambda, API Gateway, Secrets Manager, SSM Parameter Store, and IAM resources.
- **IAM**: Introduced `IAMRolePoliciesModal` to display role details and attached policies.
### Fixed
- **Dashboard**: Corrected the IAM "Policies" button to open the new IAM viewer modal instead of a no-op.
```

<div><a href="https://cursor.com/agents/bc-f2268a8b-d272-442e-a015-d642cd8d0b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2268a8b-d272-442e-a015-d642cd8d0b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->