### PR TITLE
style(gui): tailwind v4 class names for eslint

### DIFF
--- a/localcloud-gui/src/app/apigateway/page.tsx
+++ b/localcloud-gui/src/app/apigateway/page.tsx
@@ -285,7 +285,7 @@ export default function APIGatewayDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-pink-50 to-rose-100">
+    <main className="min-h-screen bg-linear-to-br from-pink-50 to-rose-100">
       <DocPageNav title="LocalCloud Kit" subtitle="API Gateway">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -447,7 +447,7 @@ export default function APIGatewayDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/aws-emulator/page.tsx
+++ b/localcloud-gui/src/app/aws-emulator/page.tsx
@@ -72,7 +72,7 @@ aws s3 ls --endpoint-url ${projectConfig.awsEndpoint}
 alias awslocal='aws --endpoint-url ${projectConfig.awsEndpoint}'`;
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="AWS Emulator">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
       </DocPageNav>

--- a/localcloud-gui/src/app/cache/page.tsx
+++ b/localcloud-gui/src/app/cache/page.tsx
@@ -198,7 +198,7 @@ export default function CachePage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Redis">
         <ServiceStatusBadge service="redis" name="Redis" />
         <div className="relative" ref={connectionRef}>

--- a/localcloud-gui/src/app/connect/page.tsx
+++ b/localcloud-gui/src/app/connect/page.tsx
@@ -4,7 +4,7 @@ import ManageHeaderBrand from "@/components/ManageHeaderBrand";
 
 export default function ConnectPage() {
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">

--- a/localcloud-gui/src/app/docs/page.tsx
+++ b/localcloud-gui/src/app/docs/page.tsx
@@ -57,7 +57,7 @@ export default function DocsHubPage() {
   }, [selectedEntry]);
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="py-4 flex items-center justify-between">

--- a/localcloud-gui/src/app/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/dynamodb/page.tsx
@@ -195,7 +195,7 @@ export default function DynamoDBDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="DynamoDB">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -321,7 +321,7 @@ export default function DynamoDBDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/iam/page.tsx
+++ b/localcloud-gui/src/app/iam/page.tsx
@@ -405,7 +405,7 @@ export default function IAMDocPage() {
   );
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-red-50 to-orange-100">
+    <main className="min-h-screen bg-linear-to-br from-red-50 to-orange-100">
       <DocPageNav title="LocalCloud Kit" subtitle="IAM & STS">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -537,7 +537,7 @@ export default function IAMDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-red-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/keycloak/page.tsx
+++ b/localcloud-gui/src/app/keycloak/page.tsx
@@ -142,7 +142,7 @@ export default function KeycloakPage() {
   ];
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Keycloak">
         <ServiceStatusBadge service="keycloak" name="Keycloak" />
         <a
@@ -292,7 +292,7 @@ export default function KeycloakPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/lambda/page.tsx
+++ b/localcloud-gui/src/app/lambda/page.tsx
@@ -220,7 +220,7 @@ export default function LambdaDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-orange-50 to-amber-100">
+    <main className="min-h-screen bg-linear-to-br from-orange-50 to-amber-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Lambda">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -460,7 +460,7 @@ cat response.json`}
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/mailpit/page.tsx
+++ b/localcloud-gui/src/app/mailpit/page.tsx
@@ -186,7 +186,7 @@ export default function MailpitIntegrationPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Mailpit">
         <ServiceStatusBadge service="mailpit" name="Mailpit" />
         <a
@@ -407,7 +407,7 @@ export default function MailpitIntegrationPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/manage/apigateway/page.tsx
+++ b/localcloud-gui/src/app/manage/apigateway/page.tsx
@@ -100,7 +100,7 @@ export default function ManageAPIGatewayPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
@@ -137,7 +137,7 @@ export default function ManageAPIGatewayPage() {
 
       <div className="flex flex-1 overflow-hidden">
         {/* API sidebar */}
-        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
           <div className="px-3 py-3 border-b border-gray-100">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">APIs ({apis.length})</p>
           </div>
@@ -162,7 +162,7 @@ export default function ManageAPIGatewayPage() {
                         : "text-gray-700 hover:bg-gray-50"
                     }`}
                   >
-                    <GlobeAltIcon className="h-4 w-4 flex-shrink-0" />
+                    <GlobeAltIcon className="h-4 w-4 shrink-0" />
                     <div className="flex-1 min-w-0">
                       <p className="truncate text-sm">{api.name}</p>
                       <p className="text-xs text-gray-400 font-mono">{api.id}</p>

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -180,7 +180,7 @@ export default function ManageDynamoDBPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
@@ -228,7 +228,7 @@ export default function ManageDynamoDBPage() {
       {/* Two-panel layout */}
       <div className="flex flex-1 overflow-hidden">
         {/* Table sidebar */}
-        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
           <div className="px-3 py-3 border-b border-gray-100">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Tables ({tables.length})</p>
           </div>
@@ -253,7 +253,7 @@ export default function ManageDynamoDBPage() {
                         : "text-gray-700 hover:bg-gray-50"
                     }`}
                   >
-                    <CircleStackIcon className="h-4 w-4 flex-shrink-0" />
+                    <CircleStackIcon className="h-4 w-4 shrink-0" />
                     <span className="truncate">{t.TableName}</span>
                   </button>
                 </li>

--- a/localcloud-gui/src/app/manage/iam/page.tsx
+++ b/localcloud-gui/src/app/manage/iam/page.tsx
@@ -138,7 +138,7 @@ export default function ManageIAMPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
@@ -175,7 +175,7 @@ export default function ManageIAMPage() {
 
       <div className="flex flex-1 overflow-hidden">
         {/* Roles sidebar */}
-        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
           <div className="px-3 py-3 border-b border-gray-100">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Roles ({roles.length})</p>
           </div>
@@ -200,7 +200,7 @@ export default function ManageIAMPage() {
                         : "text-gray-700 hover:bg-gray-50"
                     }`}
                   >
-                    <ShieldCheckIcon className="h-4 w-4 flex-shrink-0" />
+                    <ShieldCheckIcon className="h-4 w-4 shrink-0" />
                     <span className="truncate">{role.RoleName}</span>
                   </button>
                 </li>
@@ -236,10 +236,10 @@ export default function ManageIAMPage() {
               <div className="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100">
                 {selectedRole.Arn && (
                   <div className="flex items-center px-5 py-3">
-                    <dt className="w-24 text-xs font-medium text-gray-500 flex-shrink-0">ARN</dt>
+                    <dt className="w-24 text-xs font-medium text-gray-500 shrink-0">ARN</dt>
                     <dd className="flex items-center space-x-2 flex-1 min-w-0">
                       <code className="text-xs font-mono text-gray-700 truncate flex-1">{selectedRole.Arn}</code>
-                      <button onClick={() => copyArn(selectedRole.Arn!)} className="flex-shrink-0 text-gray-400 hover:text-gray-600">
+                      <button onClick={() => copyArn(selectedRole.Arn!)} className="shrink-0 text-gray-400 hover:text-gray-600">
                         {copiedArn === selectedRole.Arn ? <CheckIcon className="h-4 w-4 text-green-500" /> : <ClipboardDocumentIcon className="h-4 w-4" />}
                       </button>
                     </dd>

--- a/localcloud-gui/src/app/manage/lambda/page.tsx
+++ b/localcloud-gui/src/app/manage/lambda/page.tsx
@@ -118,7 +118,7 @@ export default function ManageLambdaPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
@@ -155,7 +155,7 @@ export default function ManageLambdaPage() {
 
       <div className="flex flex-1 overflow-hidden">
         {/* Function sidebar */}
-        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+        <aside className="w-72 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
           <div className="px-3 py-3 border-b border-gray-100 space-y-2">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Functions ({functions.length})</p>
             <label className="flex items-center gap-2 cursor-pointer select-none">
@@ -194,7 +194,7 @@ export default function ManageLambdaPage() {
                         : "text-gray-700 hover:bg-gray-50"
                     }`}
                   >
-                    <BoltIcon className="h-4 w-4 flex-shrink-0" />
+                    <BoltIcon className="h-4 w-4 shrink-0" />
                     <div className="flex-1 min-w-0">
                       <p className="truncate text-sm">{fn.FunctionName}</p>
                       {fn.Runtime && <p className="text-xs text-gray-400">{fn.Runtime}</p>}

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -188,7 +188,7 @@ export default function ManageS3Page() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">
@@ -236,7 +236,7 @@ export default function ManageS3Page() {
       {/* Body — two-panel layout */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar: bucket list */}
-        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto flex-shrink-0">
+        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
           <div className="px-3 py-3 border-b border-gray-100">
             <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Buckets ({buckets.length})</p>
           </div>
@@ -261,7 +261,7 @@ export default function ManageS3Page() {
                         : "text-gray-700 hover:bg-gray-50"
                     }`}
                   >
-                    <FolderIcon className="h-4 w-4 flex-shrink-0" />
+                    <FolderIcon className="h-4 w-4 shrink-0" />
                     <span className="truncate">{b.Name}</span>
                   </button>
                 </li>
@@ -375,9 +375,9 @@ export default function ManageS3Page() {
                             <td className="px-4 py-2.5">
                               <div className="flex items-center space-x-2">
                                 {folder ? (
-                                  <FolderIcon className="h-4 w-4 text-amber-500 flex-shrink-0" />
+                                  <FolderIcon className="h-4 w-4 text-amber-500 shrink-0" />
                                 ) : (
-                                  <DocumentIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                                  <DocumentIcon className="h-4 w-4 text-gray-400 shrink-0" />
                                 )}
                                 {folder ? (
                                   <button

--- a/localcloud-gui/src/app/manage/secrets/page.tsx
+++ b/localcloud-gui/src/app/manage/secrets/page.tsx
@@ -276,7 +276,7 @@ export default function ManageSecretsPage() {
                         </div>
                         {secret.Description && (
                           <p className="flex items-center space-x-1.5 text-sm text-gray-600 mb-1">
-                            <DocumentTextIcon className="h-4 w-4 flex-shrink-0 text-gray-400" />
+                            <DocumentTextIcon className="h-4 w-4 shrink-0 text-gray-400" />
                             <span>{secret.Description}</span>
                           </p>
                         )}
@@ -286,7 +286,7 @@ export default function ManageSecretsPage() {
                           </p>
                         )}
                       </div>
-                      <div className="flex items-center space-x-1 ml-4 flex-shrink-0">
+                      <div className="flex items-center space-x-1 ml-4 shrink-0">
                         <button
                           onClick={() => isSelected && !isEditing ? setSelectedSecret(null) : openEdit(secret)}
                           className="p-2 text-gray-400 hover:text-indigo-600 transition-colors"

--- a/localcloud-gui/src/app/manage/ssm/page.tsx
+++ b/localcloud-gui/src/app/manage/ssm/page.tsx
@@ -167,7 +167,7 @@ export default function ManageSSMPage() {
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm flex-shrink-0">
+      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
         <div className="max-w-full px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/app/postgres/page.tsx
+++ b/localcloud-gui/src/app/postgres/page.tsx
@@ -141,7 +141,7 @@ export default function PostgresPage() {
   }, [profile?.preferred_language]);
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="PostgreSQL">
         <ServiceStatusBadge service="postgres" name="PostgreSQL" />
         <a
@@ -295,7 +295,7 @@ export default function PostgresPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/posthog/page.tsx
+++ b/localcloud-gui/src/app/posthog/page.tsx
@@ -119,7 +119,7 @@ export default function PosthogPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="PostHog (Beta)">
         <ServiceStatusBadge service="posthog" name="PostHog (Beta)" />
         <a
@@ -274,7 +274,7 @@ docker compose ps`}
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -56,7 +56,7 @@ export default function ProfilePage() {
 
   if (!profile) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
+      <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
         <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
       </div>
     );
@@ -143,7 +143,7 @@ export default function ProfilePage() {
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <Toaster position="top-right" />
 
       {/* Header */}
@@ -302,7 +302,7 @@ export default function ProfilePage() {
                   }`}
                 >
                   <div className="flex items-center space-x-3">
-                    <span className={`h-2.5 w-2.5 rounded-full flex-shrink-0 ${isActive ? "bg-blue-500" : "bg-gray-300"}`} />
+                    <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${isActive ? "bg-blue-500" : "bg-gray-300"}`} />
                     <div>
                       <p className={`text-sm font-medium ${isActive ? "text-blue-900" : "text-gray-900"}`}>
                         {project.label}

--- a/localcloud-gui/src/app/redis/page.tsx
+++ b/localcloud-gui/src/app/redis/page.tsx
@@ -131,7 +131,7 @@ export default function RedisDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Redis">
         <ServiceStatusBadge service="redis" name="Redis" />
         <button
@@ -276,7 +276,7 @@ export default function RedisDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/s3/page.tsx
+++ b/localcloud-gui/src/app/s3/page.tsx
@@ -183,7 +183,7 @@ export default function S3DocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="S3">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -336,7 +336,7 @@ export default function S3DocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/secrets/page.tsx
+++ b/localcloud-gui/src/app/secrets/page.tsx
@@ -216,7 +216,7 @@ export default function SecretsDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Secrets Manager">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -343,7 +343,7 @@ export default function SecretsDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/app/ssm/page.tsx
+++ b/localcloud-gui/src/app/ssm/page.tsx
@@ -232,7 +232,7 @@ export default function SSMDocPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-teal-50 to-cyan-100">
+    <main className="min-h-screen bg-linear-to-br from-teal-50 to-cyan-100">
       <DocPageNav title="LocalCloud Kit" subtitle="Parameter Store">
         <ServiceStatusBadge service="aws-emulator" name="AWS Emulator" />
         <Link
@@ -432,7 +432,7 @@ export default function SSMDocPage() {
                         rel="noopener noreferrer"
                         className="inline-flex items-center text-blue-600 hover:underline font-medium"
                       >
-                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 flex-shrink-0" />
+                        <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                         {r.name}
                       </a>
                     </td>

--- a/localcloud-gui/src/components/BucketViewer.tsx
+++ b/localcloud-gui/src/components/BucketViewer.tsx
@@ -349,7 +349,7 @@ export default function BucketViewer({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4 min-w-0 flex-1">
               {selectedBucket && (
@@ -360,7 +360,7 @@ export default function BucketViewer({
                     setCurrentPath("");
                     setPathHistory([]);
                   }}
-                  className="p-2 text-gray-400 hover:text-gray-600 flex-shrink-0"
+                  className="p-2 text-gray-400 hover:text-gray-600 shrink-0"
                 >
                   <ArrowLeftIcon className="h-5 w-5" />
                 </button>
@@ -405,7 +405,7 @@ export default function BucketViewer({
                 )}
               </div>
             </div>
-            <div className="flex items-center space-x-4 flex-shrink-0 ml-4">
+            <div className="flex items-center space-x-4 shrink-0 ml-4">
               {selectedBucket && currentPath && pathHistory.length > 0 && (
                 <button
                   onClick={handleBackClick}
@@ -477,7 +477,7 @@ export default function BucketViewer({
                   style={{ opacity: op }}
                 >
                   <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded bg-blue-100 flex-shrink-0" />
+                    <div className="h-8 w-8 rounded bg-blue-100 shrink-0" />
                     <div className="space-y-1.5">
                       <div className="h-4 w-44 bg-gray-200 rounded" />
                       <div className="h-3 w-32 bg-gray-100 rounded" />
@@ -513,7 +513,7 @@ export default function BucketViewer({
                   style={{ opacity: 1 - i * 0.09 }}
                 >
                   <div className="flex items-center gap-2 w-2/5">
-                    <div className="h-5 w-5 rounded bg-gray-200 flex-shrink-0" />
+                    <div className="h-5 w-5 rounded bg-gray-200 shrink-0" />
                     <div className="h-3 flex-1 bg-gray-200 rounded" />
                   </div>
                   <div className="h-3 w-16 bg-gray-100 rounded" />
@@ -621,9 +621,9 @@ export default function BucketViewer({
                             <td className="px-6 py-4">
                               <div className="flex items-center">
                                 {isFolder(item.Key || "") ? (
-                                  <FolderIcon className="h-5 w-5 text-blue-500 mr-2 flex-shrink-0" />
+                                  <FolderIcon className="h-5 w-5 text-blue-500 mr-2 shrink-0" />
                                 ) : (
-                                  <DocumentIcon className="h-5 w-5 text-gray-400 mr-2 flex-shrink-0" />
+                                  <DocumentIcon className="h-5 w-5 text-gray-400 mr-2 shrink-0" />
                                 )}
                                 <div className="flex flex-col min-w-0 flex-1">
                                   {isFolder(item.Key || "") ? (

--- a/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
@@ -373,7 +373,7 @@ export default function DynamoDBAddItemModal({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header — always visible */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div>
             <h2 className="text-lg font-semibold text-gray-900">Add Item</h2>
             <p className="text-xs text-gray-500">{tableName}</p>
@@ -468,7 +468,7 @@ export default function DynamoDBAddItemModal({
 
         {/* Footer — always visible, pinned to bottom */}
         {schema && !schemaLoading && (
-          <div className="flex justify-end space-x-3 px-6 py-4 border-t border-gray-200 flex-shrink-0">
+          <div className="flex justify-end space-x-3 px-6 py-4 border-t border-gray-200 shrink-0">
             <button
               type="button"
               onClick={onClose}

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -429,7 +429,7 @@ export default function DynamoDBViewer({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div>
             <h2 className="text-lg font-semibold text-gray-900">DynamoDB Tables</h2>
             <p className="text-xs text-gray-500">View and manage table contents</p>
@@ -462,7 +462,7 @@ export default function DynamoDBViewer({
         {/* Content */}
         <div className="flex-1 flex flex-col p-6 gap-4 min-h-0">
           {/* Table Selection */}
-          <div className="flex items-center gap-3 flex-shrink-0">
+          <div className="flex items-center gap-3 shrink-0">
             <label className="text-sm font-medium text-gray-600 whitespace-nowrap">
               Select Table
             </label>
@@ -559,7 +559,7 @@ export default function DynamoDBViewer({
           {selectedTable && (
             <>
               {/* Query Controls */}
-              <div className="bg-gray-50 rounded-lg px-4 py-3 flex-shrink-0">
+              <div className="bg-gray-50 rounded-lg px-4 py-3 shrink-0">
                 <div className="flex items-center space-x-4 mb-3">
                   <div className="flex items-center space-x-2">
                     <input
@@ -712,7 +712,7 @@ export default function DynamoDBViewer({
 
               {/* Results Info */}
               {scanResult && (
-                <div className="flex items-center justify-between text-sm text-gray-600 flex-shrink-0">
+                <div className="flex items-center justify-between text-sm text-gray-600 shrink-0">
                   <span>
                     Showing {items.length} items (scanned:{" "}
                     {scanResult.scannedCount})
@@ -722,7 +722,7 @@ export default function DynamoDBViewer({
               )}
 
               {/* Add Item Button */}
-              <div className="flex justify-between items-center flex-shrink-0">
+              <div className="flex justify-between items-center shrink-0">
                 <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Items</h3>
                 <button
                   onClick={() => setAddModalOpen(true)}
@@ -825,7 +825,7 @@ export default function DynamoDBViewer({
                                     className="flex items-center gap-1.5 text-left text-xs bg-blue-50 hover:bg-blue-100 px-2 py-1 rounded border border-blue-200 font-mono text-gray-800 transition-colors cursor-pointer max-w-[200px]"
                                     title="Click to view full JSON"
                                   >
-                                    <ArrowsPointingOutIcon className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
+                                    <ArrowsPointingOutIcon className="h-3.5 w-3.5 text-blue-600 shrink-0" />
                                     <span className="truncate">
                                       {formatValue(item[header])}
                                     </span>
@@ -930,7 +930,7 @@ export default function DynamoDBViewer({
       <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
         <div className="bg-white rounded-xl shadow-2xl w-full max-w-3xl max-h-[80vh] flex flex-col">
           {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
             <div>
               <h2 className="text-lg font-semibold text-gray-900">JSON Viewer</h2>
               <p className="text-xs text-gray-500">{selectedJsonTitle}</p>

--- a/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
+++ b/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
@@ -155,12 +155,12 @@ export default function IAMRolePoliciesModal({
                 <div className="bg-white border border-gray-200 rounded-lg divide-y divide-gray-100">
                   {role.Arn && (
                     <div className="flex items-center px-5 py-3">
-                      <dt className="w-24 text-xs font-medium text-gray-500 flex-shrink-0">ARN</dt>
+                      <dt className="w-24 text-xs font-medium text-gray-500 shrink-0">ARN</dt>
                       <dd className="flex items-center space-x-2 flex-1 min-w-0">
                         <code className="text-xs font-mono text-gray-700 truncate flex-1">{role.Arn}</code>
                         <button
                           onClick={handleCopyArn}
-                          className="flex-shrink-0 text-gray-400 hover:text-gray-600"
+                          className="shrink-0 text-gray-400 hover:text-gray-600"
                           title="Copy ARN"
                         >
                           {copiedArn ? (

--- a/localcloud-gui/src/components/LogViewer.tsx
+++ b/localcloud-gui/src/components/LogViewer.tsx
@@ -125,7 +125,7 @@ export default function LogViewer({ isOpen, onClose }: LogViewerProps) {
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-4">
             <div>
               <h2 className="text-lg font-semibold text-gray-900">Log Viewer</h2>
@@ -217,7 +217,7 @@ export default function LogViewer({ isOpen, onClose }: LogViewerProps) {
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 flex-shrink-0">
+        <div className="px-6 py-3 bg-gray-50 border-t border-gray-200 shrink-0">
           <div className="flex items-center justify-between text-xs text-gray-500">
             <span>{filteredLogs.length} of {logs.length} logs</span>
             {lastUpdated && <span>Updated {lastUpdated}</span>}

--- a/localcloud-gui/src/components/MailpitModal.tsx
+++ b/localcloud-gui/src/components/MailpitModal.tsx
@@ -106,7 +106,7 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-3">
             <EnvelopeIcon className="h-5 w-5 text-gray-500" />
             <div>

--- a/localcloud-gui/src/components/QuickInspectModal.tsx
+++ b/localcloud-gui/src/components/QuickInspectModal.tsx
@@ -75,7 +75,7 @@ export default function QuickInspectModal({
           <ul className="space-y-2">
             {quickChecks.map((item, idx) => (
               <li key={`${item}-${idx}`} className="flex items-start text-sm text-gray-700">
-                <CheckCircleIcon className="h-4 w-4 text-green-500 mt-0.5 mr-2 flex-shrink-0" />
+                <CheckCircleIcon className="h-4 w-4 text-green-500 mt-0.5 mr-2 shrink-0" />
                 {item}
               </li>
             ))}

--- a/localcloud-gui/src/components/RedisModal.tsx
+++ b/localcloud-gui/src/components/RedisModal.tsx
@@ -91,7 +91,7 @@ export default function RedisModal({ onClose }: RedisModalProps) {
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-3">
             <span className="text-2xl">🧊</span>
             <div>

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -291,7 +291,7 @@ export default function ResourceList({
                           onClick={() => { onAddS3(); setShowAddMenu(false); }}
                           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 shrink-0" />
                           S3 Bucket
                         </button>
                       </>
@@ -303,7 +303,7 @@ export default function ResourceList({
                           onClick={() => { onAddDynamoDB(); setShowAddMenu(false); }}
                           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 shrink-0" />
                           DynamoDB Table
                         </button>
                       </>
@@ -315,7 +315,7 @@ export default function ResourceList({
                           onClick={() => { onAddLambda(); setShowAddMenu(false); }}
                           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-lambda" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-lambda" className="w-5 h-5 mr-3 shrink-0" />
                           Lambda Function
                         </button>
                       </>
@@ -327,7 +327,7 @@ export default function ResourceList({
                           onClick={() => { onAddAPIGateway(); setShowAddMenu(false); }}
                           className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                         >
-                          <Icon icon="logos:aws-api-gateway" className="w-5 h-5 mr-3 flex-shrink-0" />
+                          <Icon icon="logos:aws-api-gateway" className="w-5 h-5 mr-3 shrink-0" />
                           API Gateway
                         </button>
                       </>
@@ -340,7 +340,7 @@ export default function ResourceList({
                             onClick={() => { onAddSecrets(); setShowAddMenu(false); }}
                             className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                           >
-                            <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 shrink-0" />
                             Secrets Manager
                           </button>
                         )}
@@ -349,7 +349,7 @@ export default function ResourceList({
                             onClick={() => { onAddSSM(); setShowAddMenu(false); }}
                             className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                           >
-                            <Icon icon="logos:aws-systems-manager" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            <Icon icon="logos:aws-systems-manager" className="w-5 h-5 mr-3 shrink-0" />
                             Parameter Store
                           </button>
                         )}
@@ -358,7 +358,7 @@ export default function ResourceList({
                             onClick={() => { onAddIAM(); setShowAddMenu(false); }}
                             className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                           >
-                            <Icon icon="logos:aws-iam" className="w-5 h-5 mr-3 flex-shrink-0" />
+                            <Icon icon="logos:aws-iam" className="w-5 h-5 mr-3 shrink-0" />
                             IAM Role
                           </button>
                         )}
@@ -404,7 +404,7 @@ export default function ResourceList({
                     disabled={addLoading}
                     className="flex items-center p-3 text-left border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50/40 transition-colors disabled:opacity-50"
                   >
-                    <Icon icon={action.icon} className="w-8 h-8 mr-3 flex-shrink-0" />
+                    <Icon icon={action.icon} className="w-8 h-8 mr-3 shrink-0" />
                     <span className="min-w-0">
                       <span className="block text-sm font-medium text-gray-900">{action.title}</span>
                       <span className="block text-xs text-gray-500">{action.description}</span>
@@ -570,7 +570,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="Browse S3 Bucket"
                                 >
-                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Open
                                 </button>
                               )}
@@ -580,7 +580,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="Browse DynamoDB Table"
                                 >
-                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Open
                                 </button>
                               )}
@@ -590,7 +590,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="View secret"
                                 >
-                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
                                   View
                                 </button>
                               )}
@@ -600,7 +600,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="Edit parameter"
                                 >
-                                  <PencilSquareIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <PencilSquareIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Edit
                                 </button>
                               )}
@@ -610,7 +610,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="View code"
                                 >
-                                  <CodeBracketIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <CodeBracketIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Code
                                 </button>
                               )}
@@ -620,7 +620,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="View role policies"
                                 >
-                                  <EyeIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Policies
                                 </button>
                               )}
@@ -630,7 +630,7 @@ export default function ResourceList({
                                   className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
                                   title="Configure API"
                                 >
-                                  <Cog6ToothIcon className="h-3 w-3 mr-1 flex-shrink-0" />
+                                  <Cog6ToothIcon className="h-3 w-3 mr-1 shrink-0" />
                                   Config
                                 </button>
                               )}
@@ -689,7 +689,7 @@ export default function ResourceList({
                                           resource.details?.arn &&
                                           copyArnToClipboard(resource.details.arn)
                                         }
-                                        className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                                        className="shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
                                         title="Copy ARN"
                                       >
                                         <ClipboardDocumentIcon className="h-4 w-4" />
@@ -727,7 +727,7 @@ export default function ResourceList({
                                         <code className="flex-1 min-w-0">{resource.details.arn}</code>
                                         <button
                                           onClick={() => resource.details?.arn && copyArnToClipboard(resource.details.arn)}
-                                          className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                                          className="shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
                                           title="Copy ARN"
                                         >
                                           <ClipboardDocumentIcon className="h-4 w-4" />

--- a/localcloud-gui/src/components/SecretsDetailModal.tsx
+++ b/localcloud-gui/src/components/SecretsDetailModal.tsx
@@ -240,7 +240,7 @@ export default function SecretsDetailModal({
                   <p className="text-xs font-medium text-gray-500 mb-1">ARN</p>
                   <div className="flex items-center space-x-2 bg-gray-50 rounded-md px-3 py-2">
                     <code className="text-xs text-gray-700 flex-1 break-all font-mono">{secret.ARN}</code>
-                    <button onClick={copyArn} className="flex-shrink-0 text-gray-400 hover:text-gray-600" title="Copy ARN">
+                    <button onClick={copyArn} className="shrink-0 text-gray-400 hover:text-gray-600" title="Copy ARN">
                       {copied ? <CheckIcon className="h-4 w-4 text-green-500" /> : <ClipboardDocumentIcon className="h-4 w-4" />}
                     </button>
                   </div>
@@ -250,7 +250,7 @@ export default function SecretsDetailModal({
               {/* Description */}
               {secret.Description && (
                 <div className="flex items-start space-x-2 text-sm text-gray-600">
-                  <DocumentTextIcon className="h-4 w-4 mt-0.5 flex-shrink-0 text-gray-400" />
+                  <DocumentTextIcon className="h-4 w-4 mt-0.5 shrink-0 text-gray-400" />
                   <span>{secret.Description}</span>
                 </div>
               )}

--- a/localcloud-gui/src/components/SecretsManagerViewer.tsx
+++ b/localcloud-gui/src/components/SecretsManagerViewer.tsx
@@ -267,7 +267,7 @@ export default function SecretsManagerViewer({
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 flex-shrink-0">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-3">
             <div className="p-2 bg-indigo-50 rounded-lg">
               <KeyIcon className="h-5 w-5 text-indigo-600" />
@@ -633,7 +633,7 @@ export default function SecretsManagerViewer({
           >
             <div className="p-6">
               <div className="flex items-center space-x-3 mb-4">
-                <div className="flex-shrink-0">
+                <div className="shrink-0">
                   <TrashIcon className="h-8 w-8 text-red-600" />
                 </div>
                 <div>


### PR DESCRIPTION
## Summary

Aligns **Tailwind CSS v4** class names with what the **ESLint Tailwind plugin** expects, so `npm run lint` stays clean with **no style warnings**.

Branch is **rebased onto current `main`** (includes latest `main` commits; this PR adds only the GUI class renames).

## Changes

| From (v3-style) | To (v4) |
|-----------------|---------|
| `bg-gradient-to-br` | `bg-linear-to-br` |
| `flex-shrink-0` | `shrink-0` |

**Scope:** Doc-style app pages (`/s3`, `/lambda`, `/connect`, etc.), manage pages, and shared components (`ResourceList`, `BucketViewer`, modals, etc.) — **35 files** under `localcloud-gui/src/`.

## Why

Tailwind v4 [renamed](https://tailwindcss.com/docs/upgrade-guide) linear gradient utilities (`bg-gradient-*` → `bg-linear-*`) and prefers the shorter `shrink-0` alias over `flex-shrink-0`.

## Verify

```bash
cd localcloud-gui && npm run lint && npm run build
```

No user-facing behavior change — styling only.
