### PR TITLE
fix(s3): GUI bucket list and reliable uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 - **Manage Lambda**: Functions created from the dashboard now respect the active project filter (with **Show all in emulator** for full list)
 - **S3**: Prefix-based folder listing for nested keys; file viewer reliability for images and binary content from the emulator
+- **S3 upload** (`upload_s3_object.sh`): Upload no longer fails when `head-bucket` or `head-object` errors on the emulator after a successful `put-object`
 
 ### Removed
 

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -8,6 +8,7 @@ For SDK and CLI examples, see **[docs/CONNECT.md](CONNECT.md)**. The in-app doc 
 
 Open **Resources → S3 Buckets → Manage**, or use **Open Manager** on the **`/s3`** doc page.
 
+- Uses the **same active project** as the dashboard (`profile` / emulator config), not a hardcoded name.
 - Pick a bucket, then browse **folder prefixes** (nested keys) the same way as in the dashboard bucket viewer.
 - **Breadcrumbs**: The **bucket name** is a control that returns you to that bucket’s **root** (empty prefix). Each **folder segment** in the path is clickable and jumps to that prefix; the **last** segment is the current folder (not a separate link). **Back** walks up the folder stack and stays aligned with the path shown in the breadcrumbs.
 
@@ -29,7 +30,7 @@ Base path: `/api` (via Traefik: `https://app-local.localcloudkit.com:3030/api`).
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| `GET` | `/api/s3/buckets` | List buckets; optional `?projectName=` |
+| `GET` | `/api/s3/buckets` | List **all** buckets in the emulator (local dev); optional `?projectName=` (used for logging/script compatibility) |
 | `GET` | `/api/s3/bucket/:bucketName/contents` | List bucket contents; optional `?projectName=` |
 | `GET` | `/api/s3/bucket/:bucketName/object/*path` | Download object body + metadata (`?projectName=` required) |
 | `POST` | `/api/s3/bucket/:bucketName/upload-multipart` | Multipart upload (`projectName`, `objectKey`, file) |
@@ -40,6 +41,7 @@ See **[docs/SETUP_SCRIPTS.md](SETUP_SCRIPTS.md)** and `scripts/shell/` for bucke
 
 ## Troubleshooting
 
+- **Bucket on the dashboard but not in Manage S3 / bucket viewer**: The dashboard lists **saved resources**; the viewers list buckets from S3. Previously only names starting with the project prefix were returned — that hid custom bucket names. The API now lists every bucket in the emulator for the GUI. Ensure Manage S3 uses your active project (same as the dashboard) for creates and uploads.
 - Confirm the emulator is up: `curl http://localhost:4566/_localstack/health`
 - CLI: `aws --endpoint-url=http://localhost:4566 s3 ls`
 

--- a/docs/S3.md
+++ b/docs/S3.md
@@ -41,6 +41,7 @@ See **[docs/SETUP_SCRIPTS.md](SETUP_SCRIPTS.md)** and `scripts/shell/` for bucke
 
 ## Troubleshooting
 
+- **Upload fails in the GUI but the bucket exists**: The upload script used to require `head-bucket` and always ran `head-object` after `put-object`; on some emulators those calls can fail even when the object was stored. The script now skips pre-check and treats post-upload metadata as optional.
 - **Bucket on the dashboard but not in Manage S3 / bucket viewer**: The dashboard lists **saved resources**; the viewers list buckets from S3. Previously only names starting with the project prefix were returned — that hid custom bucket names. The API now lists every bucket in the emulator for the GUI. Ensure Manage S3 uses your active project (same as the dashboard) for creates and uploads.
 - Confirm the emulator is up: `curl http://localhost:4566/_localstack/health`
 - CLI: `aws --endpoint-url=http://localhost:4566 s3 ls`

--- a/localcloud-api/lib/resources.js
+++ b/localcloud-api/lib/resources.js
@@ -236,10 +236,11 @@ export async function listResources(projectName) {
 
 export async function listAllBuckets(projectName) {
   try {
-    // Fast path: only S3 list-buckets (same prefix filter as list_resources). Avoids
-    // list_resources.sh --all which queries every AWS service and is very slow.
+    // Fast path: S3 list-buckets only (no full list_resources scan). GUI passes
+    // --all-buckets so every emulator bucket is shown; create-modal names are not
+    // required to start with the project prefix.
     const { stdout, stderr } = await execAsync(
-      `./list_bucket_contents.sh ${projectName} dev`,
+      `./list_bucket_contents.sh ${projectName} dev --all-buckets`,
       { cwd: "/app/scripts/shell", env: awsEnv(), maxBuffer: 1024 * 1024 }
     );
 

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { s3Api, resourceApi } from "@/services/api";
 import ManageHeaderBrand from "@/components/ManageHeaderBrand";
+import { useProjectName } from "@/hooks/useProjectName";
 import { S3BucketConfig } from "@/types";
 import S3ConfigModal from "@/components/S3ConfigModal";
 import FileViewerModal from "@/components/FileViewerModal";
@@ -71,9 +72,8 @@ function breadcrumbFolderSegments(currentPath: string): { label: string; prefix:
   return out;
 }
 
-const projectName = "default";
-
 export default function ManageS3Page() {
+  const projectName = useProjectName();
   const [buckets, setBuckets] = useState<BucketItem[]>([]);
   const [selectedBucket, setSelectedBucket] = useState<string | null>(null);
   const [contents, setContents] = useState<BucketItem[]>([]);
@@ -97,7 +97,7 @@ export default function ManageS3Page() {
     } finally {
       setLoadingBuckets(false);
     }
-  }, []);
+  }, [projectName]);
 
   useEffect(() => { loadBuckets(); }, [loadBuckets]);
 
@@ -117,7 +117,7 @@ export default function ManageS3Page() {
     } finally {
       setLoadingContents(false);
     }
-  }, []);
+  }, [projectName]);
 
   const selectBucket = (name: string) => {
     setSelectedBucket(name);

--- a/scripts/shell/list_bucket_contents.sh
+++ b/scripts/shell/list_bucket_contents.sh
@@ -10,6 +10,14 @@ export AWS_PAGER=""
 PROJECT_NAME=${1:-"localcloud-kit"}
 ENVIRONMENT=${2:-"dev"}
 BUCKET_NAME=${3:-""}
+# When the API passes --all-buckets, list every bucket in the emulator (GUI). Bucket names from
+# the create modal are not required to start with the project prefix, so prefix-only filtering
+# hides buckets that still appear in the dashboard resource list.
+ALL_BUCKETS=false
+if [ "$BUCKET_NAME" = "--all-buckets" ]; then
+    ALL_BUCKETS=true
+    BUCKET_NAME=""
+fi
 AWS_ENDPOINT=${AWS_ENDPOINT_URL:-"http://aws-emulator:4566"}
 AWS_REGION=${AWS_REGION:-"us-east-1"}
 
@@ -57,11 +65,17 @@ list_bucket_contents() {
         --output json 2>/dev/null | tr -d '\n\r' || echo '[]'
 }
 
-# Function to list buckets for project
+# Function to list buckets for project (prefix filter) or all buckets (--all-buckets for API/GUI)
 list_project_buckets() {
-    $AWS_CMD s3api list-buckets \
-        --query "Buckets[?starts_with(Name, '$NAME_PREFIX')].{Name:Name,CreationDate:CreationDate}" \
-        --output json 2>/dev/null | tr -d '\n\r' || echo '[]'
+    if [ "$ALL_BUCKETS" = "true" ]; then
+        $AWS_CMD s3api list-buckets \
+            --query 'Buckets[].{Name:Name,CreationDate:CreationDate}' \
+            --output json 2>/dev/null | tr -d '\n\r' || echo '[]'
+    else
+        $AWS_CMD s3api list-buckets \
+            --query "Buckets[?starts_with(Name, '$NAME_PREFIX')].{Name:Name,CreationDate:CreationDate}" \
+            --output json 2>/dev/null | tr -d '\n\r' || echo '[]'
+    fi
 }
 
 # Main execution

--- a/scripts/shell/upload_s3_object.sh
+++ b/scripts/shell/upload_s3_object.sh
@@ -50,11 +50,7 @@ upload_object() {
         exit 1
     fi
     
-    # Check if bucket exists
-    if ! $AWS_CMD s3api head-bucket --bucket "$bucket_name" >/dev/null 2>&1; then
-        echo "Error: Bucket '$bucket_name' does not exist" >&2
-        exit 1
-    fi
+    # Do not use head-bucket here — some emulators return errors for valid buckets; put-object will fail clearly if missing.
     
     # Check if file exists
     if [ ! -f "$file_path" ]; then
@@ -90,16 +86,18 @@ upload_object() {
         --body "$file_path" \
         --content-type "$content_type" > /dev/null
     
-    # Get object metadata
-    $AWS_CMD s3api head-object \
+    # Optional metadata for download_s3_object.sh — must not fail the upload (set -e) if head-object is flaky on emulator
+    meta_file="/tmp/object_metadata_$$.json"
+    if $AWS_CMD s3api head-object \
         --bucket "$bucket_name" \
         --key "$object_key" \
         --query '{ContentType:ContentType,ContentLength:ContentLength,LastModified:LastModified,ETag:ETag}' \
-        --output json 2>/dev/null > /tmp/object_metadata.json
-    
-    # Output metadata as JSON comment for parsing
-    echo "<!--METADATA:$(cat /tmp/object_metadata.json)-->" >&2
-    rm -f /tmp/object_metadata.json
+        --output json 2>/dev/null > "$meta_file" && [ -s "$meta_file" ]; then
+        echo "<!--METADATA:$(cat "$meta_file")-->" >&2
+    else
+        echo "<!--METADATA:{}-->" >&2
+    fi
+    rm -f "$meta_file"
     
     echo "Successfully uploaded $object_key to bucket $bucket_name"
 }


### PR DESCRIPTION
## Summary

Fixes S3 **bucket listing** and **object upload** behavior in the GUI (dashboard bucket viewer, Manage S3) so they stay consistent with resources shown on the dashboard and uploads succeed reliably against the AWS Emulator (MiniStack).

## Problems

1. **Buckets visible on the dashboard but missing in the viewer / Manage S3**  
   The dashboard lists **tracked resources** from the app DB. The S3 API listed buckets with a **name prefix filter** (`starts_with(Name, projectName)`). Custom bucket names (e.g. from the create modal) often **do not** start with the project slug, so they never appeared in the picker even though they existed in S3 and on the dashboard.

2. **Manage S3 used a hardcoded project**  
   `projectName` was fixed to `"default"`, so creates/uploads could disagree with the **active project** used on the dashboard (`profile` / emulator config).

3. **Uploads reported failure after a successful put**  
   `upload_s3_object.sh` used `set -e` with **`head-bucket`** before upload and **`head-object`** after `put-object`. On the emulator, those calls can **error or flake** even when `put-object` succeeds, causing the script to exit non-zero and the API to return 500.

## Changes

| Area | Change |
|------|--------|
| **`scripts/shell/list_bucket_contents.sh`** | New third arg `--all-buckets`: list **every** bucket in the emulator (no prefix filter). |
| **`localcloud-api/lib/resources.js`** | `listAllBuckets` invokes the script with `--all-buckets` for the GUI fast path. |
| **`localcloud-gui/.../manage/s3/page.tsx`** | Uses **`useProjectName()`** (same resolution as the dashboard); refresh callbacks depend on `projectName`. |
| **`scripts/shell/upload_s3_object.sh`** | Drop pre-upload `head-bucket`; make post-upload `head-object` **optional**; unique temp file for metadata JSON. |
| **`docs/S3.md`** | API table, Manage S3 note, troubleshooting (listing + upload). |
| **`CHANGELOG.md`** | `[Unreleased]` entries for listing, upload, and cross-links. |

## How to verify

1. Rebuild/restart **api** so the container picks up updated shell scripts.
2. Create or pick a bucket whose **name does not** start with your project prefix — it should appear in **Manage S3** and the **dashboard bucket viewer** after refresh.
3. Upload a file (multipart) — should succeed without a false failure after upload.

## Commits

- `fix(s3): list all emulator buckets for GUI and align manage project`
- `fix(s3): make upload script resilient to flaky head-bucket/head-object`
