### PR TITLE
style(gui): replace deprecated tailwind classes with canonical equivalents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ start-legacy: ## Start all services using LocalStack 4.14 (community legacy)
 
 stop: ## Stop all Docker services
 	@echo "$(YELLOW)Stopping all services...$(NC)"
-	docker compose down
+	docker compose down --remove-orphans
 
 restart: stop start ## Restart all Docker services
 
@@ -119,7 +119,7 @@ clean-volumes: ## Clean up Docker volumes (removes all data)
 	@echo "$(YELLOW)Cleaning up Docker volumes...$(NC)"
 	@echo "$(RED)WARNING: This will remove all Docker volumes and data!$(NC)"
 	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || exit 1
-	@docker compose down -v
+	@docker compose down -v --remove-orphans
 	@docker volume prune -f
 	@echo "$(GREEN)Docker volumes cleaned$(NC)"
 
@@ -127,7 +127,7 @@ clean-all: ## Clean up everything including images and containers
 	@echo "$(YELLOW)Cleaning up all Docker resources...$(NC)"
 	@echo "$(RED)WARNING: This will remove all containers, images, and volumes!$(NC)"
 	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || exit 1
-	@docker compose down -v --rmi all
+	@docker compose down -v --rmi all --remove-orphans
 	@docker system prune -af --volumes
 	@echo "$(GREEN)All Docker resources cleaned$(NC)"
 

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ keycloak-logs: ## View Keycloak container logs
 	docker compose logs -f keycloak
 
 posthog-logs: ## View PostHog service logs
-	docker compose logs -f posthog-web posthog-worker posthog-plugin-server
+	docker compose logs -f posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init
 
 # Setup and Utilities
 setup: ## Initial setup - create directories and install dependencies

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ keycloak-logs: ## View Keycloak container logs
 	docker compose logs -f keycloak
 
 posthog-logs: ## View PostHog service logs
-	docker compose logs -f posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init
+	docker compose logs -f posthog-db-migrate posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init
 
 # Setup and Utilities
 setup: ## Initial setup - create directories and install dependencies

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,9 +196,11 @@ services:
       - "traefik.http.services.mailpit.loadbalancer.server.port=8025"
 
   # PostHog Stack (product analytics)
+  # NOTE: PostHog services are disabled (profile-gated). Run with --profile posthog to enable.
   posthog-postgres:
     image: postgres:16-alpine
     container_name: localcloud-posthog-postgres
+    profiles: ["posthog"]
     environment:
       - POSTGRES_USER=posthog
       - POSTGRES_PASSWORD=posthog
@@ -218,6 +220,7 @@ services:
   posthog-redis:
     image: redis:7-alpine
     container_name: localcloud-posthog-redis
+    profiles: ["posthog"]
     command: redis-server --appendonly yes
     volumes:
       - posthog_redis_data:/data
@@ -236,6 +239,7 @@ services:
     # drops/renames system.crash_log (custom_metrics_server_crash view migration). 25.10 has both.
     image: clickhouse/clickhouse-server:25.10
     container_name: localcloud-posthog-clickhouse
+    profiles: ["posthog"]
     environment:
       - CLICKHOUSE_DB=posthog
       # CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT intentionally omitted: when set to 1 it creates
@@ -259,6 +263,7 @@ services:
   posthog-zookeeper:
     image: zookeeper:3.9
     container_name: localcloud-posthog-zookeeper
+    profiles: ["posthog"]
     environment:
       - ZOO_MY_ID=1
       - ZOO_4LW_COMMANDS_WHITELIST=ruok,mntr,conf
@@ -275,6 +280,7 @@ services:
   posthog-kafka:
     image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
     container_name: localcloud-posthog-kafka
+    profiles: ["posthog"]
     command:
       - redpanda
       - start
@@ -310,6 +316,7 @@ services:
   posthog-kafka-init:
     image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
     container_name: localcloud-posthog-kafka-init
+    profiles: ["posthog"]
     entrypoint: /bin/sh
     command:
       - -c
@@ -333,6 +340,7 @@ services:
   posthog-db-migrate:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-db-migrate
+    profiles: ["posthog"]
     command: python manage.py migrate --no-input
     environment:
       - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
@@ -361,6 +369,7 @@ services:
   posthog-web:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-web
+    profiles: ["posthog"]
     environment:
       - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
       - REDIS_URL=redis://posthog-redis:6379/
@@ -414,6 +423,7 @@ services:
   posthog-worker:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-worker
+    profiles: ["posthog"]
     command: ./bin/docker-worker-celery --with-scheduler
     environment:
       - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,7 +349,7 @@ services:
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
-      - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
+      - POSTHOG_SKIP_MIGRATION_CHECKS=1
       - SKIP_ASYNC_MIGRATIONS_SETUP=1
       - OBJECT_STORAGE_ENABLED=false
     depends_on:
@@ -383,7 +383,7 @@ services:
   posthog-worker:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-worker
-    command: ./bin/docker-worker
+    command: ./bin/docker-worker-celery --with-scheduler
     environment:
       - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
       - REDIS_URL=redis://posthog-redis:6379/
@@ -400,7 +400,7 @@ services:
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - OBJECT_STORAGE_ENABLED=false
-      - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
+      - POSTHOG_SKIP_MIGRATION_CHECKS=1
     depends_on:
       posthog-web:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,9 @@ services:
       start_period: 10s
 
   posthog-clickhouse:
-    image: clickhouse/clickhouse-server:24.8
+    # Pin to 25.10: 24.8 lacks DateTime64-in-TTL (document_embeddings migration); 26.x
+    # drops/renames system.crash_log (custom_metrics_server_crash view migration). 25.10 has both.
+    image: clickhouse/clickhouse-server:25.10
     container_name: localcloud-posthog-clickhouse
     environment:
       - CLICKHOUSE_DB=posthog
@@ -328,11 +330,12 @@ services:
       - localstack-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - http://localhost:8000/_health/ | grep -q 'ok' || exit 1"]
+      # Require HTTP 200 only; body format may vary by PostHog version. start_period allows migrations to finish.
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8000/_health/ || exit 1"]
       interval: 30s
       timeout: 10s
-      retries: 10
-      start_period: 120s
+      retries: 15
+      start_period: 300s
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.posthog.rule=Host(`posthog.localcloudkit.com`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,7 @@ services:
     volumes:
       - posthog_clickhouse_data:/var/lib/clickhouse
       - ./posthog/clickhouse-config.xml:/etc/clickhouse-server/config.d/posthog.xml:ro
+      - ./posthog/clickhouse-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     networks:
       - localstack-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,7 +308,7 @@ services:
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
-      - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=0
+      - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
       - OBJECT_STORAGE_ENABLED=false
     depends_on:
       posthog-postgres:
@@ -349,6 +349,7 @@ services:
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - OBJECT_STORAGE_ENABLED=false
+      - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
     depends_on:
       - posthog-web
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,7 @@ services:
       - TRUSTED_PROXIES=*
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
       - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
+      - SKIP_ASYNC_MIGRATIONS_SETUP=1
       - OBJECT_STORAGE_ENABLED=false
     depends_on:
       posthog-postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,7 +240,7 @@ services:
     volumes:
       - posthog_clickhouse_data:/var/lib/clickhouse
       - ./posthog/clickhouse-config.xml:/etc/clickhouse-server/config.d/posthog.xml:ro
-      - ./posthog/clickhouse-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - ./posthog/clickhouse-users.xml:/etc/clickhouse-server/users.d/localcloud-grants.xml:ro
     networks:
       - localstack-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,7 @@ services:
       - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
     volumes:
       - posthog_clickhouse_data:/var/lib/clickhouse
+      - ./posthog/clickhouse-config.xml:/etc/clickhouse-server/config.d/posthog.xml:ro
     networks:
       - localstack-network
     restart: unless-stopped
@@ -309,7 +310,6 @@ services:
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
       - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=0
       - OBJECT_STORAGE_ENABLED=false
-      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-postgres:
         condition: service_healthy
@@ -349,7 +349,6 @@ services:
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - OBJECT_STORAGE_ENABLED=false
-      - CLICKHOUSE_REPLICATION=false
     depends_on:
       - posthog-web
     networks:
@@ -373,7 +372,6 @@ services:
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
       - SITE_URL=https://posthog.localcloudkit.com:3030
       - OBJECT_STORAGE_ENABLED=false
-      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-kafka:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,6 +330,34 @@ services:
       - localstack-network
     restart: "no"
 
+  posthog-db-migrate:
+    image: posthog/posthog:latest
+    container_name: localcloud-posthog-db-migrate
+    command: python manage.py migrate --no-input
+    environment:
+      - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
+      - REDIS_URL=redis://posthog-redis:6379/
+      - CLICKHOUSE_HOST=posthog-clickhouse
+      - CLICKHOUSE_DATABASE=posthog
+      - CLICKHOUSE_USER=default
+      - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_SECURE=false
+      - CLICKHOUSE_VERIFY=false
+      - KAFKA_HOSTS=posthog-kafka:9092
+      - PRIMARY_DB=clickhouse
+      - SECRET_KEY=localcloud-posthog-secret-key-change-me
+      - SITE_URL=https://posthog.localcloudkit.com:3030
+      - OBJECT_STORAGE_ENABLED=false
+      - CLICKHOUSE_REPLICATION=false
+    depends_on:
+      posthog-postgres:
+        condition: service_healthy
+      posthog-clickhouse:
+        condition: service_healthy
+    networks:
+      - localstack-network
+    restart: "no"
+
   posthog-web:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-web
@@ -352,6 +380,7 @@ services:
       - POSTHOG_SKIP_MIGRATION_CHECKS=1
       - SKIP_ASYNC_MIGRATIONS_SETUP=1
       - OBJECT_STORAGE_ENABLED=false
+      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-postgres:
         condition: service_healthy
@@ -362,6 +391,8 @@ services:
       posthog-kafka:
         condition: service_healthy
       posthog-kafka-init:
+        condition: service_completed_successfully
+      posthog-db-migrate:
         condition: service_completed_successfully
     networks:
       - localstack-network
@@ -401,6 +432,7 @@ services:
       - TRUSTED_PROXIES=*
       - OBJECT_STORAGE_ENABLED=false
       - POSTHOG_SKIP_MIGRATION_CHECKS=1
+      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-web:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -356,35 +356,8 @@ services:
       - localstack-network
     restart: unless-stopped
 
-  posthog-plugin-server:
-    image: posthog/posthog:latest
-    container_name: localcloud-posthog-plugin-server
-    command: ./bin/plugin-server --no-restart-loop
-    environment:
-      - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
-      - REDIS_URL=redis://posthog-redis:6379/
-      - CLICKHOUSE_HOST=posthog-clickhouse
-      - CLICKHOUSE_DATABASE=posthog
-      - CLICKHOUSE_USER=default
-      - CLICKHOUSE_PASSWORD=
-      - CLICKHOUSE_SECURE=false
-      - CLICKHOUSE_VERIFY=false
-      - KAFKA_HOSTS=posthog-kafka:9092
-      - SECRET_KEY=localcloud-posthog-secret-key-change-me
-      - SITE_URL=https://posthog.localcloudkit.com:3030
-      - OBJECT_STORAGE_ENABLED=false
-    depends_on:
-      posthog-kafka:
-        condition: service_healthy
-      posthog-clickhouse:
-        condition: service_healthy
-      posthog-postgres:
-        condition: service_healthy
-      posthog-redis:
-        condition: service_healthy
-    networks:
-      - localstack-network
-    restart: unless-stopped
+  # posthog-plugin-server removed: ./bin/plugin-server no longer ships in posthog/posthog:latest
+  # The plugin server (now "CDP worker") is not required for core analytics functionality
 
 networks:
   localstack-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,27 +273,62 @@ services:
       start_period: 20s
 
   posthog-kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
     container_name: localcloud-posthog-kafka
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://posthog-kafka:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      - --advertise-pandaproxy-addr internal://posthog-kafka:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      - --rpc-addr posthog-kafka:33145
+      - --advertise-rpc-addr posthog-kafka:33145
+      - --mode dev-container
+      - --smp 2
+      - --memory 3G
+      - --reserve-memory 500M
+      - --overprovisioned
+      - --set redpanda.empty_seed_starts_cluster=false
+      - --seeds posthog-kafka:33145
+      - --set redpanda.auto_create_topics_enabled=true
     environment:
-      - KAFKA_BROKER_ID=1
-      - KAFKA_ZOOKEEPER_CONNECT=posthog-zookeeper:2181
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://posthog-kafka:9092
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-    depends_on:
-      posthog-zookeeper:
-        condition: service_healthy
+      - ALLOW_PLAINTEXT_LISTENER=true
+    volumes:
+      - posthog_kafka_data:/var/lib/redpanda/data
     networks:
       - localstack-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 > /dev/null 2>&1"]
-      interval: 15s
+      test: ["CMD-SHELL", "curl -f http://localhost:9644/v1/status/ready || exit 1"]
+      interval: 5s
       timeout: 10s
-      retries: 10
-      start_period: 60s
+      retries: 20
+      start_period: 30s
+
+  posthog-kafka-init:
+    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+    container_name: localcloud-posthog-kafka-init
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        echo "Waiting for Kafka broker..."
+        until rpk topic list --brokers posthog-kafka:9092 2>/dev/null; do
+          sleep 2
+        done
+        echo "Creating required PostHog topics..."
+        for topic in exceptions_ingestion clickhouse_events_json; do
+          rpk topic create "$$topic" --brokers posthog-kafka:9092 -p 1 -r 1 2>&1 || true
+        done
+        echo "Topics ready."
+    depends_on:
+      posthog-kafka:
+        condition: service_healthy
+    networks:
+      - localstack-network
+    restart: "no"
 
   posthog-web:
     image: posthog/posthog:latest
@@ -326,6 +361,8 @@ services:
         condition: service_healthy
       posthog-kafka:
         condition: service_healthy
+      posthog-kafka-init:
+        condition: service_completed_successfully
     networks:
       - localstack-network
     restart: unless-stopped
@@ -385,3 +422,4 @@ volumes:
   posthog_postgres_data:
   posthog_redis_data:
   posthog_clickhouse_data:
+  posthog_kafka_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,6 +322,12 @@ services:
     networks:
       - localstack-network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://localhost:8000/_health/ | grep -q 'ok' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.posthog.rule=Host(`posthog.localcloudkit.com`)"
@@ -351,7 +357,8 @@ services:
       - OBJECT_STORAGE_ENABLED=false
       - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=1
     depends_on:
-      - posthog-web
+      posthog-web:
+        condition: service_healthy
     networks:
       - localstack-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,9 +305,11 @@ services:
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
       - SITE_URL=https://posthog.localcloudkit.com:3030
       - IS_BEHIND_PROXY=true
+      - TRUSTED_PROXIES=*
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
       - DISABLE_ASYNC_MIGRATIONS_ON_STARTUP=0
       - OBJECT_STORAGE_ENABLED=false
+      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-postgres:
         condition: service_healthy
@@ -345,7 +347,9 @@ services:
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
       - SITE_URL=https://posthog.localcloudkit.com:3030
       - IS_BEHIND_PROXY=true
+      - TRUSTED_PROXIES=*
       - OBJECT_STORAGE_ENABLED=false
+      - CLICKHOUSE_REPLICATION=false
     depends_on:
       - posthog-web
     networks:
@@ -369,6 +373,7 @@ services:
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
       - SITE_URL=https://posthog.localcloudkit.com:3030
       - OBJECT_STORAGE_ENABLED=false
+      - CLICKHOUSE_REPLICATION=false
     depends_on:
       posthog-kafka:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,7 +236,10 @@ services:
     container_name: localcloud-posthog-clickhouse
     environment:
       - CLICKHOUSE_DB=posthog
-      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+      # CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT intentionally omitted: when set to 1 it creates
+      # the default user via SQL (GRANT ALL ON *.*), which excludes NAMED COLLECTION and makes
+      # XML <grants> (in users.d/) ineffective for that user. Without it, the default user is
+      # XML-managed; users.xml already provides access_management=1 so PostHog user init still works.
     volumes:
       - posthog_clickhouse_data:/var/lib/clickhouse
       - ./posthog/clickhouse-config.xml:/etc/clickhouse-server/config.d/posthog.xml:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       start_period: 10s
 
   posthog-clickhouse:
-    image: clickhouse/clickhouse-server:23.6
+    image: clickhouse/clickhouse-server:24.8
     container_name: localcloud-posthog-clickhouse
     environment:
       - CLICKHOUSE_DB=posthog

--- a/docs/POSTHOG.md
+++ b/docs/POSTHOG.md
@@ -113,3 +113,5 @@ curl -s -X POST "https://posthog.localcloudkit.com:3030/i/v0/e/" \
 - **Health endpoint unavailable**: Check logs with `make posthog-logs`
 - **Events not appearing**: Verify API key and host match `https://posthog.localcloudkit.com:3030`
 - **Domain issues**: Re-run `sudo ./scripts/setup-hosts.sh` and `./scripts/setup-mkcert.sh`
+- **ClickHouse migration fails with "TTL expression result column should have DateTime or Date type, but has DateTime64"**: PostHog’s document_embeddings migration needs DateTime64-in-TTL (25.x+). We pin to `clickhouse/clickhouse-server:25.10`.
+- **ClickHouse migration fails with "Unknown table expression identifier 'system.crash_log'"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.

--- a/docs/POSTHOG.md
+++ b/docs/POSTHOG.md
@@ -12,12 +12,12 @@ PostHog runs with **dedicated data stores** and does not reuse the primary app P
 
 - `posthog-postgres`
 - `posthog-redis`
-- `posthog-clickhouse`
-- `posthog-kafka`
-- `posthog-zookeeper`
+- `posthog-clickhouse` (ClickHouse 25.x)
+- `posthog-kafka` (Redpanda v25.1.9, Kafka-compatible)
+- `posthog-kafka-init` (one-shot topic provisioner; exits after creating required topics)
+- `posthog-zookeeper` (for ClickHouse ReplicatedMergeTree)
 - `posthog-web`
 - `posthog-worker`
-- `posthog-plugin-server`
 
 This keeps PostHog analytics data isolated from application data.
 
@@ -109,9 +109,15 @@ curl -s -X POST "https://posthog.localcloudkit.com:3030/i/v0/e/" \
 
 ## Troubleshooting
 
-- **PostHog is stopped**: Start profile with `docker compose --profile posthog up -d`
+- **PostHog is stopped**: Start with `docker compose up -d posthog-web posthog-worker` (and all dependencies)
 - **Health endpoint unavailable**: Check logs with `make posthog-logs`
 - **Events not appearing**: Verify API key and host match `https://posthog.localcloudkit.com:3030`
 - **Domain issues**: Re-run `sudo ./scripts/setup-hosts.sh` and `./scripts/setup-mkcert.sh`
 - **ClickHouse migration fails with "TTL expression result column should have DateTime or Date type, but has DateTime64"**: PostHog’s document_embeddings migration needs DateTime64-in-TTL (25.x+). We pin to `clickhouse/clickhouse-server:25.10`.
-- **ClickHouse migration fails with "Unknown table expression identifier 'system.crash_log'"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.
+- **ClickHouse migration fails with "Unknown table expression identifier ‘system.crash_log’"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.
+- **ClickHouse or Kafka startup failures after an upgrade**: Wipe PostHog volumes to force a clean init:
+  ```bash
+  docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis posthog-zookeeper
+  docker volume rm localcloud-kit_posthog_clickhouse_data localcloud-kit_posthog_kafka_data localcloud-kit_posthog_postgres_data localcloud-kit_posthog_redis_data
+  docker compose up -d
+  ```

--- a/localcloud-api/routes/posthog.js
+++ b/localcloud-api/routes/posthog.js
@@ -32,7 +32,7 @@ router.get("/posthog/status", async (req, res) => {
       const reachable = await checkTcpPort("posthog-web", 8000);
       const status = reachable ? "starting" : "stopped";
       addLog(
-        reachable ? "info" : "warning",
+        "info",
         reachable ? "PostHog port is reachable — service is starting" : "PostHog is not running or not in active profile",
         "posthog"
       );

--- a/localcloud-api/server.js
+++ b/localcloud-api/server.js
@@ -24,7 +24,7 @@ import mailpitRouter from "./routes/mailpit.js";
 import secretsRouter from "./routes/secrets.js";
 import postgresRouter from "./routes/postgres.js";
 import keycloakRouter from "./routes/keycloak.js";
-import posthogRouter from "./routes/posthog.js";
+// import posthogRouter from "./routes/posthog.js"; // PostHog temporarily disabled
 import lambdaRouter from "./routes/lambda.js";
 import apigatewayRouter from "./routes/apigateway.js";
 import ssmRouter from "./routes/ssm.js";
@@ -68,7 +68,7 @@ app.use(mailpitRouter);
 app.use(secretsRouter);
 app.use(postgresRouter);
 app.use(keycloakRouter);
-app.use(posthogRouter);
+// app.use(posthogRouter); // PostHog temporarily disabled
 app.use(lambdaRouter);
 app.use(apigatewayRouter);
 app.use(ssmRouter);

--- a/localcloud-gui/src/app/manage/apigateway/page.tsx
+++ b/localcloud-gui/src/app/manage/apigateway/page.tsx
@@ -40,7 +40,7 @@ export default function ManageAPIGatewayPage() {
   const loadApis = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch("/api/apigateway/apis");
+      const res = await fetch(`/api/apigateway/apis?projectName=${encodeURIComponent(projectName)}`);
       const result = await res.json();
       if (result.success) {
         setApis(result.data?.items || result.data || []);

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -47,10 +47,10 @@ export default function ManageDynamoDBPage() {
   const loadTables = useCallback(async () => {
     setLoadingTables(true);
     try {
-      const res = await fetch("/api/dynamodb/tables");
+      const res = await fetch(`/api/dynamodb/tables?projectName=${encodeURIComponent(projectName)}`);
       const result = await res.json();
       if (result.success) {
-        setTables(result.data?.TableNames?.map((n: string) => ({ TableName: n })) || []);
+        setTables((result.data as string[])?.map((n: string) => ({ TableName: n })) || []);
       } else {
         toast.error("Failed to load tables");
       }

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -21,6 +21,29 @@ import SystemLogsButton from "@/components/SystemLogsButton";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DynamoDBItem = Record<string, any>;
 
+// Extract a human-readable string from a DynamoDB typed value, e.g. {S:"foo"} → "foo"
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function displayDynamoDBValue(val: any): string {
+  if (val === undefined || val === null) return "—";
+  if (typeof val !== "object") return String(val);
+  if ("S" in val) return val.S;
+  if ("N" in val) return val.N;
+  if ("BOOL" in val) return String(val.BOOL);
+  if ("NULL" in val) return "null";
+  if ("SS" in val) return JSON.stringify(val.SS);
+  if ("NS" in val) return JSON.stringify(val.NS);
+  if ("L" in val || "M" in val) return JSON.stringify(val);
+  return JSON.stringify(val);
+}
+
+// Extract the raw string/number value from a DynamoDB typed attribute for use in key expressions
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractDynamoDBKeyValue(val: any): string {
+  if (val === undefined || val === null) return "";
+  if (typeof val !== "object") return String(val);
+  return val.S ?? val.N ?? String(val);
+}
+
 interface TableInfo {
   TableName: string;
   TableStatus?: string;
@@ -84,7 +107,8 @@ export default function ManageDynamoDBPage() {
       const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(tableName)}/scan`);
       const result = await res.json();
       if (result.success) {
-        setItems(result.data?.items || []);
+        // AWS CLI returns "Items" (uppercase); normalize to handle either casing
+        setItems(result.data?.Items || result.data?.items || []);
       } else {
         toast.error("Failed to load items");
       }
@@ -124,12 +148,17 @@ export default function ManageDynamoDBPage() {
     if (!selectedTable || !deleteItemTarget || !schema) return;
     setDeleteLoading(true);
     try {
-      const key: DynamoDBItem = { [schema.pk]: deleteItemTarget[schema.pk] };
-      if (schema.sk) key[schema.sk] = deleteItemTarget[schema.sk];
+      const partitionValue = extractDynamoDBKeyValue(deleteItemTarget[schema.pk]);
+      const sortValue = schema.sk ? extractDynamoDBKeyValue(deleteItemTarget[schema.sk]) : undefined;
       const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(selectedTable)}/item`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ key }),
+        body: JSON.stringify({
+          projectName,
+          partitionKey: schema.pk,
+          partitionValue,
+          ...(schema.sk && sortValue ? { sortKey: schema.sk, sortValue } : {}),
+        }),
       });
       const result = await res.json();
       if (result.success) {
@@ -294,7 +323,7 @@ export default function ManageDynamoDBPage() {
                         <tr key={i} className="hover:bg-gray-50">
                           {allKeys.map((k) => (
                             <td key={k} className="px-4 py-2.5 text-xs font-mono text-gray-700 max-w-xs truncate">
-                              {item[k] !== undefined ? JSON.stringify(item[k]) : "—"}
+                              {displayDynamoDBValue(item[k])}
                             </td>
                           ))}
                           <td className="px-4 py-2.5 text-right">
@@ -354,7 +383,7 @@ export default function ManageDynamoDBPage() {
               const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(selectedTable)}/item`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ item }),
+                body: JSON.stringify({ item, projectName }),
               });
               const result = await res.json();
               if (result.success) {

--- a/localcloud-gui/src/app/manage/lambda/page.tsx
+++ b/localcloud-gui/src/app/manage/lambda/page.tsx
@@ -51,7 +51,7 @@ export default function ManageLambdaPage() {
   const loadFunctions = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch("/api/lambda/functions");
+      const res = await fetch(`/api/lambda/functions?projectName=${encodeURIComponent(projectName)}`);
       const result = await res.json();
       if (result.success) {
         setFunctions(result.data?.Functions || []);

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -58,7 +58,6 @@ type InspectTargetId =
   | "ssm"
   | "iam"
   | "postgres"
-  | "posthog"
   | "redis"
   | "keycloak"
   | "mailpit";
@@ -76,7 +75,7 @@ const AWS_RESOURCE_TYPES = new Set<Resource["type"]>([
 const DOC_ROUTES = [
   "/docs", "/localstack", "/s3", "/dynamodb", "/lambda",
   "/apigateway", "/secrets", "/ssm", "/iam",
-  "/redis", "/mailpit", "/postgres", "/keycloak", "/posthog",
+  "/redis", "/mailpit", "/postgres", "/keycloak",
 ];
 
 export default function Dashboard() {
@@ -92,7 +91,6 @@ export default function Dashboard() {
     redis,
     postgres,
     keycloak,
-    posthog,
     loading,
     error,
     refetch: loadInitialData,
@@ -948,23 +946,6 @@ export default function Dashboard() {
             withAdmin("https://mailpit.localcloudkit.com:3030"),
           ],
         };
-      case "posthog":
-        return {
-          title: "PostHog",
-          subtitle:
-            posthog.status === "running"
-              ? "Product analytics service is running"
-              : "Product analytics service is not running",
-          quickChecks: [
-            "PostHog status is running",
-            "Project API key is available in PostHog settings",
-            "A test event appears in the events stream",
-          ],
-          actions: [
-            { label: "Open Docs", href: "/posthog" },
-            withAdmin("https://posthog.localcloudkit.com:3030", "Open PostHog UI"),
-          ],
-        };
       default:
         return null;
     }
@@ -1702,17 +1683,6 @@ export default function Dashboard() {
             <span className="text-sm font-medium text-gray-700">PostgreSQL</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(postgres.status)}`}>
               {serviceLabel(postgres.status)}
-            </span>
-          </Link>
-
-          <div className="h-4 w-px bg-gray-200" />
-
-          {/* PostHog */}
-          <Link href="/posthog" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="PostHog">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(posthog.status)}`} />
-            <span className="text-sm font-medium text-gray-700">PostHog</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(posthog.status)}`}>
-              {serviceLabel(posthog.status)}
             </span>
           </Link>
 

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -977,7 +977,7 @@ export default function Dashboard() {
           key="error"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="flex items-center justify-center min-h-screen bg-gradient-to-br from-red-50 to-pink-100"
+          className="flex items-center justify-center min-h-screen bg-linear-to-br from-red-50 to-pink-100"
         >
           <div className="text-center">
             <div className="text-red-600 text-6xl mb-4">⚠️</div>
@@ -996,7 +996,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -1032,7 +1032,7 @@ export default function Dashboard() {
                         onClick={() => { setShowBuckets(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                         S3 Buckets
                       </button>
                       {renderResourceActions("S3 Buckets", "s3", "/manage/s3", () => {
@@ -1049,7 +1049,7 @@ export default function Dashboard() {
                         onClick={() => { setShowDynamoDB(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                         DynamoDB
                       </button>
                       {renderResourceActions("DynamoDB", "dynamodb", "/manage/dynamodb", () => {
@@ -1066,7 +1066,7 @@ export default function Dashboard() {
                         onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                         Lambda
                       </button>
                       {renderResourceActions("Lambda", "lambda", "/manage/lambda", () => {
@@ -1083,7 +1083,7 @@ export default function Dashboard() {
                         onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                         API Gateway
                       </button>
                       {renderResourceActions("API Gateway", "apigateway", "/manage/apigateway", () => {
@@ -1100,7 +1100,7 @@ export default function Dashboard() {
                         onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                         Secrets Manager
                       </button>
                       {renderResourceActions("Secrets Manager", "secretsmanager", "/manage/secrets", () => {
@@ -1113,7 +1113,7 @@ export default function Dashboard() {
                         onClick={() => { setShowSSMConfig(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                         Parameter Store
                       </button>
                       {renderResourceActions("Parameter Store", "ssm", "/manage/ssm", () => {
@@ -1126,7 +1126,7 @@ export default function Dashboard() {
                         onClick={() => { setShowIAMConfig(true); closeAllMenus(); }}
                         className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
                       >
-                        <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />
+                        <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                         IAM Roles
                       </button>
                       {renderResourceActions("IAM Roles", "iam", "/manage/iam", () => {
@@ -1168,7 +1168,7 @@ export default function Dashboard() {
                             const ServiceIcon = service.icon;
                             const itemContent = (
                               <>
-                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />
+                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
                                 {service.label}
                                 {service.id === "mailpit" && mailpit.unread > 0 && (
                                   <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
@@ -1220,7 +1220,7 @@ export default function Dashboard() {
                   <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`} />
                 </button>
                 {showDocsMenu && (
-                  <div className="absolute right-0 mt-1 w-[44rem] max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-md shadow-lg z-50 p-3">
+                  <div className="absolute right-0 mt-1 w-176 max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-md shadow-lg z-50 p-3">
                     <Link
                       href="/docs"
                       onClick={() => setShowDocsMenu(false)}
@@ -1250,7 +1250,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                           DynamoDB
                         </Link>
                         <Link
@@ -1258,7 +1258,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                           S3 Buckets
                         </Link>
                         <Link
@@ -1266,7 +1266,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                           Lambda
                         </Link>
                         <Link
@@ -1274,7 +1274,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                           API Gateway
                         </Link>
                         <Link
@@ -1282,7 +1282,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                           Secrets Manager
                         </Link>
                         <Link
@@ -1290,7 +1290,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                           Parameter Store
                         </Link>
                         <Link
@@ -1298,7 +1298,7 @@ export default function Dashboard() {
                           onClick={() => setShowDocsMenu(false)}
                           className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                           IAM &amp; STS
                         </Link>
                       </div>
@@ -1360,7 +1360,7 @@ export default function Dashboard() {
                   className="flex items-center gap-1.5 px-2 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
                 >
                   <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
-                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500 flex-shrink-0" />
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500 shrink-0" />
                     {profile?.active_project_label || "Default"}
                   </span>
                   <ChevronDownIcon className={`h-3.5 w-3.5 text-gray-400 transition-transform ${showProjectMenu ? "rotate-180" : ""}`} />
@@ -1378,7 +1378,7 @@ export default function Dashboard() {
                             : "text-gray-700 hover:bg-gray-50"
                         }`}
                       >
-                        <span className={`h-2 w-2 rounded-full mr-3 flex-shrink-0 ${p.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
+                        <span className={`h-2 w-2 rounded-full mr-3 shrink-0 ${p.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
                         {p.label}
                       </button>
                     ))}
@@ -1462,7 +1462,7 @@ export default function Dashboard() {
                 <p className="px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowBuckets(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />S3 Buckets
+                    <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />S3 Buckets
                   </button>
                   <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1470,7 +1470,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowDynamoDB(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB Tables
+                    <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />DynamoDB Tables
                   </button>
                   <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1478,7 +1478,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda Functions
+                    <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />Lambda Functions
                   </button>
                   <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1486,7 +1486,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
+                    <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />API Gateway
                   </button>
                   <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1494,7 +1494,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
+                    <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />Secrets Manager
                   </button>
                   <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1502,7 +1502,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowSSMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
+                    <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />Parameter Store
                   </button>
                   <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1510,7 +1510,7 @@ export default function Dashboard() {
                 </div>
                 <div className="flex items-center gap-1">
                   <button onClick={() => { setShowIAMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />IAM Roles
+                    <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />IAM Roles
                   </button>
                   <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
                     Inspect
@@ -1531,7 +1531,7 @@ export default function Dashboard() {
                         const ServiceIcon = service.icon;
                         const itemContent = (
                           <>
-                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />
+                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
                             {service.label}
                             {service.id === "mailpit" && mailpit.unread > 0 && (
                               <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
@@ -1583,32 +1583,32 @@ export default function Dashboard() {
                   <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />LocalStack
                 </Link>
                 <Link href="/s3" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 flex-shrink-0" />S3 Buckets
+                  <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />S3 Buckets
                 </Link>
                 <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 flex-shrink-0" />DynamoDB
+                  <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />DynamoDB
                 </Link>
                 <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 flex-shrink-0" />Lambda
+                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />Lambda
                 </Link>
                 <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 flex-shrink-0" />API Gateway
+                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />API Gateway
                 </Link>
                 <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Secrets Manager
+                  <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />Secrets Manager
                 </Link>
                 <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 flex-shrink-0" />Parameter Store
+                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />Parameter Store
                 </Link>
                 <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 flex-shrink-0" />IAM &amp; STS
+                  <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />IAM &amp; STS
                 </Link>
                 {PLATFORM_SERVICES.map((service) => {
                   const ServiceIcon = service.icon;
                   const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
                   return (
                     <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 flex-shrink-0" />{service.label}
+                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />{service.label}
                     </Link>
                   );
                 })}
@@ -1650,7 +1650,7 @@ export default function Dashboard() {
 
           {/* Keycloak */}
           <Link href="/keycloak" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Keycloak">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(keycloak.status)}`} />
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(keycloak.status)}`} />
             <span className="text-sm font-medium text-gray-700">Keycloak</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(keycloak.status)}`}>
               {serviceLabel(keycloak.status)}
@@ -1661,7 +1661,7 @@ export default function Dashboard() {
 
           {/* LocalStack */}
           <div className="flex items-center space-x-2 px-3">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${
               localstackStatus.health === "healthy" ? "bg-green-500" :
               localstackStatus.health === "unhealthy" ? "bg-red-500" : "bg-gray-400"
             }`} />
@@ -1682,7 +1682,7 @@ export default function Dashboard() {
 
           {/* Mailpit */}
           <button onClick={() => setShowMailpit(true)} className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Open Mailpit Inbox">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${mailpit.status === "healthy" ? "bg-green-500" : "bg-gray-400"}`} />
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${mailpit.status === "healthy" ? "bg-green-500" : "bg-gray-400"}`} />
             <span className="text-sm font-medium text-gray-700">Mailpit</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${mailpit.status === "healthy" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"}`}>
               {mailpit.status === "healthy" ? "Running" : "Unavailable"}
@@ -1698,7 +1698,7 @@ export default function Dashboard() {
 
           {/* PostgreSQL */}
           <Link href="/postgres" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="PostgreSQL">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(postgres.status)}`} />
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(postgres.status)}`} />
             <span className="text-sm font-medium text-gray-700">PostgreSQL</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(postgres.status)}`}>
               {serviceLabel(postgres.status)}
@@ -1709,7 +1709,7 @@ export default function Dashboard() {
 
           {/* PostHog */}
           <Link href="/posthog" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="PostHog">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(posthog.status)}`} />
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(posthog.status)}`} />
             <span className="text-sm font-medium text-gray-700">PostHog</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(posthog.status)}`}>
               {serviceLabel(posthog.status)}
@@ -1720,7 +1720,7 @@ export default function Dashboard() {
 
           {/* Redis */}
           <button onClick={() => setShowRedis(true)} className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Open Redis Cache">
-            <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${serviceDotClass(redis.status)}`} />
+            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(redis.status)}`} />
             <span className="text-sm font-medium text-gray-700">Redis</span>
             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(redis.status)}`}>
               {serviceLabel(redis.status)}

--- a/localcloud-gui/src/components/DashboardSkeleton.tsx
+++ b/localcloud-gui/src/components/DashboardSkeleton.tsx
@@ -30,7 +30,7 @@ function ResourceRowSkeleton({ opacity = 1 }: { opacity?: number }) {
 export function ServicePillSkeleton({ name }: { name: string }) {
   return (
     <div className="flex items-center space-x-2 px-3">
-      <div className="h-2.5 w-2.5 rounded-full bg-gray-300 flex-shrink-0 animate-pulse" />
+      <div className="h-2.5 w-2.5 rounded-full bg-gray-300 shrink-0 animate-pulse" />
       <span className="text-sm font-medium text-gray-700">{name}</span>
       <div className="h-5 w-16 rounded-full bg-gray-100 animate-pulse" />
     </div>
@@ -105,7 +105,7 @@ export default function DashboardSkeleton() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0, transition: { duration: 0.15 } }}
       transition={{ duration: 0.2 }}
-      className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100"
+      className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100"
     >
       {/* ── Header ─────────────────────────────────────────── */}
       <header className="bg-white shadow-sm border-b border-gray-200">

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -158,12 +158,18 @@ export default function DynamoDBViewer({
           projectName
         )}`
       );
+      if (!response.ok) {
+        throw new Error(`Failed to load tables (${response.status})`);
+      }
       const data = await response.json();
       if (data.success) {
         setTables(data.data || []);
+      } else {
+        throw new Error(data.error || "Failed to load tables");
       }
     } catch (error) {
       console.error("Failed to load tables:", error);
+      setError(error instanceof Error ? error.message : "Failed to load tables");
     } finally {
       setLoading(false);
     }
@@ -214,6 +220,7 @@ export default function DynamoDBViewer({
     if (!selectedTable) return;
 
     setLoading(true);
+    setError("");
     try {
       const response = await fetch(
         `${"/api"}/dynamodb/table/${encodeURIComponent(
@@ -222,6 +229,9 @@ export default function DynamoDBViewer({
           queryParams.limit
         }`
       );
+      if (!response.ok) {
+        throw new Error(`Failed to load table contents (${response.status})`);
+      }
       const data = await response.json();
       if (data.success) {
         // Flatten DynamoDB items for display
@@ -230,9 +240,12 @@ export default function DynamoDBViewer({
         );
         setItems(items);
         setScanResult(data.data);
+      } else {
+        throw new Error(data.error || "Failed to load table contents");
       }
     } catch (error) {
       console.error("Failed to load table contents:", error);
+      setError(error instanceof Error ? error.message : "Failed to load table contents");
     } finally {
       setLoading(false);
     }
@@ -263,6 +276,9 @@ export default function DynamoDBViewer({
           selectedTable
         )}/query?${params.toString()}`
       );
+      if (!response.ok) {
+        throw new Error(`Query failed (${response.status})`);
+      }
       const data = await response.json();
       if (data.success) {
         // Flatten DynamoDB items for display
@@ -271,9 +287,12 @@ export default function DynamoDBViewer({
         );
         setItems(items);
         setScanResult(data.data);
+      } else {
+        throw new Error(data.error || "Query failed");
       }
     } catch (error) {
       console.error("Failed to execute query:", error);
+      setError(error instanceof Error ? error.message : "Query failed");
     } finally {
       setLoading(false);
     }

--- a/localcloud-gui/src/components/ServiceStatusBadge.tsx
+++ b/localcloud-gui/src/components/ServiceStatusBadge.tsx
@@ -129,7 +129,7 @@ export default function ServiceStatusBadge({
   return (
     <div className="flex items-center space-x-2 px-3 py-1.5 bg-gray-50 border border-gray-200 rounded-full">
       <span
-        className={`h-2 w-2 rounded-full flex-shrink-0 ${dotClass[status.level]}`}
+        className={`h-2 w-2 rounded-full shrink-0 ${dotClass[status.level]}`}
       />
       <span className="text-xs font-medium text-gray-600">{name}</span>
       <span

--- a/localcloud-gui/src/constants/platformServices.ts
+++ b/localcloud-gui/src/constants/platformServices.ts
@@ -1,5 +1,4 @@
 import {
-  ChartBarIcon,
   CircleStackIcon,
   EnvelopeIcon,
   KeyIcon,
@@ -9,7 +8,7 @@ import { ComponentType } from "react";
 import { ServiceKind, ModalKey } from "@/types";
 
 export interface PlatformServiceEntry {
-  id: "keycloak" | "mailpit" | "postgres" | "redis" | "posthog";
+  id: "keycloak" | "mailpit" | "postgres" | "redis";
   label: string;
   kind: ServiceKind;
   icon: ComponentType<{ className?: string }>;
@@ -46,13 +45,7 @@ export const PLATFORM_SERVICES: PlatformServiceEntry[] = [
     icon: EnvelopeIcon,
     action: { type: "modal", modalKey: "mailpit" },
   },
-  {
-    id: "posthog",
-    label: "PostHog",
-    kind: "admin-tool",
-    icon: ChartBarIcon,
-    action: { type: "link", href: "/posthog" },
-  },
+  // PostHog temporarily disabled — re-add when integration is stable
 ];
 
 export const SERVICE_KIND_LABEL: Record<ServiceKind, string> = {

--- a/localcloud-gui/src/hooks/useServicesData.ts
+++ b/localcloud-gui/src/hooks/useServicesData.ts
@@ -3,13 +3,12 @@ import {
   KeycloakStatus,
   LocalStackStatus,
   MailpitStats,
-  PosthogStatus,
   PostgresStatus,
   ProjectConfig,
   RedisStatus,
   Resource,
 } from "@/types";
-import { dashboardApi, keycloakApi, postgresApi, posthogApi } from "@/services/api";
+import { dashboardApi, keycloakApi, postgresApi } from "@/services/api";
 
 interface LocalStackData {
   status: LocalStackStatus;
@@ -23,7 +22,6 @@ interface ServicesData {
   redis: RedisStatus;
   postgres: PostgresStatus;
   keycloak: KeycloakStatus;
-  posthog: PosthogStatus;
 }
 
 export function useServicesData() {
@@ -45,7 +43,6 @@ export function useServicesData() {
     redis: { status: "unknown" },
     postgres: { status: "unknown" },
     keycloak: { status: "unknown" },
-    posthog: { status: "unknown" },
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -53,11 +50,10 @@ export function useServicesData() {
   const loadData = useCallback(async () => {
     try {
       setError(null);
-      const [payloadResult, postgresResult, keycloakResult, posthogResult] = await Promise.allSettled([
+      const [payloadResult, postgresResult, keycloakResult] = await Promise.allSettled([
         dashboardApi.getData(),
         postgresApi.status(),
         keycloakApi.status(),
-        posthogApi.status(),
       ]);
 
       if (payloadResult.status === "rejected") {
@@ -73,8 +69,6 @@ export function useServicesData() {
         postgresResult.status === "fulfilled" ? postgresResult.value : { status: "unknown" };
       const keycloakStatus: KeycloakStatus =
         keycloakResult.status === "fulfilled" ? keycloakResult.value : { status: "unknown" };
-      const posthogStatus: PosthogStatus =
-        posthogResult.status === "fulfilled" ? posthogResult.value : { status: "unknown" };
 
       startTransition(() => {
         setData({
@@ -83,7 +77,6 @@ export function useServicesData() {
           redis,
           postgres: postgresStatus,
           keycloak: keycloakStatus,
-          posthog: posthogStatus,
         });
       });
     } catch (err) {

--- a/localcloud-gui/src/hooks/useServicesData.ts
+++ b/localcloud-gui/src/hooks/useServicesData.ts
@@ -98,7 +98,7 @@ export function useServicesData() {
 
   useEffect(() => {
     loadData();
-    const interval = setInterval(loadData, 5000);
+    const interval = setInterval(loadData, 30000);
     return () => clearInterval(interval);
   }, [loadData]);
 

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -34,6 +34,14 @@
                 </replica>
             </shard>
         </posthog_primary_replica>
+        <posthog_single_shard>
+            <shard>
+                <replica>
+                    <host>posthog-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog_single_shard>
     </remote_servers>
 
     <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries -->

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -64,6 +64,19 @@
         <hostClusterRole>data</hostClusterRole>
     </macros>
 
+    <!-- Enable crash_log system table — required by PostHog's ClickHouse migrations which
+         create metrics tables with SELECT ... FROM system.crash_log. Without this config
+         block, system.crash_log does not exist and migrate_clickhouse fails with Code: 60. -->
+    <crash_log>
+        <database>system</database>
+        <table>crash_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+        <max_size_rows>1024</max_size_rows>
+        <reserved_size_rows>1024</reserved_size_rows>
+        <buffer_size_rows_flush_threshold>512</buffer_size_rows_flush_threshold>
+        <flush_on_crash>false</flush_on_crash>
+    </crash_log>
+
     <!-- Named collections for Kafka engine tables.
          PostHog's latest image references both 'msk_cluster' and 'warpstream_ingestion'
          when creating Kafka engine tables during init. Both must exist or ClickHouse will

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -1,0 +1,35 @@
+<clickhouse>
+    <!-- ZooKeeper connection — required for ReplicatedMergeTree tables -->
+    <zookeeper>
+        <node>
+            <host>posthog-zookeeper</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+
+    <!-- Cluster definitions — PostHog expects both 'posthog' and 'posthog_migrations' -->
+    <remote_servers>
+        <posthog>
+            <shard>
+                <replica>
+                    <host>posthog-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog>
+        <posthog_migrations>
+            <shard>
+                <replica>
+                    <host>posthog-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog_migrations>
+    </remote_servers>
+
+    <!-- Macros used by ReplicatedMergeTree table definitions -->
+    <macros>
+        <shard>01</shard>
+        <replica>01</replica>
+    </macros>
+</clickhouse>

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -7,8 +7,9 @@
         </node>
     </zookeeper>
 
-    <!-- Cluster definitions — PostHog expects 'posthog', 'posthog_migrations',
-         and 'posthog_primary_replica' (used by distributed table migrations). -->
+    <!-- Cluster definitions — must match PostHog's official docker/clickhouse/config.d/default.xml.
+         All five cluster names are required: posthog, posthog_migrations, posthog_primary_replica,
+         posthog_single_shard, and posthog_writable. All point to the single local node. -->
     <remote_servers>
         <posthog>
             <shard>
@@ -42,21 +43,37 @@
                 </replica>
             </shard>
         </posthog_single_shard>
+        <!-- posthog_writable: used by PostHog for Distributed table DDL and event writes -->
+        <posthog_writable>
+            <shard>
+                <replica>
+                    <host>posthog-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog_writable>
     </remote_servers>
 
-    <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries -->
+    <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries.
+         Values must match PostHog's official config: hostClusterType=online, hostClusterRole=data.
+         These are embedded in ReplicatedMergeTree ZooKeeper paths and table routing logic. -->
     <macros>
         <shard>01</shard>
-        <replica>01</replica>
-        <hostClusterType>default</hostClusterType>
-        <hostClusterRole>default</hostClusterRole>
+        <replica>ch1</replica>
+        <hostClusterType>online</hostClusterType>
+        <hostClusterRole>data</hostClusterRole>
     </macros>
 
-    <!-- Named collection 'msk_cluster' — PostHog Kafka engine tables reference this by name.
-         In production PostHog uses Amazon MSK; locally we point it at posthog-kafka. -->
+    <!-- Named collections for Kafka engine tables.
+         PostHog's latest image references both 'msk_cluster' and 'warpstream_ingestion'
+         when creating Kafka engine tables during init. Both must exist or ClickHouse will
+         throw a "collection not found" error at startup. -->
     <named_collections>
         <msk_cluster>
             <kafka_broker_list>posthog-kafka:9092</kafka_broker_list>
         </msk_cluster>
+        <warpstream_ingestion>
+            <kafka_broker_list>posthog-kafka:9092</kafka_broker_list>
+        </warpstream_ingestion>
     </named_collections>
 </clickhouse>

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -27,9 +27,11 @@
         </posthog_migrations>
     </remote_servers>
 
-    <!-- Macros used by ReplicatedMergeTree table definitions -->
+    <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries -->
     <macros>
         <shard>01</shard>
         <replica>01</replica>
+        <hostClusterType>default</hostClusterType>
+        <hostClusterRole>default</hostClusterRole>
     </macros>
 </clickhouse>

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -7,7 +7,8 @@
         </node>
     </zookeeper>
 
-    <!-- Cluster definitions — PostHog expects both 'posthog' and 'posthog_migrations' -->
+    <!-- Cluster definitions — PostHog expects 'posthog', 'posthog_migrations',
+         and 'posthog_primary_replica' (used by distributed table migrations). -->
     <remote_servers>
         <posthog>
             <shard>
@@ -25,6 +26,14 @@
                 </replica>
             </shard>
         </posthog_migrations>
+        <posthog_primary_replica>
+            <shard>
+                <replica>
+                    <host>posthog-clickhouse</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </posthog_primary_replica>
     </remote_servers>
 
     <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries -->

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -34,4 +34,12 @@
         <hostClusterType>default</hostClusterType>
         <hostClusterRole>default</hostClusterRole>
     </macros>
+
+    <!-- Named collection 'msk_cluster' — PostHog Kafka engine tables reference this by name.
+         In production PostHog uses Amazon MSK; locally we point it at posthog-kafka. -->
+    <named_collections>
+        <msk_cluster>
+            <kafka_broker_list>posthog-kafka:9092</kafka_broker_list>
+        </msk_cluster>
+    </named_collections>
 </clickhouse>

--- a/posthog/clickhouse-init.sql
+++ b/posthog/clickhouse-init.sql
@@ -1,3 +1,0 @@
--- Grant the default user permission to use named collections (e.g. msk_cluster used by Kafka engine tables).
--- ClickHouse 23.x+ requires explicit NAMED COLLECTION grants even for XML-defined collections.
-GRANT NAMED COLLECTION ON msk_cluster TO default;

--- a/posthog/clickhouse-init.sql
+++ b/posthog/clickhouse-init.sql
@@ -1,0 +1,3 @@
+-- Grant the default user permission to use named collections (e.g. msk_cluster used by Kafka engine tables).
+-- ClickHouse 23.x+ requires explicit NAMED COLLECTION grants even for XML-defined collections.
+GRANT NAMED COLLECTION ON msk_cluster TO default;

--- a/posthog/clickhouse-users.xml
+++ b/posthog/clickhouse-users.xml
@@ -1,24 +1,12 @@
 <clickhouse>
     <users>
         <default>
-            <!-- ClickHouse 24.8+: <access_management> and <named_collection_control> flags
-                 cannot coexist with a <grants> block on the same user — the server will
-                 fatal on startup. Everything is expressed here via explicit grants instead.
-
-                 GRANT ALL ON *.*              — full data/DDL access on all databases
-                 GRANT ACCESS MANAGEMENT       — equivalent of access_management=1
-                                                 (create/alter/drop users, roles, quotas)
-                 GRANT NAMED COLLECTION ADMIN  — equivalent of named_collection_control=1
-                                                 (create/alter/drop named collections)
-                 GRANT NAMED COLLECTION ON *   — use named collections in queries
-                                                 (required by PostHog Kafka engine tables
-                                                  referencing the msk_cluster collection) -->
-            <grants>
-                <query>GRANT ALL ON *.* TO default WITH GRANT OPTION</query>
-                <query>GRANT ACCESS MANAGEMENT ON *.* TO default</query>
-                <query>GRANT NAMED COLLECTION ADMIN ON *.* TO default</query>
-                <query>GRANT NAMED COLLECTION ON * TO default WITH GRANT OPTION</query>
-            </grants>
+            <!-- Allow SQL-level access management (create users, roles, etc.) -->
+            <access_management>1</access_management>
+            <!-- Allow managing named collections (create/alter/drop). PostHog uses msk_cluster from config. -->
+            <named_collection_control>1</named_collection_control>
+            <!-- Do not use <grants> here: ClickHouse 24.x does not allow mixing
+                 grants with access_management/named_collection_control on the same user. -->
         </default>
     </users>
 </clickhouse>

--- a/posthog/clickhouse-users.xml
+++ b/posthog/clickhouse-users.xml
@@ -1,0 +1,17 @@
+<clickhouse>
+    <users>
+        <default>
+            <!-- Allow SQL-level access management (create users, roles, etc.) -->
+            <access_management>1</access_management>
+            <!-- Allow managing named collections (create/alter/drop) -->
+            <named_collection_control>1</named_collection_control>
+            <!-- Grants applied directly from config — bypasses WITH GRANT OPTION check.
+                 Required because PostHog Kafka engine tables reference the msk_cluster
+                 named collection defined in clickhouse-config.xml and ClickHouse 23.x+
+                 requires an explicit NAMED COLLECTION grant to use it in queries. -->
+            <grants>
+                <query>GRANT NAMED COLLECTION ON * TO default WITH GRANT OPTION</query>
+            </grants>
+        </default>
+    </users>
+</clickhouse>

--- a/posthog/clickhouse-users.xml
+++ b/posthog/clickhouse-users.xml
@@ -1,15 +1,22 @@
 <clickhouse>
     <users>
         <default>
-            <!-- Allow SQL-level access management (create users, roles, etc.) -->
-            <access_management>1</access_management>
-            <!-- Allow managing named collections (create/alter/drop) -->
-            <named_collection_control>1</named_collection_control>
-            <!-- Grants applied directly from config — bypasses WITH GRANT OPTION check.
-                 Required because PostHog Kafka engine tables reference the msk_cluster
-                 named collection defined in clickhouse-config.xml and ClickHouse 23.x+
-                 requires an explicit NAMED COLLECTION grant to use it in queries. -->
+            <!-- ClickHouse 24.8+: <access_management> and <named_collection_control> flags
+                 cannot coexist with a <grants> block on the same user — the server will
+                 fatal on startup. Everything is expressed here via explicit grants instead.
+
+                 GRANT ALL ON *.*              — full data/DDL access on all databases
+                 GRANT ACCESS MANAGEMENT       — equivalent of access_management=1
+                                                 (create/alter/drop users, roles, quotas)
+                 GRANT NAMED COLLECTION ADMIN  — equivalent of named_collection_control=1
+                                                 (create/alter/drop named collections)
+                 GRANT NAMED COLLECTION ON *   — use named collections in queries
+                                                 (required by PostHog Kafka engine tables
+                                                  referencing the msk_cluster collection) -->
             <grants>
+                <query>GRANT ALL ON *.* TO default WITH GRANT OPTION</query>
+                <query>GRANT ACCESS MANAGEMENT ON *.* TO default</query>
+                <query>GRANT NAMED COLLECTION ADMIN ON *.* TO default</query>
                 <query>GRANT NAMED COLLECTION ON * TO default WITH GRANT OPTION</query>
             </grants>
         </default>

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -671,7 +671,7 @@ main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
   
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi

--- a/scripts/shell/destroy_single_resource.sh
+++ b/scripts/shell/destroy_single_resource.sh
@@ -156,7 +156,7 @@ destroy_iam_role() {
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi

--- a/scripts/shell/list_dynamodb_tables.sh
+++ b/scripts/shell/list_dynamodb_tables.sh
@@ -42,7 +42,7 @@ main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
   
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi

--- a/scripts/shell/list_resources.sh
+++ b/scripts/shell/list_resources.sh
@@ -160,7 +160,7 @@ list_ssm_parameters() {
 main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi

--- a/scripts/shell/query_dynamodb_table.sh
+++ b/scripts/shell/query_dynamodb_table.sh
@@ -46,7 +46,7 @@ main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
   
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi

--- a/scripts/shell/scan_dynamodb_table.sh
+++ b/scripts/shell/scan_dynamodb_table.sh
@@ -41,7 +41,7 @@ main() {
   command -v aws >/dev/null 2>&1 || { echo "AWS CLI is not installed. Please install it first." >&2; exit 1; }
   command -v jq >/dev/null 2>&1 || { echo "jq is not installed. Please install it first." >&2; exit 1; }
   
-  if ! curl -s "$AWS_ENDPOINT" >/dev/null; then
+  if ! curl -s --connect-timeout 5 --max-time 10 "$AWS_ENDPOINT" >/dev/null; then
     echo "LocalStack is not running at $AWS_ENDPOINT. Please start it first." >&2
     exit 1
   fi


### PR DESCRIPTION
Replace `flex-shrink-0` → `shrink-0`, `bg-gradient-to-br` → `bg-linear-to-br`,
and `w-[44rem]` → `w-176` across Dashboard.tsx and DashboardSkeleton.tsx to
resolve tailwindcss-intellisense suggestCanonicalClasses warnings.