### PR TITLE
docs: update service example from MailHog to Mailpit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ POSTHOG_INTERNAL_URL=http://posthog-web:8000
 
 ## Adding a New Service
 
-When adding a new service (e.g., MailHog):
+When adding a new service (e.g., Mailpit):
 
 1. **docker-compose.yml** — add the service block with the image, ports, network, and restart policy
 2. **traefik/dynamic.yml** — add a router and service entry if it needs HTTPS routing through Traefik


### PR DESCRIPTION
## Summary

- Update documentation example in AGENTS.md to reference Mailpit instead of MailHog as the example service for adding new services
- Reflects current best practices for email testing in development environments

## Type of change

- [x] `docs` — documentation only

## Pre-merge checklist

### Documentation & changelog
- [x] Documentation updated with current service references

## Notes

This is a minor documentation update to use Mailpit as the example service instead of MailHog when documenting the process for adding new services to the development environment. No functional changes.

https://claude.ai/code/session_019kNjQTywhGVMHQCf4v1J3w