### PR TITLE
feat: make Traefik port configurable via APP_PORT variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ENVIRONMENT ?= dev
 AWS_ENDPOINT ?= http://localhost:4566
 AWS_REGION ?= us-east-1
 LOCALSTACK_VERSION ?= latest
+APP_PORT ?= 3030
 
 # Colors for output
 GREEN := \033[0;32m
@@ -40,7 +41,8 @@ help: ## Show this help message
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  $(GREEN)%-15s$(NC) %s\n", $$1, $$2}' $(MAKEFILE_LIST) | grep -E "(setup|check)"
 	@echo ""
 	@echo "$(YELLOW)Usage Examples:$(NC)"
-	@echo "  make start                              # Start with LocalStack latest"
+	@echo "  make start                              # Start with LocalStack latest (port 3030)"
+	@echo "  make start APP_PORT=4040                # Start on a custom port (e.g. 4040)"
 	@echo "  make start LOCALSTACK_VERSION=4.14      # Start with a specific LocalStack version"
 	@echo "  make start-legacy                       # Start with LocalStack 4.14 (community legacy)"
 	@echo "  make gui-start                          # Start GUI system with Docker"
@@ -54,18 +56,18 @@ start: ## Start all services with Docker Compose (LOCALSTACK_VERSION=latest by d
 	@echo "$(GREEN)Starting LocalStack Template with Docker...$(NC)"
 	@echo "$(YELLOW)Using LocalStack version: $(LOCALSTACK_VERSION)$(NC)"
 	@mkdir -p volume/cache volume/lib volume/logs volume/tmp
-	LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) docker compose up --build -d
+	LOCALSTACK_VERSION=$(LOCALSTACK_VERSION) APP_PORT=$(APP_PORT) docker compose up --build -d
 	@echo "$(GREEN)Waiting for services to be ready...$(NC)"
-	@until curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 || curl -s http://localhost/health > /dev/null 2>&1; do sleep 2; done
+	@until curl -s -k https://app-local.localcloudkit.com:$(APP_PORT)/health > /dev/null 2>&1 || curl -s http://localhost/health > /dev/null 2>&1; do sleep 2; done
 	@echo "$(GREEN)All services are ready!$(NC)"
 	@echo ""
 	@echo "$(GREEN)--- App URLs (via Traefik, TLS) ---$(NC)"
-	@echo "$(YELLOW)  GUI:            https://app-local.localcloudkit.com:3030$(NC)"
-	@echo "$(YELLOW)  API:            https://app-local.localcloudkit.com:3030/api$(NC)"
-	@echo "$(YELLOW)  Mailpit (mail): https://mailpit.localcloudkit.com:3030$(NC)"
-	@echo "$(YELLOW)  Keycloak:       https://keycloak.localcloudkit.com:3030$(NC)"
-	@echo "$(YELLOW)  pgAdmin:        https://pgadmin.localcloudkit.com:3030$(NC)"
-	@echo "$(YELLOW)  PostHog:        https://posthog.localcloudkit.com:3030$(NC)"
+	@echo "$(YELLOW)  GUI:            https://app-local.localcloudkit.com:$(APP_PORT)$(NC)"
+	@echo "$(YELLOW)  API:            https://app-local.localcloudkit.com:$(APP_PORT)/api$(NC)"
+	@echo "$(YELLOW)  Mailpit (mail): https://mailpit.localcloudkit.com:$(APP_PORT)$(NC)"
+	@echo "$(YELLOW)  Keycloak:       https://keycloak.localcloudkit.com:$(APP_PORT)$(NC)"
+	@echo "$(YELLOW)  pgAdmin:        https://pgadmin.localcloudkit.com:$(APP_PORT)$(NC)"
+	@echo "$(YELLOW)  PostHog:        https://posthog.localcloudkit.com:$(APP_PORT)$(NC)"
 	@echo ""
 	@echo "$(GREEN)--- Direct localhost URLs (no TLS) ---$(NC)"
 	@echo "$(YELLOW)  LocalStack:     http://localhost:4566$(NC)"
@@ -90,10 +92,10 @@ status: ## Check Docker services status
 	@docker compose ps
 	@echo ""
 	@echo "$(YELLOW)Health Checks:$(NC)"
-	@curl -s -k https://app-local.localcloudkit.com:3030/health > /dev/null 2>&1 && echo "$(GREEN)  GUI/API:   https://app-local.localcloudkit.com:3030  ✓$(NC)" || echo "$(RED)  GUI/API:   not responding$(NC)"
+	@curl -s -k https://app-local.localcloudkit.com:$(APP_PORT)/health > /dev/null 2>&1 && echo "$(GREEN)  GUI/API:   https://app-local.localcloudkit.com:$(APP_PORT)  ✓$(NC)" || echo "$(RED)  GUI/API:   not responding$(NC)"
 	@curl -s http://localhost:4566/_localstack/health > /dev/null 2>&1 && echo "$(GREEN)  LocalStack: http://localhost:4566  ✓$(NC)" || echo "$(RED)  LocalStack: not responding$(NC)"
 	@curl -s http://localhost:8025/api/v1/info > /dev/null 2>&1 && echo "$(GREEN)  Mailpit:   http://localhost:8025  ✓$(NC)" || echo "$(YELLOW)  Mailpit:   not responding (may not be running)$(NC)"
-	@curl -s -k https://posthog.localcloudkit.com:3030/_health > /dev/null 2>&1 && echo "$(GREEN)  PostHog:   https://posthog.localcloudkit.com:3030  ✓$(NC)" || echo "$(YELLOW)  PostHog:   not responding (optional profile may be stopped)$(NC)"
+	@curl -s -k https://posthog.localcloudkit.com:$(APP_PORT)/_health > /dev/null 2>&1 && echo "$(GREEN)  PostHog:   https://posthog.localcloudkit.com:$(APP_PORT)  ✓$(NC)" || echo "$(YELLOW)  PostHog:   not responding (optional profile may be stopped)$(NC)"
 
 logs: ## View Docker services logs
 	docker compose logs -f
@@ -141,7 +143,7 @@ reset-env: clean clean-all ## Full environment reset (clean resources, stop serv
 gui-start: ## Start the LocalCloud Kit GUI system with Docker
 	@echo "$(BLUE)Starting LocalCloud Kit GUI with Docker...$(NC)"
 	@docker compose up -d localcloud-gui localcloud-api nginx
-	@echo "$(GREEN)LocalCloud Kit GUI is running at https://app-local.localcloudkit.com:3030$(NC)"
+	@echo "$(GREEN)LocalCloud Kit GUI is running at https://app-local.localcloudkit.com:$(APP_PORT)$(NC)"
 
 gui-stop: ## Stop the LocalCloud Kit GUI system
 	@echo "$(YELLOW)Stopping LocalCloud Kit GUI...$(NC)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: traefik:v3
     container_name: traefik
     ports:
-      - "3030:3030"
+      - "${APP_PORT:-3030}:3030"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
@@ -150,7 +150,7 @@ services:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - KC_HTTP_ENABLED=true
-      - KC_HOSTNAME=https://keycloak.localcloudkit.com:3030
+      - KC_HOSTNAME=https://keycloak.localcloudkit.com:${APP_PORT:-3030}
       - KC_PROXY_HEADERS=xforwarded
       - KC_HOSTNAME_STRICT=false
       - KC_HOSTNAME_STRICT_HTTPS=false
@@ -395,7 +395,7 @@ services:
       - KAFKA_HOSTS=posthog-kafka:9092
       - PRIMARY_DB=clickhouse
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
-      - SITE_URL=https://posthog.localcloudkit.com:3030
+      - SITE_URL=https://posthog.localcloudkit.com:${APP_PORT:-3030}
       - DEPLOYMENT=hobby
       - OBJECT_STORAGE_ENABLED=false
       - CLICKHOUSE_REPLICATION=false
@@ -439,7 +439,7 @@ services:
       - KAFKA_HOSTS=posthog-kafka:9092
       - PRIMARY_DB=clickhouse
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
-      - SITE_URL=https://posthog.localcloudkit.com:3030
+      - SITE_URL=https://posthog.localcloudkit.com:${APP_PORT:-3030}
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
@@ -508,7 +508,7 @@ services:
       - KAFKA_HOSTS=posthog-kafka:9092
       - PRIMARY_DB=clickhouse
       - SECRET_KEY=localcloud-posthog-secret-key-change-me
-      - SITE_URL=https://posthog.localcloudkit.com:3030
+      - SITE_URL=https://posthog.localcloudkit.com:${APP_PORT:-3030}
       - IS_BEHIND_PROXY=true
       - TRUSTED_PROXIES=*
       - DEPLOYMENT=hobby

--- a/env.example
+++ b/env.example
@@ -19,6 +19,8 @@ AWS_SECRET_ACCESS_KEY=test
 # Application Configuration
 NODE_ENV=production
 PORT=3031
+# Host port Traefik listens on (override with: make start APP_PORT=4040 or set here)
+APP_PORT=3030
 
 # API Configuration
 API_BASE_URL=https://app-local.localcloudkit.com:3030/api


### PR DESCRIPTION
## Summary

- Add `APP_PORT` environment variable (default: 3030) to make the Traefik listening port configurable
- Update Makefile to pass `APP_PORT` to docker compose and use it in all service URLs
- Update docker-compose.yml to use `${APP_PORT:-3030}` for Traefik port binding and service configurations
- Update env.example with `APP_PORT` documentation

## Type of change

- [x] `feat` — new feature
- [x] `build` / `chore` — infra, deps, tooling

## Motivation

Previously, the Traefik port was hardcoded to 3030 throughout the codebase, making it impossible to run multiple instances of LocalCloud Kit on the same machine or use a different port without manual edits. This change introduces a configurable `APP_PORT` variable that allows users to easily override the port via environment variable or make command.

## Changes

### Makefile
- Added `APP_PORT ?= 3030` variable definition
- Updated help text to document port customization
- Modified `start` target to pass `APP_PORT` to docker compose
- Updated all service URL outputs to use `$(APP_PORT)` instead of hardcoded `3030`
- Updated `status` target health checks to use `$(APP_PORT)`
- Updated `gui-start` target output to use `$(APP_PORT)`

### docker-compose.yml
- Changed Traefik port binding from `"3030:3030"` to `"${APP_PORT:-3030}:3030"`
- Updated Keycloak `KC_HOSTNAME` to use `${APP_PORT:-3030}`
- Updated PostHog `SITE_URL` in all three PostHog service definitions to use `${APP_PORT:-3030}`

### env.example
- Added `APP_PORT=3030` with documentation explaining it controls the Traefik listening port

## Usage

Users can now customize the port in three ways:
1. Default: `make start` (uses port 3030)
2. Command line: `make start APP_PORT=4040` (uses port 4040)
3. Environment file: Set `APP_PORT=4040` in `.env` file

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits
- [x] No hardcoded secrets or credentials introduced
- [x] Localhost-only assumptions removed (port is now configurable)

### Documentation & changelog
- [ ] `CHANGELOG.md` — needs entry under `## [Unreleased]`
- [x] `README.md` — no changes needed (port customization is self-documenting via help text)
- [ ] `CLAUDE.md` — no changes needed (no architecture changes)

## Test Plan

- Verify `make start` works with default port 3030
- Verify `make start APP_PORT=4040` starts services on port 4040
- Verify all service URLs in output reflect the custom port
- Verify health checks use the correct port
- Verify docker compose receives the APP_PORT variable correctly

https://claude.ai/code/session_01JxpLQ6cWvVcB1ZXCkFewVn