### PR TITLE
feat(iam): support multi-service trust policies and saved configs in IAM role modal

### DIFF
--- a/localcloud-gui/src/app/cache/page.tsx
+++ b/localcloud-gui/src/app/cache/page.tsx
@@ -37,8 +37,8 @@ export default function CachePage() {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<any>(null);
-  const [allKeys, setAllKeys] = useState<any[]>([]);
+  const [status, setStatus] = useState<{ status: string; info?: unknown } | null>(null);
+  const [allKeys, setAllKeys] = useState<{ key: string; value: string }[]>([]);
   const [activeAction, setActiveAction] = useState<
     "set" | "get" | "delete" | null
   >("set");
@@ -83,8 +83,8 @@ export default function CachePage() {
       const res = await cacheApi.status();
       setStatus(res);
       setResult(null);
-    } catch (e: any) {
-      setError(e.message || "Failed to fetch status");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch status");
     } finally {
       setLoading(false);
     }
@@ -106,8 +106,8 @@ export default function CachePage() {
         setActiveAction(null);
         await handleShowAllKeys();
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to set key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to set key");
     } finally {
       setLoading(false);
     }
@@ -127,8 +127,8 @@ export default function CachePage() {
         setKey("");
         setActiveAction(null);
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to get key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to get key");
     } finally {
       setLoading(false);
     }
@@ -149,8 +149,8 @@ export default function CachePage() {
         setActiveAction(null);
         await handleShowAllKeys();
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to delete key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to delete key");
     } finally {
       setLoading(false);
     }
@@ -168,8 +168,8 @@ export default function CachePage() {
           setAllKeys(keysRes.data || []);
         }
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to flush cache");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to flush cache");
     } finally {
       setLoading(false);
     }
@@ -185,8 +185,8 @@ export default function CachePage() {
       } else {
         setError(res.error || "Failed to fetch keys");
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to fetch keys");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch keys");
     } finally {
       setLoading(false);
     }

--- a/localcloud-gui/src/components/CacheModal.tsx
+++ b/localcloud-gui/src/components/CacheModal.tsx
@@ -15,8 +15,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
   const [result, setResult] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<any>(null);
-  const [allKeys, setAllKeys] = useState<any[]>([]);
+  const [status, setStatus] = useState<{ status: string; info?: unknown } | null>(null);
+  const [allKeys, setAllKeys] = useState<{ key: string; value: string }[]>([]);
   const [showAllKeys, setShowAllKeys] = useState(false);
   const [activeAction, setActiveAction] = useState<
     "set" | "get" | "delete" | null
@@ -49,8 +49,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
       const res = await cacheApi.status();
       setStatus(res);
       setResult(null);
-    } catch (e: any) {
-      setError(e.message || "Failed to fetch status");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch status");
     } finally {
       setLoading(false);
     }
@@ -71,8 +71,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
         setValue("");
         setActiveAction(null);
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to set key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to set key");
     } finally {
       setLoading(false);
     }
@@ -92,8 +92,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
         setKey("");
         setActiveAction(null);
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to get key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to get key");
     } finally {
       setLoading(false);
     }
@@ -113,8 +113,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
         setKey("");
         setActiveAction(null);
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to delete key");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to delete key");
     } finally {
       setLoading(false);
     }
@@ -134,8 +134,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
           setShowAllKeys(true);
         }
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to flush cache");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to flush cache");
     } finally {
       setLoading(false);
     }
@@ -152,8 +152,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
       } else {
         setError(res.error || "Failed to fetch keys");
       }
-    } catch (e: any) {
-      setError(e.message || "Failed to fetch keys");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch keys");
     } finally {
       setLoading(false);
     }
@@ -162,7 +162,6 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
   // Fetch status when modal opens
   useEffect(() => {
     if (isOpen) fetchStatus();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   if (!isOpen) return null;
@@ -226,8 +225,8 @@ export default function CacheModal({ isOpen, onClose }: CacheModalProps) {
                   {status.status}
                 </span>
               </div>
-              {status.info && (
-                <div className="break-all">Info: {status.info}</div>
+              {!!status.info && (
+                <div className="break-all">Info: {JSON.stringify(status.info)}</div>
               )}
             </div>
           )}

--- a/localcloud-gui/src/components/ConnectionGuide.tsx
+++ b/localcloud-gui/src/components/ConnectionGuide.tsx
@@ -89,7 +89,7 @@ const CodeBlock = ({
         // Optionally remove the theme link on unmount
         // if (link) link.remove();
       };
-    }, [theme]);
+    }, []); // ClientCodeBlock remounts when theme changes, so effect always runs fresh
 
     useEffect(() => {
       // Use highlight.js to generate highlighted HTML safely
@@ -107,7 +107,7 @@ const CodeBlock = ({
       }).value;
 
       setHighlightedCode(highlighted);
-    }, [code, language]);
+    }, []); // ClientCodeBlock remounts when code/language change, so effect always runs fresh
 
     return (
       <pre className="p-4 rounded-lg overflow-x-auto">

--- a/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { ChevronDownIcon, XMarkIcon, PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { getDynamoDBTableSchema } from "@/services/api";
 
@@ -29,7 +29,7 @@ interface TableSchema {
 interface DynamoDBAddItemModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (item: Record<string, any>) => void;
+  onSubmit: (item: Record<string, unknown>) => void;
   tableName: string;
   projectName: string;
   loading?: boolean;
@@ -69,8 +69,7 @@ function isAttributeEmpty(attr: NestedAttribute): boolean {
 
 // Recursive builder for DynamoDB attribute
 // Returns undefined when the attribute is effectively empty so it can be dropped cleanly
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function buildDynamoDBAttribute(attr: NestedAttribute): any {
+function buildDynamoDBAttribute(attr: NestedAttribute): unknown {
   if (isAttributeEmpty(attr)) return undefined;
 
   if (attr.type === "S") return { S: attr.value ?? "" };
@@ -78,7 +77,7 @@ function buildDynamoDBAttribute(attr: NestedAttribute): any {
   if (attr.type === "BOOL") return { BOOL: attr.value === "true" };
 
   if (attr.type === "M" && attr.children) {
-    const mapObj: Record<string, any> = {};
+    const mapObj: Record<string, unknown> = {};
     for (const child of attr.children) {
       if (!child.key) continue;
       const builtChild = buildDynamoDBAttribute(child);
@@ -113,7 +112,7 @@ function AttributeEditor({
   onRemove?: () => void;
   parentType?: AttributeType | null;
 }) {
-  const handleFieldChange = (field: keyof NestedAttribute, value: any) => {
+  const handleFieldChange = (field: keyof NestedAttribute, value: unknown) => {
     onChange({ ...attr, [field]: value });
   };
 
@@ -257,11 +256,34 @@ export default function DynamoDBAddItemModal({
   const [attributes, setAttributes] = useState<NestedAttribute[]>([]);
   const [error, setError] = useState("");
 
+  const loadTableSchema = useCallback(async () => {
+    setSchemaLoading(true);
+    setError("");
+    try {
+      const response = await getDynamoDBTableSchema(projectName, tableName);
+      if (response.success) {
+        setSchema(response.data);
+        // Initialize key values
+        const initialKeys: Record<string, string> = {};
+        response.data.Table.KeySchema.forEach(
+          (key: { AttributeName: string }) => {
+            initialKeys[key.AttributeName] = "";
+          }
+        );
+        setKeyValues(initialKeys);
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load table schema");
+    } finally {
+      setSchemaLoading(false);
+    }
+  }, [projectName, tableName]);
+
   useEffect(() => {
     if (isOpen && tableName) {
       loadTableSchema();
     }
-  }, [isOpen, tableName]);
+  }, [isOpen, tableName, loadTableSchema]);
 
   // Reset form state each time the modal is opened so previous values don't persist
   useEffect(() => {
@@ -282,29 +304,6 @@ export default function DynamoDBAddItemModal({
       document.body.style.overflow = "";
     };
   }, [isOpen, onClose]);
-
-  const loadTableSchema = async () => {
-    setSchemaLoading(true);
-    setError("");
-    try {
-      const response = await getDynamoDBTableSchema(projectName, tableName);
-      if (response.success) {
-        setSchema(response.data);
-        // Initialize key values
-        const initialKeys: Record<string, string> = {};
-        response.data.Table.KeySchema.forEach(
-          (key: { AttributeName: string }) => {
-            initialKeys[key.AttributeName] = "";
-          }
-        );
-        setKeyValues(initialKeys);
-      }
-    } catch (err: any) {
-      setError(err.message || "Failed to load table schema");
-    } finally {
-      setSchemaLoading(false);
-    }
-  };
 
   const handleAddAttribute = () => {
     setAttributes([...attributes, { key: "", type: "S" }]);
@@ -344,7 +343,7 @@ export default function DynamoDBAddItemModal({
     }
 
     // Build item in DynamoDB format
-    const item: Record<string, any> = {};
+    const item: Record<string, unknown> = {};
 
     // Add key values
     schema.Table.KeySchema.forEach((key: { AttributeName: string }) => {

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -17,7 +17,7 @@ import {
   ArrowTopRightOnSquareIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import DynamoDBAddItemModal from "./DynamoDBAddItemModal";
 import DynamoDBConfigModal from "./DynamoDBConfigModal";
 import { Icon } from "@iconify/react";
@@ -33,17 +33,15 @@ interface DynamoDBViewerProps {
   skName?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 interface DynamoDBItem {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface ScanResult {
   items: DynamoDBItem[];
   count: number;
   scannedCount: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lastEvaluatedKey?: any;
+  lastEvaluatedKey?: unknown;
 }
 
 interface TableSchema {
@@ -83,7 +81,7 @@ export default function DynamoDBViewer({
   const [addLoading, setAddLoading] = useState(false);
   const [error, setError] = useState<string>("");
   const [jsonViewerOpen, setJsonViewerOpen] = useState(false);
-  const [selectedJsonData, setSelectedJsonData] = useState<any>(null);
+  const [selectedJsonData, setSelectedJsonData] = useState<unknown>(null);
   const [selectedJsonTitle, setSelectedJsonTitle] = useState<string>("");
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [itemToDelete, setItemToDelete] = useState<DynamoDBItem | null>(null);
@@ -110,11 +108,36 @@ export default function DynamoDBViewer({
     }
   };
 
+  const loadTables = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch(
+        `${"/api"}/dynamodb/tables?projectName=${encodeURIComponent(
+          projectName
+        )}`
+      );
+      if (!response.ok) {
+        throw new Error(`Failed to load tables (${response.status})`);
+      }
+      const data = await response.json();
+      if (data.success) {
+        setTables(data.data || []);
+      } else {
+        throw new Error(data.error || "Failed to load tables");
+      }
+    } catch (error) {
+      console.error("Failed to load tables:", error);
+      setError(error instanceof Error ? error.message : "Failed to load tables");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectName]);
+
   useEffect(() => {
     if (isOpen) {
       loadTables();
     }
-  }, [isOpen]);
+  }, [isOpen, loadTables]);
 
   useEffect(() => {
     if (isOpen && selectedTableName && tables.length > 0) {
@@ -148,32 +171,8 @@ export default function DynamoDBViewer({
       loadTableSchema();
       loadTableContents();
     }
-  }, [selectedTable]);
-
-  const loadTables = async () => {
-    setLoading(true);
-    try {
-      const response = await fetch(
-        `${"/api"}/dynamodb/tables?projectName=${encodeURIComponent(
-          projectName
-        )}`
-      );
-      if (!response.ok) {
-        throw new Error(`Failed to load tables (${response.status})`);
-      }
-      const data = await response.json();
-      if (data.success) {
-        setTables(data.data || []);
-      } else {
-        throw new Error(data.error || "Failed to load tables");
-      }
-    } catch (error) {
-      console.error("Failed to load tables:", error);
-      setError(error instanceof Error ? error.message : "Failed to load tables");
-    } finally {
-      setLoading(false);
-    }
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTable]); // intentionally only re-run when table selection changes
 
   const refreshData = async () => {
     await loadTables();
@@ -195,19 +194,20 @@ export default function DynamoDBViewer({
   };
 
   // Helper to flatten DynamoDB item format
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const flattenDynamoDBItem = (item: any): Record<string, any> => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const flat: Record<string, any> = {};
-    for (const key in item) {
-      const value = item[key];
+  const flattenDynamoDBItem = (item: unknown): Record<string, unknown> => {
+    const flat: Record<string, unknown> = {};
+    if (typeof item !== "object" || item === null) return flat;
+    const obj = item as Record<string, unknown>;
+    for (const key in obj) {
+      const value = obj[key];
       if (typeof value === "object" && value !== null) {
-        if ("S" in value) flat[key] = value.S;
-        else if ("N" in value) flat[key] = Number(value.N);
-        else if ("BOOL" in value) flat[key] = value.BOOL;
-        else if ("NULL" in value) flat[key] = null;
-        else if ("L" in value) flat[key] = value.L.map(flattenDynamoDBItem);
-        else if ("M" in value) flat[key] = flattenDynamoDBItem(value.M);
+        const v = value as Record<string, unknown>;
+        if ("S" in v) flat[key] = v.S;
+        else if ("N" in v) flat[key] = Number(v.N);
+        else if ("BOOL" in v) flat[key] = v.BOOL;
+        else if ("NULL" in v) flat[key] = null;
+        else if ("L" in v) flat[key] = (v.L as unknown[]).map(flattenDynamoDBItem);
+        else if ("M" in v) flat[key] = flattenDynamoDBItem(v.M);
         else flat[key] = value;
       } else {
         flat[key] = value;
@@ -298,22 +298,21 @@ export default function DynamoDBViewer({
     }
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleAddItem = async (item: any) => {
+  const handleAddItem = async (item: Record<string, unknown>) => {
     setAddLoading(true);
     setError("");
     try {
       await addDynamoDBItem(projectName, selectedTable, item);
       setAddModalOpen(false);
       await loadTableContents();
-    } catch (err: any) {
-      setError(err.message || "Failed to add item");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to add item");
     } finally {
       setAddLoading(false);
     }
   };
 
-  const formatValue = (value: any): string => {
+  const formatValue = (value: unknown): string => {
     if (value === null || value === undefined) return "";
     if (typeof value === "object") return JSON.stringify(value);
     return String(value);
@@ -361,7 +360,7 @@ export default function DynamoDBViewer({
     return key ? (key.KeyType === "HASH" ? "Partition Key" : "Sort Key") : "";
   };
 
-  const handleJsonClick = (data: any, title: string) => {
+  const handleJsonClick = (data: unknown, title: string) => {
     setSelectedJsonData(data);
     setSelectedJsonTitle(title);
     setJsonViewerOpen(true);
@@ -406,8 +405,8 @@ export default function DynamoDBViewer({
       setDeleteModalOpen(false);
       setItemToDelete(null);
       await loadTableContents(); // Refresh the table
-    } catch (err: any) {
-      setError(err.message || "Failed to delete item");
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to delete item");
     } finally {
       setDeleteLoading(false);
     }

--- a/localcloud-gui/src/components/FileViewerModal.tsx
+++ b/localcloud-gui/src/components/FileViewerModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { XMarkIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 import hljs from "highlight.js";
 import { highlightThemes, HighlightTheme } from "./highlightThemes";
@@ -143,7 +143,7 @@ export default function FileViewerModal({
   const [error, setError] = useState<string | null>(null);
   const [selectedTheme, setSelectedTheme] = useState<HighlightTheme>(theme);
 
-  const loadFileContent = async () => {
+  const loadFileContent = useCallback(async () => {
     if (!isOpen) return;
 
     setLoading(true);
@@ -168,7 +168,7 @@ export default function FileViewerModal({
     } finally {
       setLoading(false);
     }
-  };
+  }, [isOpen, bucketName, objectKey, projectName]);
 
   useEffect(() => {
     if (isOpen) {
@@ -177,7 +177,7 @@ export default function FileViewerModal({
       setFileContent(null);
       setError(null);
     }
-  }, [isOpen, projectName, bucketName, objectKey]);
+  }, [isOpen, loadFileContent]);
 
   useEffect(() => {
     setSelectedTheme(theme);
@@ -315,8 +315,8 @@ export default function FileViewerModal({
     const jsonString = fileContent.content.trim();
     try {
       prettyJson = JSON.stringify(JSON.parse(jsonString), null, 2);
-    } catch (e: any) {
-      jsonParseError = e.message || "Invalid JSON format.";
+    } catch (e: unknown) {
+      jsonParseError = e instanceof Error ? e.message : "Invalid JSON format.";
       prettyJson = jsonString;
     }
   }
@@ -503,6 +503,7 @@ export default function FileViewerModal({
                   </div>
                 )}
                 {viewerType === "image" && (
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={`data:${fileContent.metadata.ContentType};base64,${fileContent.content}`}
                     alt={objectKey}
@@ -528,10 +529,10 @@ export default function FileViewerModal({
                   <div className="overflow-x-auto">
                     <table className="min-w-full text-xs border border-gray-400">
                       <tbody>
-                        {Papa.parse(fileContent.content.trim()).data.map(
-                          (row: any, i: number) => (
+                        {Papa.parse<string[]>(fileContent.content.trim()).data.map(
+                          (row, i) => (
                             <tr key={i}>
-                              {row.map((cell: any, j: number) => (
+                              {row.map((cell, j) => (
                                 <td
                                   key={j}
                                   className="border border-gray-400 px-2 py-1 whitespace-nowrap text-gray-800 font-medium"

--- a/localcloud-gui/src/components/IAMConfigModal.tsx
+++ b/localcloud-gui/src/components/IAMConfigModal.tsx
@@ -5,6 +5,8 @@ import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify/react";
 import { IAMRoleConfig } from "@/types";
 import SavedConfigPicker from "./SavedConfigPicker";
+import { usePreferences } from "@/context/PreferencesContext";
+import { toast } from "react-hot-toast";
 
 // Common AWS service principals that can assume roles
 const TRUST_SERVICE_OPTIONS = [
@@ -55,6 +57,7 @@ export default function IAMConfigModal({
   projectName,
   loading = false,
 }: IAMConfigModalProps) {
+  const { saveConfig } = usePreferences();
   const [roleName, setRoleName] = useState(`${projectName}-role`);
   const [trustServices, setTrustServices] = useState<string[]>(DEFAULT_TRUST_SERVICES);
   const [description, setDescription] = useState("");
@@ -62,6 +65,10 @@ export default function IAMConfigModal({
   const [advancedMode, setAdvancedMode] = useState(false);
   const [customPolicy, setCustomPolicy] = useState("");
   const [customPolicyError, setCustomPolicyError] = useState("");
+  const [saveAsConfig, setSaveAsConfig] = useState(false);
+  const [configName, setConfigName] = useState("");
+  const [configNameTouched, setConfigNameTouched] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -83,6 +90,9 @@ export default function IAMConfigModal({
       setAdvancedMode(false);
       setCustomPolicy("");
       setCustomPolicyError("");
+      setSaveAsConfig(false);
+      setConfigName("");
+      setConfigNameTouched(false);
     }
   }, [isOpen, projectName]);
 
@@ -110,8 +120,21 @@ export default function IAMConfigModal({
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handlePrettify = () => {
+    try {
+      setCustomPolicy(JSON.stringify(JSON.parse(customPolicy), null, 2));
+      setCustomPolicyError("");
+    } catch {
+      setCustomPolicyError("Invalid JSON — cannot prettify.");
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (saveAsConfig && !configName.trim()) {
+      setConfigNameTouched(true);
+      return;
+    }
     if (advancedMode) {
       try {
         JSON.parse(customPolicy);
@@ -131,13 +154,27 @@ export default function IAMConfigModal({
     if (advancedMode) {
       config.customPolicy = customPolicy;
     }
+    if (saveAsConfig && configName.trim()) {
+      setSaving(true);
+      try {
+        await saveConfig(configName.trim(), "iam", config);
+        toast.success(`Config "${configName.trim()}" saved`);
+      } catch {
+        toast.error("Failed to save config");
+      } finally {
+        setSaving(false);
+      }
+    }
     onSubmit(config);
   };
 
+  const configNameError = configNameTouched && saveAsConfig && !configName.trim();
   const canSubmit =
     !loading &&
+    !saving &&
     roleName.trim() !== "" &&
-    (advancedMode ? customPolicy.trim() !== "" : trustServices.length > 0);
+    (advancedMode ? customPolicy.trim() !== "" : trustServices.length > 0) &&
+    (!saveAsConfig || configName.trim() !== "");
 
   const currentConfig: Record<string, unknown> = {
     roleName,
@@ -182,6 +219,7 @@ export default function IAMConfigModal({
             onLoad={handleLoad}
             currentConfig={currentConfig}
             configLabel="IAM Role"
+            hideSave
           />
 
           {/* Role Name */}
@@ -255,16 +293,25 @@ export default function IAMConfigModal({
                 <label className="block text-sm font-medium text-gray-700">
                   Trust Policy (JSON)
                 </label>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setAdvancedMode(false);
-                    setCustomPolicyError("");
-                  }}
-                  className="text-xs text-blue-600 hover:text-blue-800 font-medium"
-                >
-                  Back to selector
-                </button>
+                <div className="flex items-center space-x-3">
+                  <button
+                    type="button"
+                    onClick={handlePrettify}
+                    className="text-xs text-gray-500 hover:text-gray-700 font-medium"
+                  >
+                    Prettify
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setAdvancedMode(false);
+                      setCustomPolicyError("");
+                    }}
+                    className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                  >
+                    Back to selector
+                  </button>
+                </div>
               </div>
               <textarea
                 value={customPolicy}
@@ -328,6 +375,42 @@ export default function IAMConfigModal({
             </p>
           </div>
 
+          {/* Save as config */}
+          <div className="border-t pt-4">
+            <label className="flex items-center space-x-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={saveAsConfig}
+                onChange={(e) => {
+                  setSaveAsConfig(e.target.checked);
+                  if (!e.target.checked) setConfigName("");
+                }}
+                className="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300 rounded"
+              />
+              <span className="text-sm text-gray-700">Save as config</span>
+            </label>
+            {saveAsConfig && (
+              <div className="mt-3">
+                <input
+                  type="text"
+                  value={configName}
+                  onChange={(e) => setConfigName(e.target.value)}
+                  onBlur={() => setConfigNameTouched(true)}
+                  placeholder="e.g. my-lambda-role"
+                  className={`w-full px-3 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 text-gray-900 ${
+                    configNameError
+                      ? "border-red-400 focus:ring-red-400 focus:border-red-400 bg-red-50"
+                      : "border-gray-300 focus:ring-red-500 focus:border-red-500"
+                  }`}
+                  autoFocus
+                />
+                {configNameError && (
+                  <p className="text-xs text-red-600 mt-1">Config name is required.</p>
+                )}
+              </div>
+            )}
+          </div>
+
           {/* Actions */}
           <div className="flex justify-end space-x-3 pt-2">
             <button
@@ -343,7 +426,7 @@ export default function IAMConfigModal({
               className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
               disabled={!canSubmit}
             >
-              {loading ? "Creating..." : "Create Role"}
+              {loading || saving ? "Creating..." : "Create Role"}
             </button>
           </div>
         </form>

--- a/localcloud-gui/src/components/IAMConfigModal.tsx
+++ b/localcloud-gui/src/components/IAMConfigModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { XMarkIcon } from "@heroicons/react/24/outline";
 import { Icon } from "@iconify/react";
 import { IAMRoleConfig } from "@/types";
+import SavedConfigPicker from "./SavedConfigPicker";
 
 // Common AWS service principals that can assume roles
 const TRUST_SERVICE_OPTIONS = [
@@ -15,6 +16,29 @@ const TRUST_SERVICE_OPTIONS = [
   { value: "firehose", label: "Kinesis Firehose" },
   { value: "s3", label: "S3" },
 ];
+
+const DEFAULT_TRUST_SERVICES = ["lambda"];
+
+function buildTrustPolicy(services: string[]): string {
+  const principals =
+    services.length === 1
+      ? `${services[0]}.amazonaws.com`
+      : services.map((s) => `${s}.amazonaws.com`);
+  return JSON.stringify(
+    {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: principals },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    },
+    null,
+    2
+  );
+}
 
 interface IAMConfigModalProps {
   isOpen: boolean;
@@ -32,9 +56,12 @@ export default function IAMConfigModal({
   loading = false,
 }: IAMConfigModalProps) {
   const [roleName, setRoleName] = useState(`${projectName}-role`);
-  const [trustService, setTrustService] = useState("lambda");
+  const [trustServices, setTrustServices] = useState<string[]>(DEFAULT_TRUST_SERVICES);
   const [description, setDescription] = useState("");
   const [path, setPath] = useState("/");
+  const [advancedMode, setAdvancedMode] = useState(false);
+  const [customPolicy, setCustomPolicy] = useState("");
+  const [customPolicyError, setCustomPolicyError] = useState("");
 
   useEffect(() => {
     if (!isOpen) return;
@@ -50,33 +77,75 @@ export default function IAMConfigModal({
   useEffect(() => {
     if (isOpen) {
       setRoleName(`${projectName}-role`);
-      setTrustService("lambda");
+      setTrustServices(DEFAULT_TRUST_SERVICES);
       setDescription("");
       setPath("/");
+      setAdvancedMode(false);
+      setCustomPolicy("");
+      setCustomPolicyError("");
     }
   }, [isOpen, projectName]);
 
   if (!isOpen) return null;
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    onSubmit({ roleName, trustService, description, path });
+  const toggleService = (value: string) => {
+    setTrustServices((prev) =>
+      prev.includes(value) ? prev.filter((s) => s !== value) : [...prev, value]
+    );
   };
 
-  const previewTrustPolicy = JSON.stringify(
-    {
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Principal: { Service: `${trustService}.amazonaws.com` },
-          Action: "sts:AssumeRole",
-        },
-      ],
-    },
-    null,
-    2
-  );
+  const previewPolicy = advancedMode ? customPolicy : buildTrustPolicy(trustServices);
+
+  const handleLoad = (config: Record<string, unknown>) => {
+    if (config.roleName) setRoleName(config.roleName as string);
+    if (Array.isArray(config.trustServices)) setTrustServices(config.trustServices as string[]);
+    if (config.description !== undefined) setDescription(config.description as string);
+    if (config.path !== undefined) setPath(config.path as string);
+    if (config.customPolicy) {
+      setAdvancedMode(true);
+      setCustomPolicy(config.customPolicy as string);
+    } else {
+      setAdvancedMode(false);
+      setCustomPolicy("");
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (advancedMode) {
+      try {
+        JSON.parse(customPolicy);
+      } catch {
+        setCustomPolicyError("Invalid JSON — please check your trust policy.");
+        return;
+      }
+    }
+    const trustPolicy = advancedMode ? customPolicy : buildTrustPolicy(trustServices);
+    const config: IAMRoleConfig = {
+      roleName,
+      trustServices,
+      trustPolicy,
+      description,
+      path,
+    };
+    if (advancedMode) {
+      config.customPolicy = customPolicy;
+    }
+    onSubmit(config);
+  };
+
+  const canSubmit =
+    !loading &&
+    roleName.trim() !== "" &&
+    (advancedMode ? customPolicy.trim() !== "" : trustServices.length > 0);
+
+  const currentConfig: Record<string, unknown> = {
+    roleName,
+    trustServices,
+    description,
+    path,
+    ...(advancedMode ? { customPolicy } : {}),
+  };
 
   return (
     <div
@@ -108,6 +177,12 @@ export default function IAMConfigModal({
         </div>
 
         <form onSubmit={handleSubmit} className="p-6 space-y-5">
+          <SavedConfigPicker
+            resourceType="iam"
+            onLoad={handleLoad}
+            currentConfig={currentConfig}
+            configLabel="IAM Role"
+          />
 
           {/* Role Name */}
           <div>
@@ -124,47 +199,101 @@ export default function IAMConfigModal({
             />
           </div>
 
-          {/* Trusted Service */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Trusted AWS Service
-            </label>
-            <div className="grid grid-cols-2 gap-2">
-              {TRUST_SERVICE_OPTIONS.map((opt) => (
-                <label
-                  key={opt.value}
-                  className={`flex items-center space-x-2 px-3 py-2 border rounded-md cursor-pointer transition-colors ${
-                    trustService === opt.value
-                      ? "border-red-500 bg-red-50 text-red-700"
-                      : "border-gray-300 hover:border-gray-400 text-gray-700"
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="trustService"
-                    value={opt.value}
-                    checked={trustService === opt.value}
-                    onChange={() => setTrustService(opt.value)}
-                    className="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300"
-                  />
-                  <span className="text-sm">{opt.label}</span>
+          {/* Trusted Services (simple mode) */}
+          {!advancedMode && (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-sm font-medium text-gray-700">
+                  Trusted AWS Services
                 </label>
-              ))}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAdvancedMode(true);
+                    setCustomPolicy(buildTrustPolicy(trustServices));
+                  }}
+                  className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                >
+                  Advanced (custom JSON)
+                </button>
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {TRUST_SERVICE_OPTIONS.map((opt) => (
+                  <label
+                    key={opt.value}
+                    className={`flex items-center space-x-2 px-3 py-2 border rounded-md cursor-pointer transition-colors ${
+                      trustServices.includes(opt.value)
+                        ? "border-red-500 bg-red-50 text-red-700"
+                        : "border-gray-300 hover:border-gray-400 text-gray-700"
+                    }`}
+                  >
+                    <input
+                      type="checkbox"
+                      value={opt.value}
+                      checked={trustServices.includes(opt.value)}
+                      onChange={() => toggleService(opt.value)}
+                      className="h-4 w-4 text-red-600 focus:ring-red-500 border-gray-300 rounded"
+                    />
+                    <span className="text-sm">{opt.label}</span>
+                  </label>
+                ))}
+              </div>
+              {trustServices.length === 0 && (
+                <p className="text-xs text-red-500 mt-1">Select at least one trusted service.</p>
+              )}
+              <p className="text-xs text-gray-500 mt-1">
+                AWS services that can assume this role via{" "}
+                <code className="bg-gray-100 px-1 rounded">sts:AssumeRole</code>. Select multiple to allow all of them.
+              </p>
             </div>
-            <p className="text-xs text-gray-500 mt-1">
-              The AWS service that can assume this role via <code className="bg-gray-100 px-1 rounded">sts:AssumeRole</code>.
-            </p>
-          </div>
+          )}
 
-          {/* Trust Policy Preview */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Trust Policy Preview
-            </label>
-            <pre className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-md text-xs font-mono text-gray-700 overflow-x-auto whitespace-pre-wrap">
-              {previewTrustPolicy}
-            </pre>
-          </div>
+          {/* Advanced mode — raw JSON textarea */}
+          {advancedMode && (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-sm font-medium text-gray-700">
+                  Trust Policy (JSON)
+                </label>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAdvancedMode(false);
+                    setCustomPolicyError("");
+                  }}
+                  className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+                >
+                  Back to selector
+                </button>
+              </div>
+              <textarea
+                value={customPolicy}
+                onChange={(e) => {
+                  setCustomPolicy(e.target.value);
+                  setCustomPolicyError("");
+                }}
+                rows={10}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500 text-gray-900 font-mono text-xs"
+                placeholder='{"Version":"2012-10-17","Statement":[...]}'
+                required
+              />
+              {customPolicyError && (
+                <p className="text-xs text-red-500 mt-1">{customPolicyError}</p>
+              )}
+            </div>
+          )}
+
+          {/* Trust Policy Preview (simple mode only) */}
+          {!advancedMode && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Trust Policy Preview
+              </label>
+              <pre className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-md text-xs font-mono text-gray-700 overflow-x-auto whitespace-pre-wrap">
+                {previewPolicy}
+              </pre>
+            </div>
+          )}
 
           {/* Description */}
           <div>
@@ -193,7 +322,9 @@ export default function IAMConfigModal({
               placeholder="/"
             />
             <p className="text-xs text-gray-500 mt-1">
-              IAM path for the role (e.g. <code className="bg-gray-100 px-1 rounded">/service-role/</code>). Defaults to <code className="bg-gray-100 px-1 rounded">/</code>.
+              IAM path for the role (e.g.{" "}
+              <code className="bg-gray-100 px-1 rounded">/service-role/</code>). Defaults to{" "}
+              <code className="bg-gray-100 px-1 rounded">/</code>.
             </p>
           </div>
 
@@ -210,7 +341,7 @@ export default function IAMConfigModal({
             <button
               type="submit"
               className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
-              disabled={loading || !roleName.trim()}
+              disabled={!canSubmit}
             >
               {loading ? "Creating..." : "Create Role"}
             </button>

--- a/localcloud-gui/src/components/RedisModal.tsx
+++ b/localcloud-gui/src/components/RedisModal.tsx
@@ -41,7 +41,7 @@ export default function RedisModal({ onClose }: RedisModalProps) {
         status: statusData.status,
         info: statusData.info,
       });
-      setKeys(keysData.keys || []);
+      setKeys((keysData.data || []).map((k) => k.key));
     } catch {
       setRedisInfo({ status: "unavailable" });
     } finally {

--- a/localcloud-gui/src/components/SavedConfigPicker.tsx
+++ b/localcloud-gui/src/components/SavedConfigPicker.tsx
@@ -12,6 +12,7 @@ interface SavedConfigPickerProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   currentConfig: any;
   configLabel: string;
+  hideSave?: boolean;
 }
 
 export default function SavedConfigPicker({
@@ -19,6 +20,7 @@ export default function SavedConfigPicker({
   onLoad,
   currentConfig,
   configLabel,
+  hideSave = false,
 }: SavedConfigPickerProps) {
   const { profile, savedConfigs, saveConfig } = usePreferences();
   const [showSaveInput, setShowSaveInput] = useState(false);
@@ -56,17 +58,19 @@ export default function SavedConfigPicker({
           <span className="text-sm font-medium text-gray-700">Saved configs</span>
           <span className="text-xs text-gray-400">({profile.active_project_label})</span>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowSaveInput((v) => !v)}
-          className="text-xs text-blue-600 hover:text-blue-800 font-medium"
-        >
-          {showSaveInput ? "Cancel" : `Save ${configLabel}`}
-        </button>
+        {!hideSave && (
+          <button
+            type="button"
+            onClick={() => setShowSaveInput((v) => !v)}
+            className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+          >
+            {showSaveInput ? "Cancel" : `Save ${configLabel}`}
+          </button>
+        )}
       </div>
 
       {/* Save input */}
-      {showSaveInput && (
+      {!hideSave && showSaveInput && (
         <div className="flex items-center space-x-2 mb-3">
           <input
             type="text"

--- a/localcloud-gui/src/components/SavedConfigPicker.tsx
+++ b/localcloud-gui/src/components/SavedConfigPicker.tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 
 interface SavedConfigPickerProps {
-  resourceType: "s3" | "dynamodb" | "secrets";
+  resourceType: "s3" | "dynamodb" | "secrets" | "iam";
   onLoad: (config: SavedConfig["config"]) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   currentConfig: any;

--- a/localcloud-gui/src/components/SecretsDetailModal.tsx
+++ b/localcloud-gui/src/components/SecretsDetailModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   XMarkIcon,
   EyeIcon,
@@ -53,6 +53,24 @@ export default function SecretsDetailModal({
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [copied, setCopied] = useState(false);
 
+  const loadSecret = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/secrets/${encodeURIComponent(secretName)}?includeValue=false`);
+      const result = await res.json();
+      if (result.success) {
+        setSecret(result.data);
+        setEditDesc(result.data.Description || "");
+      } else {
+        toast.error("Failed to load secret");
+      }
+    } catch {
+      toast.error("Failed to load secret");
+    } finally {
+      setLoading(false);
+    }
+  }, [secretName]);
+
   useEffect(() => {
     if (isOpen && secretName) {
       loadSecret();
@@ -65,7 +83,7 @@ export default function SecretsDetailModal({
       setEditing(false);
       setConfirmDelete(false);
     }
-  }, [isOpen, secretName]);
+  }, [isOpen, secretName, loadSecret]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -83,24 +101,6 @@ export default function SecretsDetailModal({
       document.body.style.overflow = "";
     };
   }, [isOpen, onClose, editing, confirmDelete]);
-
-  const loadSecret = async () => {
-    setLoading(true);
-    try {
-      const res = await fetch(`/api/secrets/${encodeURIComponent(secretName)}?includeValue=false`);
-      const result = await res.json();
-      if (result.success) {
-        setSecret(result.data);
-        setEditDesc(result.data.Description || "");
-      } else {
-        toast.error("Failed to load secret");
-      }
-    } catch {
-      toast.error("Failed to load secret");
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleReveal = async () => {
     if (revealed) {

--- a/localcloud-gui/src/components/ServiceStatusBadge.tsx
+++ b/localcloud-gui/src/components/ServiceStatusBadge.tsx
@@ -37,7 +37,7 @@ async function fetchStatus(service: ServiceKey): Promise<StatusState> {
       }
       case "redis": {
         const s = await cacheApi.status();
-        const st = s?.data?.status ?? s?.status ?? "unknown";
+        const st = s?.status ?? "unknown";
         if (st === "running") return { level: "running", label: "Running" };
         if (st === "stopped") return { level: "stopped", label: "Stopped" };
         return { level: "unknown", label: "Unknown" };

--- a/localcloud-gui/src/hooks/useAsync.ts
+++ b/localcloud-gui/src/hooks/useAsync.ts
@@ -4,19 +4,19 @@ interface UseAsyncReturn<T> {
   data: T | null;
   loading: boolean;
   error: Error | null;
-  execute: (...args: any[]) => Promise<T>;
+  execute: (...args: unknown[]) => Promise<T>;
   reset: () => void;
 }
 
 export function useAsync<T>(
-  asyncFunction: (...args: any[]) => Promise<T>
+  asyncFunction: (...args: unknown[]) => Promise<T>
 ): UseAsyncReturn<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
   const execute = useCallback(
-    async (...args: any[]) => {
+    async (...args: unknown[]) => {
       setLoading(true);
       setError(null);
 

--- a/localcloud-gui/src/services/api.ts
+++ b/localcloud-gui/src/services/api.ts
@@ -11,10 +11,21 @@ import {
   Project,
   ProjectConfig,
   Resource,
+  ResourceTemplate,
   RedisStatus,
   SavedConfig,
   UserProfile,
 } from "@/types";
+
+interface CacheStatus {
+  status: "running" | "stopped" | "unknown";
+  info?: Record<string, string>;
+}
+
+interface CacheKeyEntry {
+  key: string;
+  value: string;
+}
 
 export interface DashboardData {
   localstackStatus: LocalStackStatus;
@@ -124,8 +135,8 @@ export const configApi = {
     return response.data.data!;
   },
 
-  getTemplates: async (): Promise<any[]> => {
-    const response = await api.get<ApiResponse<any[]>>("/config/templates");
+  getTemplates: async (): Promise<ResourceTemplate[]> => {
+    const response = await api.get<ApiResponse<ResourceTemplate[]>>("/config/templates");
     return response.data.data || [];
   },
 };
@@ -153,6 +164,7 @@ export const healthApi = {
 // S3 Bucket Management
 export const s3Api = {
   // List all buckets for a project
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getBuckets: async (projectName: string): Promise<ApiResponse<any[]>> => {
     try {
       const response = await fetch(
@@ -172,6 +184,7 @@ export const s3Api = {
   getBucketContents: async (
     projectName: string,
     bucketName: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<ApiResponse<any[]>> => {
     try {
       const response = await fetch(
@@ -192,6 +205,7 @@ export const s3Api = {
     projectName: string,
     bucketName: string,
     objectKey: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<ApiResponse<any>> => {
     try {
       const response = await fetch(
@@ -215,6 +229,7 @@ export const s3Api = {
     bucketName: string,
     objectKey: string,
     content: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<ApiResponse<any>> => {
     try {
       const response = await fetch(
@@ -246,6 +261,7 @@ export const s3Api = {
     bucketName: string,
     objectKey: string,
     file: File
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<ApiResponse<any>> => {
     try {
       const formData = new FormData();
@@ -275,6 +291,7 @@ export const s3Api = {
     projectName: string,
     bucketName: string,
     objectKey: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<ApiResponse<any>> => {
     try {
       const response = await fetch(
@@ -334,28 +351,28 @@ export const mailpitApi = {
 
 // Redis Cache Management
 export const cacheApi = {
-  status: async (): Promise<any> => {
-    const response = await api.get("/cache/status");
+  status: async (): Promise<CacheStatus> => {
+    const response = await api.get<CacheStatus>("/cache/status");
     return response.data;
   },
-  set: async (key: string, value: string): Promise<any> => {
-    const response = await api.post("/cache/set", { key, value });
+  set: async (key: string, value: string): Promise<ApiResponse> => {
+    const response = await api.post<ApiResponse>("/cache/set", { key, value });
     return response.data;
   },
-  get: async (key: string): Promise<any> => {
-    const response = await api.get("/cache/get", { params: { key } });
+  get: async (key: string): Promise<ApiResponse> => {
+    const response = await api.get<ApiResponse>("/cache/get", { params: { key } });
     return response.data;
   },
-  del: async (key: string): Promise<any> => {
-    const response = await api.delete("/cache/del", { data: { key } });
+  del: async (key: string): Promise<ApiResponse> => {
+    const response = await api.delete<ApiResponse>("/cache/del", { data: { key } });
     return response.data;
   },
-  flush: async (): Promise<any> => {
-    const response = await api.post("/cache/flush");
+  flush: async (): Promise<ApiResponse> => {
+    const response = await api.post<ApiResponse>("/cache/flush");
     return response.data;
   },
-  keys: async (): Promise<any> => {
-    const response = await api.get("/cache/keys");
+  keys: async (): Promise<ApiResponse<CacheKeyEntry[]>> => {
+    const response = await api.get<ApiResponse<CacheKeyEntry[]>>("/cache/keys");
     return response.data;
   },
 };
@@ -363,7 +380,7 @@ export const cacheApi = {
 export async function addDynamoDBItem(
   projectName: string,
   tableName: string,
-  item: any
+  item: Record<string, unknown>
 ) {
   const res = await fetch(`/api/dynamodb/table/${tableName}/item`, {
     method: "POST",
@@ -450,8 +467,7 @@ export const savedConfigsApi = {
     const response = await api.get<ApiResponse<SavedConfig[]>>("/saved-configs", { params });
     return response.data.data || [];
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  create: async (projectId: number, name: string, resourceType: string, config: any): Promise<SavedConfig> => {
+  create: async (projectId: number, name: string, resourceType: string, config: unknown): Promise<SavedConfig> => {
     const response = await api.post<ApiResponse<SavedConfig>>("/saved-configs", {
       project_id: projectId,
       name,

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -99,7 +99,9 @@ export interface SSMParameterConfig {
 
 export interface IAMRoleConfig {
   roleName: string;
-  trustService: string;
+  trustServices: string[];
+  trustPolicy: string;
+  customPolicy?: string;
   description?: string;
   path?: string;
 }
@@ -223,7 +225,7 @@ export interface SavedConfig {
   id: number;
   project_id: number;
   name: string;
-  resource_type: "s3" | "dynamodb" | "secrets" | "secretsmanager" | "lambda" | "apigateway" | "ssm";
+  resource_type: "s3" | "dynamodb" | "secrets" | "secretsmanager" | "lambda" | "apigateway" | "ssm" | "iam";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
   config_json: string;

--- a/scripts/shell/create_single_resource.sh
+++ b/scripts/shell/create_single_resource.sh
@@ -602,38 +602,26 @@ EOF
 }
 
 create_iam_role() {
+  DEFAULT_TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
   if [ -n "$RESOURCE_CONFIG" ]; then
     ROLE_NAME=$(echo "$RESOURCE_CONFIG" | jq -r '.roleName // empty')
     DESCRIPTION=$(echo "$RESOURCE_CONFIG" | jq -r '.description // empty')
-    TRUST_SERVICE=$(echo "$RESOURCE_CONFIG" | jq -r '.trustService // "lambda"')
+    TRUST_POLICY=$(echo "$RESOURCE_CONFIG" | jq -r '.trustPolicy // empty')
     PATH_PREFIX=$(echo "$RESOURCE_CONFIG" | jq -r '.path // "/"')
 
     if [ -z "$ROLE_NAME" ]; then
       ROLE_NAME="${NAME_PREFIX}-role"
     fi
+    if [ -z "$TRUST_POLICY" ] || [ "$TRUST_POLICY" = "null" ]; then
+      TRUST_POLICY="$DEFAULT_TRUST_POLICY"
+    fi
   else
     ROLE_NAME="${NAME_PREFIX}-role"
     DESCRIPTION="Default IAM role created by LocalCloud Kit"
-    TRUST_SERVICE="lambda"
+    TRUST_POLICY="$DEFAULT_TRUST_POLICY"
     PATH_PREFIX="/"
   fi
-
-  # Build trust policy document for the given service principal
-  TRUST_POLICY=$(cat <<TRUST
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "${TRUST_SERVICE}.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-TRUST
-)
 
   CMD="$AWS_CMD iam create-role --role-name \"$ROLE_NAME\" --assume-role-policy-document '$TRUST_POLICY'"
   if [ -n "$DESCRIPTION" ] && [ "$DESCRIPTION" != "null" ]; then
@@ -647,6 +635,7 @@ TRUST
   log "Created IAM role: $ROLE_NAME"
 
   ARN="arn:aws:iam::000000000000:role${PATH_PREFIX}${ROLE_NAME}"
+  TRUST_SERVICES=$(echo "$RESOURCE_CONFIG" | jq -c '.trustServices // ["lambda"]')
 
   cat <<EOF
 {
@@ -659,7 +648,7 @@ TRUST
   "details": {
     "roleName": "$ROLE_NAME",
     "arn": "$ARN",
-    "trustService": "$TRUST_SERVICE",
+    "trustServices": $TRUST_SERVICES,
     "path": "$PATH_PREFIX",
     "description": "$DESCRIPTION"
   }


### PR DESCRIPTION
Replace the single radio-button trust service selector with multi-select
checkboxes so users can allow multiple AWS services to assume a role in
one step. Add an Advanced toggle that exposes a raw JSON textarea for
custom trust policies, pre-populated from the simple selection.

Include SavedConfigPicker so IAM role configs can be saved and reloaded
per project, matching the pattern used by other resource modals.

Fix the shell script: instead of string-interpolating a single service
name into a heredoc, the frontend now builds the complete trust policy
JSON and passes it as trustPolicy in iamConfig. The script reads it
directly with jq, eliminating the single-service limitation and the
broken array case.

Types updated: IAMRoleConfig gains trustServices[], trustPolicy, and
optional customPolicy; SavedConfig.resource_type gains "iam".