### PR TITLE
fix(docker): remove orphaned posthog-zookeeper and add kafka dep to db-migrate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,9 @@ start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by d
 start-legacy: ## Start all services using LocalStack 4.14 (community legacy)
 	@$(MAKE) start LOCALSTACK_VERSION=4.14
 
-stop: ## Stop all Docker services
+stop: ## Stop all Docker services (includes optional PostHog profile)
 	@echo "$(YELLOW)Stopping all services...$(NC)"
-	docker compose down --remove-orphans
+	docker compose --profile posthog down --remove-orphans
 
 restart: stop start ## Restart all Docker services
 
@@ -119,15 +119,15 @@ clean-volumes: ## Clean up Docker volumes (removes all data)
 	@echo "$(YELLOW)Cleaning up Docker volumes...$(NC)"
 	@echo "$(RED)WARNING: This will remove all Docker volumes and data!$(NC)"
 	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || exit 1
-	@docker compose down -v --remove-orphans
+	@docker compose --profile posthog down -v --remove-orphans
 	@docker volume prune -f
 	@echo "$(GREEN)Docker volumes cleaned$(NC)"
 
-clean-all: ## Clean up everything including images and containers
+clean-all: ## Clean up everything including images and containers (includes PostHog profile)
 	@echo "$(YELLOW)Cleaning up all Docker resources...$(NC)"
 	@echo "$(RED)WARNING: This will remove all containers, images, and volumes!$(NC)"
 	@read -p "Are you sure? (y/N): " confirm && [ "$$confirm" = "y" ] || exit 1
-	@docker compose down -v --rmi all --remove-orphans
+	@docker compose --profile posthog down -v --rmi all --remove-orphans
 	@docker system prune -af --volumes
 	@echo "$(GREEN)All Docker resources cleaned$(NC)"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Local Cloud Development Environment**
 
-Build and test cloud apps locally — no AWS account needed. Free, fast, and with full data visibility. Emulates S3, DynamoDB, Lambda, API Gateway, SSM Parameter Store, Secrets Manager, Redis cache, email testing with Mailpit, and optional product analytics with PostHog.
+Build and test cloud apps locally — no AWS account needed. Free, fast, and with full data visibility. Emulates S3, DynamoDB, Lambda, API Gateway, SSM Parameter Store, Secrets Manager, Redis cache, email testing with Mailpit, and optional beta product analytics with PostHog.
 
 [![Version](https://img.shields.io/badge/version-0.13.1-blue.svg)](https://github.com/jonbrobinson/localcloud-kit/releases/tag/v0.13.1)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -80,7 +80,7 @@ Via Traefik (TLS — trusted cert, no browser warnings):
 - **Mailpit** (email inbox): https://mailpit.localcloudkit.com:3030
 - **pgAdmin** (database UI): https://pgadmin.localcloudkit.com:3030
 - **Keycloak** (identity & access): https://keycloak.localcloudkit.com:3030
-- **PostHog** (analytics, optional profile): https://posthog.localcloudkit.com:3030
+- **PostHog** (analytics, optional beta profile): https://posthog.localcloudkit.com:3030
 
 Direct localhost (no TLS — always available):
 
@@ -103,7 +103,7 @@ Direct localhost (no TLS — always available):
 | pgAdmin | https://pgadmin.localcloudkit.com:3030 | PostgreSQL UI |
 | PostgreSQL | localhost:5432 | Direct DB |
 | Keycloak | https://keycloak.localcloudkit.com:3030 | Identity & access |
-| PostHog | https://posthog.localcloudkit.com:3030 | Product analytics (optional profile) |
+| PostHog | https://posthog.localcloudkit.com:3030 | Product analytics (optional beta profile) |
 
 > **Note**: Run `./scripts/setup.sh` once to add subdomains to `/etc/hosts` and generate the TLS certificate.
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The header contains three primary dropdowns:
 #### PostHog Analytics (optional profile)
 
 - **Optional Compose Profile**: Start only when needed via `docker compose --profile posthog up -d`
-- **Isolated Data Stores**: Dedicated PostHog Postgres, Redis, ClickHouse, and Kafka services
+- **Isolated Data Stores**: Dedicated PostHog Postgres, Redis, ClickHouse, Kafka, and ZooKeeper services
 - **Dashboard Visibility**: Service health appears in the status bar and Services menu
 - **Doc & SDK Examples**: Local integration snippets for TypeScript, Node.js, Python, and CLI
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The header contains three primary dropdowns:
 #### PostHog Analytics (optional profile)
 
 - **Optional Compose Profile**: Start only when needed via `docker compose --profile posthog up -d`
-- **Isolated Data Stores**: Dedicated PostHog Postgres, Redis, ClickHouse, Kafka, and Zookeeper services
+- **Isolated Data Stores**: Dedicated PostHog Postgres, Redis, ClickHouse, and Kafka services
 - **Dashboard Visibility**: Service health appears in the status bar and Services menu
 - **Doc & SDK Examples**: Local integration snippets for TypeScript, Node.js, Python, and CLI
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,8 +183,8 @@ services:
     image: axllent/mailpit:latest
     container_name: localcloud-mailpit
     ports:
-      - "1025:1025"  # SMTP
-      - "8025:8025"  # Web UI (direct access)
+      - "1025:1025" # SMTP
+      - "8025:8025" # Web UI (direct access)
     networks:
       - localstack-network
     restart: unless-stopped
@@ -282,7 +282,11 @@ services:
       - localstack-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O - 'http://localhost:8123/ping' | grep -q 'Ok.'"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O - 'http://localhost:8123/ping' | grep -q 'Ok.'",
+        ]
       interval: 10s
       timeout: 5s
       retries: 20
@@ -322,7 +326,8 @@ services:
       - localstack-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:9644/v1/status/ready || exit 1"]
+      test:
+        ["CMD-SHELL", "curl -f http://localhost:9644/v1/status/ready || exit 1"]
       interval: 5s
       timeout: 10s
       retries: 20
@@ -466,7 +471,11 @@ services:
     restart: unless-stopped
     healthcheck:
       # Require HTTP 200 only; body format may vary by PostHog version. start_period allows migrations to finish.
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:8000/_health/ || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O /dev/null http://localhost:8000/_health/ || exit 1",
+        ]
       interval: 30s
       timeout: 10s
       retries: 15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,23 +260,6 @@ services:
       retries: 20
       start_period: 60s
 
-  posthog-zookeeper:
-    image: zookeeper:3.9
-    container_name: localcloud-posthog-zookeeper
-    profiles: ["posthog"]
-    environment:
-      - ZOO_MY_ID=1
-      - ZOO_4LW_COMMANDS_WHITELIST=ruok,mntr,conf
-    networks:
-      - localstack-network
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD-SHELL", "echo ruok | nc -w2 localhost 2181 | grep imok"]
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 20s
-
   posthog-kafka:
     image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
     container_name: localcloud-posthog-kafka
@@ -361,6 +344,8 @@ services:
       posthog-postgres:
         condition: service_healthy
       posthog-clickhouse:
+        condition: service_healthy
+      posthog-kafka:
         condition: service_healthy
     networks:
       - localstack-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,7 +218,8 @@ services:
       start_period: 30s
 
   posthog-redis:
-    image: redis:7.2-alpine
+    # Use 7.4+ so existing volumes with RDB format version 12 (AOF base file) load without "Can't handle RDB format version 12"
+    image: redis:7.4-alpine
     container_name: localcloud-posthog-redis
     profiles: ["posthog"]
     command: redis-server --appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru
@@ -238,6 +239,9 @@ services:
     image: zookeeper:3.7.0
     container_name: localcloud-posthog-zookeeper
     profiles: ["posthog"]
+    environment:
+      # Allow ruok so the healthcheck (echo ruok | nc ... | grep imok) can succeed
+      - ZOO_4LW_COMMANDS_WHITELIST=srvr,ruok
     volumes:
       - posthog_zookeeper_data:/data
       - posthog_zookeeper_datalog:/datalog
@@ -258,6 +262,8 @@ services:
     image: clickhouse/clickhouse-server:25.10
     container_name: localcloud-posthog-clickhouse
     profiles: ["posthog"]
+    # Match data volume owner so ClickHouse does not throw MISMATCHING_USERS_FOR_PROCESS_AND_DATA (430)
+    user: "101:101"
     depends_on:
       posthog-zookeeper:
         condition: service_healthy
@@ -346,6 +352,23 @@ services:
       - localstack-network
     restart: "no"
 
+  # Create system.crash_log so PostHog's migrate_clickhouse can create the custom_metrics_server_crash view.
+  # ClickHouse only creates this table on fatal crash; PostHog expects it to exist.
+  posthog-clickhouse-crash-log-init:
+    image: clickhouse/clickhouse-server:25.10
+    container_name: localcloud-posthog-clickhouse-crash-log-init
+    profiles: ["posthog"]
+    entrypoint: ["/usr/bin/clickhouse-client"]
+    command:
+      - --host=posthog-clickhouse
+      - --query=CREATE TABLE IF NOT EXISTS system.crash_log (build_id String, revision UInt32, version String, trace_full Array(String), trace Array(UInt64), query_id String, thread_id UInt64, signal Int32, timestamp_ns UInt64, event_time DateTime, event_date Date, hostname LowCardinality(String)) ENGINE = MergeTree() ORDER BY (event_date, hostname)
+    depends_on:
+      posthog-clickhouse:
+        condition: service_healthy
+    networks:
+      - localstack-network
+    restart: "no"
+
   posthog-db-migrate:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-db-migrate
@@ -376,6 +399,8 @@ services:
     depends_on:
       posthog-postgres:
         condition: service_healthy
+      posthog-redis:
+        condition: service_healthy
       posthog-clickhouse:
         condition: service_healthy
       posthog-zookeeper:
@@ -390,6 +415,9 @@ services:
     image: posthog/posthog:latest
     container_name: localcloud-posthog-web
     profiles: ["posthog"]
+    # Run only the web server (Unit/Granian); default ./bin/docker also starts ./bin/docker-worker
+    # (Node) which fails with "Cannot find module '/code/nodejs/dist/index.js'" in posthog/posthog:latest.
+    command: ["./bin/docker-server"]
     environment:
       - DATABASE_URL=postgres://posthog:posthog@posthog-postgres:5432/posthog
       - REDIS_URL=redis://posthog-redis:6379/
@@ -425,6 +453,8 @@ services:
         condition: service_healthy
       posthog-clickhouse:
         condition: service_healthy
+      posthog-clickhouse-crash-log-init:
+        condition: service_completed_successfully
       posthog-kafka:
         condition: service_healthy
       posthog-kafka-init:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,10 +218,10 @@ services:
       start_period: 30s
 
   posthog-redis:
-    image: redis:7-alpine
+    image: redis:7.2-alpine
     container_name: localcloud-posthog-redis
     profiles: ["posthog"]
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --maxmemory 200mb --maxmemory-policy allkeys-lru
     volumes:
       - posthog_redis_data:/data
     networks:
@@ -234,14 +234,36 @@ services:
       retries: 10
       start_period: 10s
 
+  posthog-zookeeper:
+    image: zookeeper:3.7.0
+    container_name: localcloud-posthog-zookeeper
+    profiles: ["posthog"]
+    volumes:
+      - posthog_zookeeper_data:/data
+      - posthog_zookeeper_datalog:/datalog
+      - posthog_zookeeper_logs:/logs
+    networks:
+      - localstack-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc -w2 localhost 2181 | grep imok"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
   posthog-clickhouse:
     # Pin to 25.10: 24.8 lacks DateTime64-in-TTL (document_embeddings migration); 26.x
     # drops/renames system.crash_log (custom_metrics_server_crash view migration). 25.10 has both.
     image: clickhouse/clickhouse-server:25.10
     container_name: localcloud-posthog-clickhouse
     profiles: ["posthog"]
+    depends_on:
+      posthog-zookeeper:
+        condition: service_healthy
     environment:
       - CLICKHOUSE_DB=posthog
+      - CLICKHOUSE_SKIP_USER_SETUP=1
       # CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT intentionally omitted: when set to 1 it creates
       # the default user via SQL (GRANT ALL ON *.*), which excludes NAMED COLLECTION and makes
       # XML <grants> (in users.d/) ineffective for that user. Without it, the default user is
@@ -284,6 +306,10 @@ services:
       - --set redpanda.auto_create_topics_enabled=true
     environment:
       - ALLOW_PLAINTEXT_LISTENER=true
+      # Hobby: keep logs for 1 hour to reduce local disk usage
+      - KAFKA_LOG_RETENTION_MS=3600000
+      - KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS=300000
+      - KAFKA_LOG_RETENTION_HOURS=1
     volumes:
       - posthog_kafka_data:/var/lib/redpanda/data
     networks:
@@ -332,18 +358,27 @@ services:
       - CLICKHOUSE_DATABASE=posthog
       - CLICKHOUSE_USER=default
       - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
       - CLICKHOUSE_SECURE=false
       - CLICKHOUSE_VERIFY=false
       - KAFKA_HOSTS=posthog-kafka:9092
       - PRIMARY_DB=clickhouse
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
       - SITE_URL=https://posthog.localcloudkit.com:3030
+      - DEPLOYMENT=hobby
       - OBJECT_STORAGE_ENABLED=false
       - CLICKHOUSE_REPLICATION=false
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
     depends_on:
       posthog-postgres:
         condition: service_healthy
       posthog-clickhouse:
+        condition: service_healthy
+      posthog-zookeeper:
         condition: service_healthy
       posthog-kafka:
         condition: service_healthy
@@ -362,6 +397,10 @@ services:
       - CLICKHOUSE_DATABASE=posthog
       - CLICKHOUSE_USER=default
       - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
       - CLICKHOUSE_SECURE=false
       - CLICKHOUSE_VERIFY=false
       - KAFKA_HOSTS=posthog-kafka:9092
@@ -373,8 +412,12 @@ services:
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
       - POSTHOG_SKIP_MIGRATION_CHECKS=1
       - SKIP_ASYNC_MIGRATIONS_SETUP=1
+      - DEPLOYMENT=hobby
       - OBJECT_STORAGE_ENABLED=false
       - CLICKHOUSE_REPLICATION=false
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
+      - FLAGS_REDIS_ENABLED=false
     depends_on:
       posthog-postgres:
         condition: service_healthy
@@ -417,6 +460,10 @@ services:
       - CLICKHOUSE_DATABASE=posthog
       - CLICKHOUSE_USER=default
       - CLICKHOUSE_PASSWORD=
+      - CLICKHOUSE_API_USER=api
+      - CLICKHOUSE_API_PASSWORD=apipass
+      - CLICKHOUSE_APP_USER=app
+      - CLICKHOUSE_APP_PASSWORD=apppass
       - CLICKHOUSE_SECURE=false
       - CLICKHOUSE_VERIFY=false
       - KAFKA_HOSTS=posthog-kafka:9092
@@ -425,9 +472,13 @@ services:
       - SITE_URL=https://posthog.localcloudkit.com:3030
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
+      - DEPLOYMENT=hobby
       - OBJECT_STORAGE_ENABLED=false
       - POSTHOG_SKIP_MIGRATION_CHECKS=1
       - CLICKHOUSE_REPLICATION=false
+      - OTEL_SDK_DISABLED=true
+      - DISABLE_SECURE_SSL_REDIRECT=true
+      - FLAGS_REDIS_ENABLED=false
     depends_on:
       posthog-web:
         condition: service_healthy
@@ -450,3 +501,6 @@ volumes:
   posthog_redis_data:
   posthog_clickhouse_data:
   posthog_kafka_data:
+  posthog_zookeeper_data:
+  posthog_zookeeper_datalog:
+  posthog_zookeeper_logs:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -224,7 +224,6 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
   - Dedicated `posthog-redis`
   - Dedicated `posthog-clickhouse`
   - Dedicated `posthog-kafka`
-  - Dedicated `posthog-zookeeper`
 - **Start**: `docker compose --profile posthog up -d`
 
 ## Volume Mounts

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -224,6 +224,7 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
   - Dedicated `posthog-redis`
   - Dedicated `posthog-clickhouse`
   - Dedicated `posthog-kafka`
+  - Dedicated `posthog-zookeeper`
 - **Start**: `docker compose --profile posthog up -d`
 
 ## Volume Mounts

--- a/docs/POSTHOG.md
+++ b/docs/POSTHOG.md
@@ -1,6 +1,6 @@
-# PostHog (Optional Profile)
+# PostHog (Beta, Optional Profile)
 
-LocalCloud Kit includes PostHog as an **optional** platform service for local product analytics, event capture, and feature flags.
+LocalCloud Kit includes PostHog as an **optional, beta** platform service for local product analytics, event capture, and feature flags. This integration is experimental and intended for local evaluation only; APIs and behavior may change between releases.
 
 ## Why optional?
 
@@ -113,8 +113,12 @@ curl -s -X POST "https://posthog.localcloudkit.com:3030/i/v0/e/" \
 - **Health endpoint unavailable**: Check logs with `make posthog-logs`
 - **Events not appearing**: Verify API key and host match `https://posthog.localcloudkit.com:3030`
 - **Domain issues**: Re-run `sudo ./scripts/setup-hosts.sh` and `./scripts/setup-mkcert.sh`
+- **`posthog-zookeeper` is unhealthy / "dependency failed to start"**: ZooKeeper 3.7+ disables four-letter commands (e.g. `ruok`) by default. We set `ZOO_4LW_COMMANDS_WHITELIST=srvr,ruok` so the healthcheck can succeed. If you override the image or env, keep `ruok` in the whitelist.
+- **`posthog-redis` unhealthy / "Can't handle RDB format version 12"**: The data volume was written by Redis 7.4+ (RDB v12). We use `redis:7.4-alpine` so it can load. If you still see this, remove the volume and start fresh: `docker volume rm localcloud-kit_posthog_redis_data` then `docker compose --profile posthog up -d`.
+- **ClickHouse exits with "Effective user of the process (root) does not match the owner of the data (clickhouse)" (Code: 430)**: The data volume is owned by user `clickhouse` (UID 101). We set `user: "101:101"` on the service so the process runs as that user. If you still see this after a volume from another setup, remove the volume and start fresh, or `chown -R 101:101` the volume data.
 - **ClickHouse migration fails with "TTL expression result column should have DateTime or Date type, but has DateTime64"**: PostHog’s document_embeddings migration needs DateTime64-in-TTL (25.x+). We pin to `clickhouse/clickhouse-server:25.10`.
 - **ClickHouse migration fails with "Unknown table expression identifier ‘system.crash_log’"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.
+- **`posthog-web` crash loop / "Cannot find module '/code/nodejs/dist/index.js'" / "Nodejs services crashed!"**: The default `posthog/posthog:latest` startup runs a Node service (docker-worker) whose built file is missing in the image. We override the web service command to run only `./bin/docker-server` (Nginx Unit/Granian); core analytics work without the in-container Node worker. If you remove the `command` override, ensure the image you use includes a working Node build or pin to a known-good tag.
 - **ClickHouse or Kafka startup failures after an upgrade**: Wipe PostHog volumes to force a clean init:
   ```bash
   docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis posthog-zookeeper

--- a/docs/POSTHOG.md
+++ b/docs/POSTHOG.md
@@ -4,7 +4,7 @@ LocalCloud Kit includes PostHog as an **optional** platform service for local pr
 
 ## Why optional?
 
-PostHog requires a multi-service stack (web, worker, plugin server, ClickHouse, Kafka, Redis, PostgreSQL). Keeping it optional avoids slowing down the default local workflow for teams that do not need analytics during every run.
+PostHog requires a multi-service stack (web, worker, plugin server, ClickHouse, Kafka, ZooKeeper, Redis, PostgreSQL). Keeping it optional avoids slowing down the default local workflow for teams that do not need analytics during every run.
 
 ## Isolation model
 
@@ -13,8 +13,9 @@ PostHog runs with **dedicated data stores** and does not reuse the primary app P
 - `posthog-postgres`
 - `posthog-redis`
 - `posthog-clickhouse` (ClickHouse 25.x)
-- `posthog-kafka` (Redpanda v25.1.9, Kafka-compatible; ZooKeeper-free)
+- `posthog-kafka` (Redpanda v25.1.9, Kafka-compatible)
 - `posthog-kafka-init` (one-shot topic provisioner; exits after creating required topics)
+- `posthog-zookeeper` (ZooKeeper 3.7.0 — required by ClickHouse for ReplicatedMergeTree coordination)
 - `posthog-web`
 - `posthog-worker`
 
@@ -116,7 +117,7 @@ curl -s -X POST "https://posthog.localcloudkit.com:3030/i/v0/e/" \
 - **ClickHouse migration fails with "Unknown table expression identifier ‘system.crash_log’"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.
 - **ClickHouse or Kafka startup failures after an upgrade**: Wipe PostHog volumes to force a clean init:
   ```bash
-  docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis
-  docker volume rm localcloud-kit_posthog_clickhouse_data localcloud-kit_posthog_kafka_data localcloud-kit_posthog_postgres_data localcloud-kit_posthog_redis_data
+  docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis posthog-zookeeper
+  docker volume rm localcloud-kit_posthog_clickhouse_data localcloud-kit_posthog_kafka_data localcloud-kit_posthog_postgres_data localcloud-kit_posthog_redis_data localcloud-kit_posthog_zookeeper_data localcloud-kit_posthog_zookeeper_datalog localcloud-kit_posthog_zookeeper_logs
   docker compose up -d
   ```

--- a/docs/POSTHOG.md
+++ b/docs/POSTHOG.md
@@ -4,7 +4,7 @@ LocalCloud Kit includes PostHog as an **optional** platform service for local pr
 
 ## Why optional?
 
-PostHog requires a multi-service stack (web, worker, plugin server, ClickHouse, Kafka, Zookeeper, Redis, PostgreSQL). Keeping it optional avoids slowing down the default local workflow for teams that do not need analytics during every run.
+PostHog requires a multi-service stack (web, worker, plugin server, ClickHouse, Kafka, Redis, PostgreSQL). Keeping it optional avoids slowing down the default local workflow for teams that do not need analytics during every run.
 
 ## Isolation model
 
@@ -13,9 +13,8 @@ PostHog runs with **dedicated data stores** and does not reuse the primary app P
 - `posthog-postgres`
 - `posthog-redis`
 - `posthog-clickhouse` (ClickHouse 25.x)
-- `posthog-kafka` (Redpanda v25.1.9, Kafka-compatible)
+- `posthog-kafka` (Redpanda v25.1.9, Kafka-compatible; ZooKeeper-free)
 - `posthog-kafka-init` (one-shot topic provisioner; exits after creating required topics)
-- `posthog-zookeeper` (for ClickHouse ReplicatedMergeTree)
 - `posthog-web`
 - `posthog-worker`
 
@@ -117,7 +116,7 @@ curl -s -X POST "https://posthog.localcloudkit.com:3030/i/v0/e/" \
 - **ClickHouse migration fails with "Unknown table expression identifier ‘system.crash_log’"**: PostHog creates a view on `system.crash_log`; ClickHouse 26.x removed or renamed it. Use 25.10 (or another 25.x) instead of `latest`. We pin to 25.10 for compatibility.
 - **ClickHouse or Kafka startup failures after an upgrade**: Wipe PostHog volumes to force a clean init:
   ```bash
-  docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis posthog-zookeeper
+  docker compose down posthog-web posthog-worker posthog-clickhouse posthog-kafka posthog-kafka-init posthog-postgres posthog-redis
   docker volume rm localcloud-kit_posthog_clickhouse_data localcloud-kit_posthog_kafka_data localcloud-kit_posthog_postgres_data localcloud-kit_posthog_redis_data
   docker compose up -d
   ```

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -281,7 +281,7 @@ export default function ManageDynamoDBPage() {
                   </button>
                   <button
                     onClick={() => setShowAddItem(true)}
-                    className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+                    className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium bg-indigo-600 text-white rounded-lg shadow-sm hover:bg-indigo-700"
                   >
                     <PlusIcon className="h-3.5 w-3.5" />
                     <span>Add Item</span>
@@ -299,7 +299,7 @@ export default function ManageDynamoDBPage() {
                   <p className="text-sm text-gray-400">No items in this table</p>
                   <button
                     onClick={() => setShowAddItem(true)}
-                    className="mt-3 inline-flex items-center px-3 py-1.5 text-xs font-medium text-indigo-600 hover:text-indigo-800"
+                    className="mt-3 inline-flex items-center px-3 py-1.5 text-xs font-medium bg-indigo-600 text-white rounded-lg shadow-sm hover:bg-indigo-700"
                   >
                     <PlusIcon className="h-3.5 w-3.5 mr-1" />
                     Add first item

--- a/localcloud-gui/src/app/posthog/page.tsx
+++ b/localcloud-gui/src/app/posthog/page.tsx
@@ -139,7 +139,7 @@ export default function PosthogPage() {
           <p className="text-sm text-gray-600 leading-relaxed">
             LocalCloud Kit includes <strong>PostHog</strong> as an optional platform service for local
             product analytics, event capture, and feature-flag development. The PostHog stack runs in an
-            isolated profile with dedicated Postgres, Redis, ClickHouse, Kafka, and Zookeeper containers.
+            isolated profile with dedicated Postgres, Redis, ClickHouse, and Kafka containers.
           </p>
           <p className="text-sm text-gray-600 leading-relaxed mt-2">
             This stack is intended for local service usage and is intentionally isolated from your
@@ -194,7 +194,7 @@ docker compose ps`}
                 <tr>
                   <td className="px-4 py-2.5 text-gray-600">Isolation model</td>
                   <td className="px-4 py-2.5 text-gray-900">
-                    Dedicated PostHog Postgres/Redis/ClickHouse/Kafka/Zookeeper
+                    Dedicated PostHog Postgres/Redis/ClickHouse/Kafka
                   </td>
                 </tr>
                 <tr>

--- a/localcloud-gui/src/app/posthog/page.tsx
+++ b/localcloud-gui/src/app/posthog/page.tsx
@@ -120,8 +120,8 @@ export default function PosthogPage() {
 
   return (
     <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      <DocPageNav title="LocalCloud Kit" subtitle="PostHog">
-        <ServiceStatusBadge service="posthog" name="PostHog" />
+      <DocPageNav title="LocalCloud Kit" subtitle="PostHog (Beta)">
+        <ServiceStatusBadge service="posthog" name="PostHog (Beta)" />
         <a
           href={POSTHOG_UI_URL}
           target="_blank"
@@ -134,6 +134,14 @@ export default function PosthogPage() {
       </DocPageNav>
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+        <section className="bg-amber-50 border border-amber-200 text-amber-900 rounded-lg px-4 py-3 text-sm">
+          <p className="font-medium">PostHog integration is currently in beta.</p>
+          <p className="mt-1">
+            This stack is experimental and intended for local evaluation only. APIs, behavior, and defaults
+            may change between releases.
+          </p>
+        </section>
+
         <section className="bg-white rounded-lg shadow p-6 border border-gray-200">
           <h2 className="text-lg font-semibold text-gray-900 mb-2">About PostHog</h2>
           <p className="text-sm text-gray-600 leading-relaxed">

--- a/localcloud-gui/src/app/posthog/page.tsx
+++ b/localcloud-gui/src/app/posthog/page.tsx
@@ -139,7 +139,7 @@ export default function PosthogPage() {
           <p className="text-sm text-gray-600 leading-relaxed">
             LocalCloud Kit includes <strong>PostHog</strong> as an optional platform service for local
             product analytics, event capture, and feature-flag development. The PostHog stack runs in an
-            isolated profile with dedicated Postgres, Redis, ClickHouse, and Kafka containers.
+            isolated profile with dedicated Postgres, Redis, ClickHouse, Kafka, and ZooKeeper containers.
           </p>
           <p className="text-sm text-gray-600 leading-relaxed mt-2">
             This stack is intended for local service usage and is intentionally isolated from your
@@ -194,7 +194,7 @@ docker compose ps`}
                 <tr>
                   <td className="px-4 py-2.5 text-gray-600">Isolation model</td>
                   <td className="px-4 py-2.5 text-gray-900">
-                    Dedicated PostHog Postgres/Redis/ClickHouse/Kafka
+                    Dedicated PostHog Postgres/Redis/ClickHouse/Kafka/ZooKeeper
                   </td>
                 </tr>
                 <tr>

--- a/localcloud-gui/src/components/DashboardSkeleton.tsx
+++ b/localcloud-gui/src/components/DashboardSkeleton.tsx
@@ -49,7 +49,7 @@ export function ServicesBarSkeleton() {
       <div className="h-4 w-px bg-gray-200" />
       <ServicePillSkeleton name="PostgreSQL" />
       <div className="h-4 w-px bg-gray-200" />
-      <ServicePillSkeleton name="PostHog" />
+      <ServicePillSkeleton name="PostHog (Beta)" />
       <div className="h-4 w-px bg-gray-200" />
       <ServicePillSkeleton name="Redis" />
     </div>

--- a/localcloud-gui/src/constants/docsHub.ts
+++ b/localcloud-gui/src/constants/docsHub.ts
@@ -238,10 +238,10 @@ export const DOCS_HUB_ENTRIES: DocsHubEntry[] = [
   },
   {
     id: "posthog",
-    title: "PostHog",
+    title: "PostHog (Beta)",
     category: "platform-services",
     docsPath: "/posthog",
-    summary: "Product analytics and feature-flag verification in local mode.",
+    summary: "Experimental product analytics and feature-flag verification in local mode.",
     quickChecks: [
       "PostHog service is running",
       "Project API key and host match local settings",

--- a/nginx.conf
+++ b/nginx.conf
@@ -95,6 +95,7 @@ http {
         }
 
         # All other routes - proxy to Next.js GUI
+        # Longer timeouts so first request survives dev-mode compile when many containers (e.g. PostHog) share CPU
         location / {
             proxy_pass http://gui;
             proxy_http_version 1.1;
@@ -106,10 +107,10 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_cache_bypass $http_upgrade;
             
-            # Timeouts
-            proxy_connect_timeout 30s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 30s;
+            # Timeouts: 90s so first-load dev compile can finish when host is under load (e.g. PostHog profile)
+            proxy_connect_timeout 90s;
+            proxy_send_timeout 90s;
+            proxy_read_timeout 90s;
             
             # Error handling
             proxy_intercept_errors on;

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -1,12 +1,4 @@
 <clickhouse>
-    <!-- ZooKeeper connection — required for ReplicatedMergeTree tables -->
-    <zookeeper>
-        <node>
-            <host>posthog-zookeeper</host>
-            <port>2181</port>
-        </node>
-    </zookeeper>
-
     <!-- Cluster definitions — must match PostHog's official docker/clickhouse/config.d/default.xml.
          All five cluster names are required: posthog, posthog_migrations, posthog_primary_replica,
          posthog_single_shard, and posthog_writable. All point to the single local node. -->
@@ -54,9 +46,8 @@
         </posthog_writable>
     </remote_servers>
 
-    <!-- Macros used by ReplicatedMergeTree table definitions and PostHog cluster queries.
-         Values must match PostHog's official config: hostClusterType=online, hostClusterRole=data.
-         These are embedded in ReplicatedMergeTree ZooKeeper paths and table routing logic. -->
+    <!-- Macros used by PostHog cluster queries.
+         Values must match PostHog's official config: hostClusterType=online, hostClusterRole=data. -->
     <macros>
         <shard>01</shard>
         <replica>ch1</replica>

--- a/posthog/clickhouse-config.xml
+++ b/posthog/clickhouse-config.xml
@@ -1,4 +1,14 @@
 <clickhouse>
+    <!-- ZooKeeper coordination — required for ReplicatedMergeTree tables created by PostHog migrations.
+         Even with CLICKHOUSE_REPLICATION=false, PostHog's ClickHouse migrations create
+         ReplicatedMergeTree tables and expect a coordination service to be available. -->
+    <zookeeper>
+        <node>
+            <host>posthog-zookeeper</host>
+            <port>2181</port>
+        </node>
+    </zookeeper>
+
     <!-- Cluster definitions — must match PostHog's official docker/clickhouse/config.d/default.xml.
          All five cluster names are required: posthog, posthog_migrations, posthog_primary_replica,
          posthog_single_shard, and posthog_writable. All point to the single local node. -->

--- a/posthog/clickhouse-users.xml
+++ b/posthog/clickhouse-users.xml
@@ -8,5 +8,27 @@
             <!-- Do not use <grants> here: ClickHouse 24.x does not allow mixing
                  grants with access_management/named_collection_control on the same user. -->
         </default>
+
+        <!-- api user: used by PostHog web/worker for analytics queries (CLICKHOUSE_API_USER) -->
+        <api>
+            <password>apipass</password>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>0</access_management>
+        </api>
+
+        <!-- app user: used by PostHog plugins/ingestion pipeline (CLICKHOUSE_APP_USER) -->
+        <app>
+            <password>apppass</password>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>0</access_management>
+        </app>
     </users>
 </clickhouse>


### PR DESCRIPTION
posthog-zookeeper was never referenced by any depends_on — Redpanda
(used as the Kafka implementation) is ZooKeeper-free by design, and
ClickHouse replication is disabled (CLICKHOUSE_REPLICATION=false), so
ZooKeeper served no purpose and consumed resources unnecessarily.

posthog-db-migrate now depends on posthog-kafka being healthy before
running migrations. PostHog's migrate command references KAFKA_HOSTS
and may attempt Kafka-dependent setup steps; without this guard the
migrate container could race against Kafka startup.