### PR TITLE
fix(modals): prevent create dialogs from closing on blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 ### Fixed
 
 - **DocPageNav / AWS resource docs**: "Open Manager" buttons now remain visible on smaller screens and use higher-contrast styling across S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager, and Parameter Store pages.
+- **Create resource modals**: Backdrop close behavior now only triggers on direct backdrop clicks, preventing DynamoDB and other create forms from closing when inputs lose focus.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 - **DocPageNav / AWS resource docs**: "Open Manager" buttons now remain visible on smaller screens and use higher-contrast styling across S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager, and Parameter Store pages.
 - **Create resource modals**: Backdrop close behavior now only triggers on direct backdrop clicks, preventing DynamoDB and other create forms from closing when inputs lose focus.
+- **Resource viewer/edit modals**: Non-create modals now use the same direct-backdrop click guard, preventing accidental closes during focus and click interactions inside viewer and edit dialogs.
 
 ### Removed
 

--- a/localcloud-gui/src/components/APIGatewayConfigModal.tsx
+++ b/localcloud-gui/src/components/APIGatewayConfigModal.tsx
@@ -80,15 +80,18 @@ export default function APIGatewayConfigModal({
     onSubmit(config);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/APIGatewayConfigViewer.tsx
+++ b/localcloud-gui/src/components/APIGatewayConfigViewer.tsx
@@ -51,15 +51,18 @@ export default function APIGatewayConfigViewer({
     }
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md">
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">
             <div className="p-2 bg-indigo-50 rounded-lg">

--- a/localcloud-gui/src/components/BucketViewer.tsx
+++ b/localcloud-gui/src/components/BucketViewer.tsx
@@ -334,11 +334,17 @@ export default function BucketViewer({
 
   if (!isOpen) return null;
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
   <>
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
         initial={{ opacity: 0, y: 16, scale: 0.98 }}
@@ -346,7 +352,6 @@ export default function BucketViewer({
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
         className="bg-white rounded-xl shadow-2xl w-full max-w-4xl h-[88vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200 shrink-0">

--- a/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
@@ -361,16 +361,21 @@ export default function DynamoDBAddItemModal({
     onSubmit(item);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
     <div
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <div
         className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header — always visible */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">

--- a/localcloud-gui/src/components/DynamoDBConfigModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBConfigModal.tsx
@@ -130,15 +130,18 @@ export default function DynamoDBConfigModal({
     onSubmit(config);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-xl max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -414,11 +414,17 @@ export default function DynamoDBViewer({
 
   if (!isOpen) return <></>;
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
   <>
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
         initial={{ opacity: 0, y: 16, scale: 0.98 }}
@@ -426,7 +432,6 @@ export default function DynamoDBViewer({
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
         className="bg-white rounded-xl shadow-2xl w-full max-w-7xl h-[88vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">

--- a/localcloud-gui/src/components/IAMConfigModal.tsx
+++ b/localcloud-gui/src/components/IAMConfigModal.tsx
@@ -184,15 +184,18 @@ export default function IAMConfigModal({
     ...(advancedMode ? { customPolicy } : {}),
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
+++ b/localcloud-gui/src/components/IAMRolePoliciesModal.tsx
@@ -99,15 +99,18 @@ export default function IAMRolePoliciesModal({
     });
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">
             <div className="p-2 bg-indigo-50 rounded-lg">

--- a/localcloud-gui/src/components/LambdaCodeModal.tsx
+++ b/localcloud-gui/src/components/LambdaCodeModal.tsx
@@ -139,14 +139,19 @@ export default function LambdaCodeModal({
     </button>
   );
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <div
         className="bg-white rounded-xl shadow-2xl w-full max-w-4xl max-h-[90vh] overflow-hidden flex flex-col"
-        onClick={(ev) => ev.stopPropagation()}
       >
         <input
           ref={fileInputRef}

--- a/localcloud-gui/src/components/LambdaConfigModal.tsx
+++ b/localcloud-gui/src/components/LambdaConfigModal.tsx
@@ -108,15 +108,18 @@ export default function LambdaConfigModal({
     onSubmit(config);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/LogViewer.tsx
+++ b/localcloud-gui/src/components/LogViewer.tsx
@@ -115,15 +115,18 @@ export default function LogViewer({ isOpen, onClose }: LogViewerProps) {
 
   if (!isOpen) return null;
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-4xl max-h-[90vh] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-4xl max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-4">

--- a/localcloud-gui/src/components/MailpitModal.tsx
+++ b/localcloud-gui/src/components/MailpitModal.tsx
@@ -96,15 +96,18 @@ export default function MailpitModal({ onClose }: MailpitModalProps) {
     }
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-2xl max-h-[85vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/QuickInspectModal.tsx
+++ b/localcloud-gui/src/components/QuickInspectModal.tsx
@@ -50,12 +50,18 @@ export default function QuickInspectModal({
     }
   };
 
+  const handleBackdropMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onClose}>
-      <div
-        className="w-full max-w-xl bg-white rounded-xl shadow-2xl overflow-hidden"
-        onClick={(event) => event.stopPropagation()}
-      >
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      onMouseDown={handleBackdropMouseDown}
+    >
+      <div className="w-full max-w-xl bg-white rounded-xl shadow-2xl overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-200 flex items-start justify-between">
           <div>
             <h2 className="text-lg font-semibold text-gray-900">{title}</h2>

--- a/localcloud-gui/src/components/RedisModal.tsx
+++ b/localcloud-gui/src/components/RedisModal.tsx
@@ -81,15 +81,18 @@ export default function RedisModal({ onClose }: RedisModalProps) {
     : "—";
   const connectedClients = info["connected_clients"] || "—";
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/S3ConfigModal.tsx
+++ b/localcloud-gui/src/components/S3ConfigModal.tsx
@@ -111,15 +111,18 @@ export default function S3ConfigModal({
     onSubmit(config);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/SSMConfigModal.tsx
+++ b/localcloud-gui/src/components/SSMConfigModal.tsx
@@ -52,15 +52,18 @@ export default function SSMConfigModal({
     onSubmit({ parameterName, parameterValue, parameterType, description });
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/SSMEditModal.tsx
+++ b/localcloud-gui/src/components/SSMEditModal.tsx
@@ -67,15 +67,18 @@ export default function SSMEditModal({
     onSave({ parameterName, parameterValue, parameterType, description });
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">
             <div className="p-2 bg-teal-50 rounded-lg">

--- a/localcloud-gui/src/components/SecretsConfigModal.tsx
+++ b/localcloud-gui/src/components/SecretsConfigModal.tsx
@@ -90,15 +90,18 @@ export default function SecretsConfigModal({
     onSubmit(config);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-        onClick={(e) => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center space-x-3">

--- a/localcloud-gui/src/components/SecretsDetailModal.tsx
+++ b/localcloud-gui/src/components/SecretsDetailModal.tsx
@@ -192,10 +192,16 @@ export default function SecretsDetailModal({
 
   if (!isOpen) return null;
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
   return (
     <div
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
         initial={{ opacity: 0, y: 16, scale: 0.98 }}
@@ -203,7 +209,6 @@ export default function SecretsDetailModal({
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
         className="bg-white rounded-xl shadow-2xl w-full max-w-lg flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">

--- a/localcloud-gui/src/components/SecretsManagerViewer.tsx
+++ b/localcloud-gui/src/components/SecretsManagerViewer.tsx
@@ -251,12 +251,27 @@ export default function SecretsManagerViewer({
     setShowDeleteModal(true);
   };
 
+  const handleBackdropMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleNestedBackdropMouseDown = (
+    e: React.MouseEvent<HTMLDivElement>,
+    close: () => void
+  ) => {
+    if (e.target === e.currentTarget) {
+      close();
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
     <div
       className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      onClick={onClose}
+      onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
         initial={{ opacity: 0, y: 16, scale: 0.98 }}
@@ -264,7 +279,6 @@ export default function SecretsManagerViewer({
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
         className="bg-white rounded-xl shadow-2xl w-full max-w-2xl h-[74vh] min-h-[500px] flex flex-col"
-        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
@@ -496,14 +510,12 @@ export default function SecretsManagerViewer({
       {showEditModal && selectedSecret && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowEditModal(false);
-          }}
+          onMouseDown={(e) =>
+            handleNestedBackdropMouseDown(e, () => setShowEditModal(false))
+          }
         >
           <div
             className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto"
-            onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
               <div>
@@ -622,14 +634,12 @@ export default function SecretsManagerViewer({
       {showDeleteModal && selectedSecret && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-60 p-4"
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowDeleteModal(false);
-          }}
+          onMouseDown={(e) =>
+            handleNestedBackdropMouseDown(e, () => setShowDeleteModal(false))
+          }
         >
           <div
             className="bg-white rounded-xl shadow-2xl w-full max-w-md"
-            onClick={(e) => e.stopPropagation()}
           >
             <div className="p-6">
               <div className="flex items-center space-x-3 mb-4">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes create DynamoDB modal so focusing/defocusing inputs no longer dismisses the dialog.
- Applies the same backdrop-close fix to all AWS resource create config modals (S3, Lambda, API Gateway, IAM, Secrets, SSM) for consistent behavior.
- Extends the same guarded backdrop behavior to non-create viewers/edit modals (S3, DynamoDB, Lambda, API Gateway, IAM, Secrets, SSM, Redis, Mailpit, Logs, and Quick Inspect).
- Keeps click-outside-to-close support, but only when clicking directly on the backdrop.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [ ] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `AGENTS.md` / IDE entry (`CLAUDE.md`) updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Fixed
- **Create and viewer modals**: Backdrop close behavior now only triggers on direct backdrop clicks, preventing create/edit/view dialogs from closing during focus and interaction inside modal content.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6517e1c7-920f-423f-8b1d-8abd1f694f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6517e1c7-920f-423f-8b1d-8abd1f694f1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

