### PR TITLE
build(docker): pin traefik, nginx, redis, redpanda, zookeeper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Changed
 
+- **docker-compose.yml**: Pinned Traefik `v3.6`, Nginx `1.27-alpine`, standalone Redis `7.4-alpine`; PostHog profile — Zookeeper `3.9`, Redpanda `v25.3.1` (ClickHouse remains `25.10` for PostHog compatibility)
+- **docs/DOCKER.md**: Image tags aligned with compose pins (Traefik, Nginx, Redis; PostHog Redpanda / Zookeeper called out in the PostHog section)
 - **Docs & copy**: LocalStack → AWS Emulator / MiniStack across README, **/connect**, **/aws-emulator**, **docs/AWS_EMULATOR.md**, **docs/LAMBDA.md** (Manage Lambda + **Show all in emulator**), **samples/README**
 - **README**: Centered **logo** (`localcloud-gui/public/logo.svg`); S3 feature bullets and Documentation link to **docs/S3.md**; Manage S3 breadcrumb note under screenshots
 - **/s3** doc page: **Manage S3** section describing breadcrumb and **Back** behavior

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Traefik Entry Point
   traefik:
-    image: traefik:v3
+    image: traefik:v3.6
     container_name: traefik
     ports:
       - "${APP_PORT:-3030}:3030"
@@ -84,7 +84,7 @@ services:
 
   # Nginx Reverse Proxy
   nginx:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     container_name: localcloud-nginx
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
@@ -171,7 +171,7 @@ services:
 
   # Redis Cache (standalone)
   redis:
-    image: redis:7-alpine
+    image: redis:7.4-alpine
     container_name: localcloud-redis
     ports:
       - "6380:6379"
@@ -237,7 +237,7 @@ services:
       start_period: 10s
 
   posthog-zookeeper:
-    image: zookeeper:3.7.0
+    image: zookeeper:3.9
     container_name: localcloud-posthog-zookeeper
     profiles: ["posthog"]
     environment:
@@ -294,7 +294,7 @@ services:
       start_period: 60s
 
   posthog-kafka:
-    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+    image: docker.redpanda.com/redpandadata/redpanda:v25.3.1
     container_name: localcloud-posthog-kafka
     profiles: ["posthog"]
     command:
@@ -335,7 +335,7 @@ services:
       start_period: 30s
 
   posthog-kafka-init:
-    image: docker.redpanda.com/redpandadata/redpanda:v25.1.9
+    image: docker.redpanda.com/redpandadata/redpanda:v25.3.1
     container_name: localcloud-posthog-kafka-init
     profiles: ["posthog"]
     entrypoint: /bin/sh

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -136,7 +136,7 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
 
 ### 1. Traefik Edge Router
 
-- **Image**: `traefik:v3.0`
+- **Image**: `traefik:v3.6`
 - **Ports**:
   - `3030:3030` (HTTPS - port 80 is free for other applications)
   - `8080:8080` (Dashboard, disabled by default)
@@ -155,7 +155,7 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
 
 ### 2. Nginx Internal Reverse Proxy
 
-- **Image**: `nginx:alpine`
+- **Image**: `nginx:1.27-alpine`
 - **Port**: `80` (internal only, not exposed to host)
 - **Role**: Internal routing to GUI, API, and AWS Emulator
 - **Configuration**: `nginx.conf`
@@ -205,7 +205,7 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
 
 ### 6. Redis Cache
 
-- **Image**: `redis:7-alpine`
+- **Image**: `redis:7.4-alpine`
 - **Port**: `6380:6379` (exposed for direct access)
 - **Role**: Standalone cache service (independent of the AWS Emulator)
 - **Features**:
@@ -223,8 +223,8 @@ This guide explains how to run the LocalCloud Kit using Docker containers with T
   - Dedicated `posthog-postgres`
   - Dedicated `posthog-redis`
   - Dedicated `posthog-clickhouse`
-  - Dedicated `posthog-kafka`
-  - Dedicated `posthog-zookeeper`
+  - Dedicated `posthog-kafka` (Redpanda `v25.3.1`)
+  - Dedicated `posthog-zookeeper` (`zookeeper:3.9`)
 - **Start**: `docker compose --profile posthog up -d`
 
 ## Volume Mounts


### PR DESCRIPTION
## Summary

Pins several Docker images in `docker-compose.yml` to tags that were verified with `docker pull`, so local stacks are more reproducible than floating majors (`v3`, `alpine`, `7-alpine`).

## Image changes

| Service | Before | After |
|--------|--------|--------|
| **traefik** | `traefik:v3` | `traefik:v3.6` |
| **nginx** | `nginx:alpine` | `nginx:1.27-alpine` |
| **redis** (standalone) | `redis:7-alpine` | `redis:7.4-alpine` (aligned with PostHog Redis / RDB 7.4+ note) |
| **posthog-zookeeper** | `zookeeper:3.7.0` | `zookeeper:3.9` |
| **posthog-kafka** + **posthog-kafka-init** | Redpanda `v25.1.9` | `v25.3.1` |

## Intentionally unchanged

- **ClickHouse** remains `25.10` — compose comments document PostHog migration / `system.crash_log` constraints.
- **Postgres** stays on **16** to avoid major-version volume surprises.
- Images still on `latest` (MiniStack, pgAdmin, Keycloak, Mailpit, PostHog app) were not pinned in this PR.

## Docs

- `docs/DOCKER.md` — Traefik, Nginx, Redis lines + PostHog Redpanda/Zookeeper callouts.
- `CHANGELOG.md` — `[Unreleased]` → **Changed**.

## Verification

- `docker compose config -q` passes.
- Recommend a one-time smoke test with `docker compose --profile posthog up -d` if you use the PostHog profile (Redpanda + Zookeeper bumps).

---

**Note:** Compose file has no top-level `version:` key (correct for Compose V2); this change is image tags only.