### PR TITLE
chore(agents): neutralize vendor naming and relocate verify skill

### DIFF
--- a/.agent/commands/verify-new-service.md
+++ b/.agent/commands/verify-new-service.md
@@ -97,11 +97,12 @@ The service being verified is: **$ARGUMENTS**
 - [ ] CHANGELOG entry uses bold component name format: `- **ServiceName**: description`
 - [ ] CHANGELOG entry is user-facing language (not implementation details)
 
-## 12. CLAUDE.md
+## 12. AGENTS.md and IDE entry
 
-- [ ] Service added to the **Services** table in the Architecture section
+- [ ] Service added to the **Services** table in `AGENTS.md` (Architecture section)
 - [ ] Subdomain listed in the Networking & Routing section
-- [ ] "Adding a New Service" checklist still accurate (update if steps changed)
+- [ ] "Adding a New Service" checklist in `AGENTS.md` still accurate (update if steps changed)
+- [ ] If your tool reads `CLAUDE.md`, that file still points at `AGENTS.md` as the source of truth
 
 ---
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@
 ### Documentation & changelog
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
 - [ ] `README.md` updated if access URLs or features changed
-- [ ] `CLAUDE.md` updated if architecture, services table, or conventions changed
+- [ ] `AGENTS.md` / IDE entry (`CLAUDE.md`) updated if architecture, services table, or conventions changed
 - [ ] Relevant `docs/*.md` files updated with current domain/URL info
 
 ## CHANGELOG entry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # LocalCloud Kit — AGENTS.md
 
 This file is the single source of truth for project context and standards in
-this repository. All AI coding agents (and `CLAUDE.md`) read from this file.
+this repository. All AI coding agents read from this file.
 
 ---
 
@@ -198,10 +198,10 @@ Entries go under `## [Unreleased]` at the top of the file. Use these subsections
 
 ## Attribution
 
-- **Author**: The commit author must always be a human. No AI agent (Claude, Copilot, Cursor, or any other) may appear as the commit author.
+- **Author**: The commit author must always be a human. No automated coding tool or AI agent may appear as the commit author.
 - **Co-author**: Use `Co-Authored-By:` only for human collaborators. Never include AI agents in author or co-author fields.
-- **No AI attribution**: Do not add `Co-Authored-By: Claude`, `Co-Authored-By: GitHub Copilot`, or any other AI attribution in commit messages or footers.
-- **No AI badges**: Do not add `🤖 Generated with [Claude Code]`, `Built with Copilot`, or similar AI-generation lines in PR descriptions, commit bodies, or other output.
+- **No AI attribution**: Do not add `Co-Authored-By:` lines for bots, assistants, or AI products in commit messages or footers.
+- **No AI badges**: Do not add vendor AI-generation lines (for example “generated with … assistant”) in PR descriptions, commit bodies, or other output.
 - **Default author**: The correct git author for this repo is `Jonathan Robinson <jonrobinson.codes@gmail.com>`. Before committing, verify `git config user.name` and `git config user.email` match this identity.
 
 ---
@@ -430,7 +430,7 @@ const handleTabChange = (tab: PageTab) => {
 
 ## Git Branch Convention
 
-- All agent work happens on branches prefixed `claude/` followed by a short description and a unique session ID suffix
-- Example: `claude/add-iam-roles-localstack-OWviN`
+- All agent work happens on branches prefixed `agents/` followed by a short description and a unique session ID suffix
+- Example: `agents/add-iam-roles-emulator-OWviN`
 - **Never push to `main` directly**
 - Always push with `git push -u origin <branch-name>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **FileViewerModal**: Image/PDF via blob URLs, Content-Type handling, base64 normalization for object downloads
 - **Shell**: **download_s3_object.sh** — metadata via `jq`, single-line base64; **list_bucket_contents.sh**, **get_lambda_code.sh**, **upload_s3_object.sh** aligned with emulator workflow
 - **.gitignore**: Allow **samples/lambda-demo.zip** while keeping generic `*.zip` ignored
+- **AGENTS.md / PR template / project structure**: Agent branches documented as `agents/*`; attribution guidance without vendor product names; **verify-new-service** checklist lives under **`.agent/commands/`**; git history messages neutralized (session URLs, AI co-author lines, legacy branch path prose). The IDE hook file **`CLAUDE.md`** remains for tools that require that filename.
 
 ### Fixed
 
@@ -46,8 +47,8 @@ All notable changes to LocalCloud Kit will be documented in this file.
 ## [0.13.1] - 2026-03-13
 
 ### Changed
-- **CLAUDE.md**: Require reading AGENTS.md before executing any action
-- **AGENTS.md**: Attribution section expanded — commit author must always be human; no AI agents (Claude, Copilot, Cursor, etc.) in author or co-author fields; Co-Authored-By reserved for human collaborators only
+- **IDE entry / AGENTS.md**: Require reading AGENTS.md before executing any action
+- **AGENTS.md**: Attribution section expanded — commit author must always be human; no automated tools in author or co-author fields; Co-Authored-By reserved for human collaborators only
 
 ## [0.13.0] - 2026-03-13
 
@@ -186,7 +187,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **PostgreSQL**: Full PostgreSQL service integration — container managed via Docker Compose with status monitoring, connection info, and pgAdmin support
 - **Keycloak**: Identity and access management service — HTTPS routing via Traefik, status page with admin console link, and dedicated docs (`docs/KEYCLOAK.md`)
 - **DocPageNav**: Persistent top navigation bar on all doc pages with profile icon, docs dropdown, and per-page language selector
-- **verify-new-service**: Claude command skill for verifying new service integrations end-to-end
+- **verify-new-service**: IDE slash-command checklist for verifying new service integrations end-to-end
 - **`/api/postgres`**: Backend route for PostgreSQL health-check and connection status
 - **`/api/keycloak`**: Backend route for Keycloak health-check and status
 - **docs/KEYCLOAK.md**: Documentation for Keycloak setup, configuration, and usage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
-# LocalCloud Kit — CLAUDE.md
+# LocalCloud Kit — IDE agent entry
 
 **Always read [AGENTS.md](./AGENTS.md) before executing any action.** All project context, architecture, standards, and conventions live there.
 
-This file is Claude Code's entry point only — `AGENTS.md` is the single source of truth.
+This file is the IDE agent entry point only — `AGENTS.md` is the single source of truth.

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -94,7 +94,7 @@ localcloud-kit/
 ├── 📄 Makefile                 # Build and run commands
 ├── 📄 env.example              # Environment variable template
 ├── 📄 AGENTS.md                # AI coding agent context
-├── 📄 CLAUDE.md                # Claude AI context
+├── 📄 CLAUDE.md                # IDE hook filename; content defers to AGENTS.md
 └── 📄 README.md                # This project
 ```
 


### PR DESCRIPTION
## Summary

Moves agent-related hygiene out of direct `main` commits: neutral wording in **AGENTS.md** / PR template / project structure docs, relocates the **verify-new-service** checklist to **`.agent/commands/`**, and updates **CHANGELOG** (including `[Unreleased]`).

## Context

- Follows the repo branch convention **`agents/*`**.
- Keeps the **`CLAUDE.md`** filename where tools require it; copy and checklists point at **AGENTS.md** as source of truth.

## Checklist

- [x] Branch from current `main` tip with only the intended commit(s)
- [x] CHANGELOG `[Unreleased]` updated for user-visible doc/path changes