### PR TITLE
fix(dynamodb): add highlighted json viewer and nested value expanders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **DocPageNav / AWS resource docs**: "Open Manager" buttons now remain visible on smaller screens and use higher-contrast styling across S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager, and Parameter Store pages.
 - **Create resource modals**: Backdrop close behavior now only triggers on direct backdrop clicks, preventing DynamoDB and other create forms from closing when inputs lose focus.
 - **Resource viewer/edit modals**: Non-create modals now use the same direct-backdrop click guard, preventing accidental closes during focus and click interactions inside viewer and edit dialogs.
+- **DynamoDB viewer and manager**: JSON values now use docs-style syntax highlighting in the viewer modal, and map/list attributes in `/manage/dynamodb` now support nested expand/collapse inspection.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ The header contains three primary dropdowns:
 - **Global Secondary Indexes**: Complete GSI support with proper provisioning
 - **Query & Scan**: Advanced querying with GSI support
 - **Schema Validation**: Interactive forms for adding items with type checking
+- **Syntax-highlighted JSON viewer**: Dashboard DynamoDB viewer uses the same themed code highlighting as docs pages
+- **Nested map/list explorer**: Manage DynamoDB supports expand/collapse for `M` and `L` attribute values
 
 #### Lambda Functions
 

--- a/docs/AWS_EMULATOR.md
+++ b/docs/AWS_EMULATOR.md
@@ -62,7 +62,7 @@ ELASTICACHE_BASE_PORT=16400
 | Service | Notes |
 |---------|-------|
 | S3 | Bucket management, multipart uploads up to 100MB, nested folders — GUI details in [docs/S3.md](S3.md) |
-| DynamoDB | Tables, CRUD, GSI, query/scan |
+| DynamoDB | Tables, CRUD, GSI, query/scan, syntax-highlighted JSON viewer, expandable map/list values in the manager |
 | Lambda | Function management, runtime/handler config, invocation |
 | API Gateway | REST endpoint creation, stage deployments |
 | IAM | Roles, policies, identity management |

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -10,6 +10,8 @@ import {
   BookOpenIcon,
   TrashIcon,
   MagnifyingGlassIcon,
+  ChevronRightIcon,
+  ChevronDownIcon,
 } from "@heroicons/react/24/outline";
 import { resourceApi } from "@/services/api";
 import ManageHeaderBrand from "@/components/ManageHeaderBrand";
@@ -32,8 +34,109 @@ function displayDynamoDBValue(val: any): string {
   if ("NULL" in val) return "null";
   if ("SS" in val) return JSON.stringify(val.SS);
   if ("NS" in val) return JSON.stringify(val.NS);
-  if ("L" in val || "M" in val) return JSON.stringify(val);
+  if ("M" in val && val.M && typeof val.M === "object") {
+    return `Map(${Object.keys(val.M).length})`;
+  }
+  if ("L" in val && Array.isArray(val.L)) {
+    return `List(${val.L.length})`;
+  }
   return JSON.stringify(val);
+}
+
+type ValueEntry = { label: string; value: unknown };
+
+function getExpandableEntries(value: unknown): ValueEntry[] | null {
+  if (value === null || value === undefined || typeof value !== "object") {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, index) => ({ label: `[${index}]`, value: item }));
+  }
+
+  const typed = value as Record<string, unknown>;
+  const scalarTypedKeys = ["S", "N", "BOOL", "NULL", "SS", "NS", "BS", "B"];
+  if (scalarTypedKeys.some((key) => key in typed)) {
+    return null;
+  }
+
+  if ("M" in typed && typed.M && typeof typed.M === "object" && !Array.isArray(typed.M)) {
+    return Object.entries(typed.M as Record<string, unknown>).map(([label, child]) => ({
+      label,
+      value: child,
+    }));
+  }
+
+  if ("L" in typed && Array.isArray(typed.L)) {
+    return (typed.L as unknown[]).map((item, index) => ({
+      label: `[${index}]`,
+      value: item,
+    }));
+  }
+
+  const objectEntries = Object.entries(typed);
+  if (objectEntries.length === 0) {
+    return null;
+  }
+
+  return objectEntries.map(([label, child]) => ({ label, value: child }));
+}
+
+function getContainerLabel(value: unknown, childCount: number): string {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const typed = value as Record<string, unknown>;
+    if ("M" in typed) return `Map (${childCount})`;
+    if ("L" in typed) return `List (${childCount})`;
+  }
+
+  if (Array.isArray(value)) return `Array (${childCount})`;
+  return `Object (${childCount})`;
+}
+
+function DynamoValueTree({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  const entries = getExpandableEntries(value);
+  const [expanded, setExpanded] = useState(depth === 0);
+
+  if (!entries) {
+    const rendered = displayDynamoDBValue(value);
+    return (
+      <span className="font-mono text-xs text-gray-700 break-all" title={rendered}>
+        {rendered}
+      </span>
+    );
+  }
+
+  return (
+    <div className="min-w-[11rem]">
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="inline-flex items-center gap-1 rounded px-1 py-0.5 text-xs font-medium text-indigo-700 hover:bg-indigo-50"
+      >
+        {expanded ? (
+          <ChevronDownIcon className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+          <ChevronRightIcon className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <span className="font-mono">{getContainerLabel(value, entries.length)}</span>
+      </button>
+
+      {expanded && (
+        <div className="mt-1 ml-2 border-l border-indigo-100 pl-2 space-y-1">
+          {entries.map((entry, index) => (
+            <div key={`${entry.label}-${index}`} className="flex items-start gap-1.5">
+              <span className="font-mono text-[11px] font-semibold text-gray-500 shrink-0">
+                {entry.label}:
+              </span>
+              <div className="min-w-0">
+                <DynamoValueTree value={entry.value} depth={depth + 1} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 // Extract the raw string/number value from a DynamoDB typed attribute for use in key expressions
@@ -326,11 +429,26 @@ export default function ManageDynamoDBPage() {
                     <tbody className="divide-y divide-gray-50">
                       {items.map((item, i) => (
                         <tr key={i} className="hover:bg-gray-50">
-                          {allKeys.map((k) => (
-                            <td key={k} className="px-4 py-2.5 text-xs font-mono text-gray-700 max-w-xs truncate">
-                              {displayDynamoDBValue(item[k])}
-                            </td>
-                          ))}
+                          {allKeys.map((k) => {
+                            const value = item[k];
+                            const expandable = Boolean(getExpandableEntries(value));
+                            return (
+                              <td
+                                key={k}
+                                className={`px-4 py-2.5 align-top ${
+                                  expandable ? "text-gray-700" : "text-xs font-mono text-gray-700"
+                                }`}
+                              >
+                                {expandable ? (
+                                  <DynamoValueTree value={value} />
+                                ) : (
+                                  <span className="block max-w-xs truncate" title={displayDynamoDBValue(value)}>
+                                    {displayDynamoDBValue(value)}
+                                  </span>
+                                )}
+                              </td>
+                            );
+                          })}
                           <td className="px-4 py-2.5 text-right">
                             <button
                               onClick={() => setDeleteItemTarget(item)}

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -23,6 +23,7 @@ import DynamoDBConfigModal from "./DynamoDBConfigModal";
 import { Icon } from "@iconify/react";
 import { AnimatePresence, motion } from "framer-motion";
 import { toast } from "react-hot-toast";
+import ThemeableCodeBlock from "./ThemeableCodeBlock";
 
 interface DynamoDBViewerProps {
   isOpen: boolean;
@@ -951,9 +952,10 @@ export default function DynamoDBViewer({
 
           {/* JSON Content */}
           <div className="flex-1 p-6 overflow-auto">
-            <pre className="text-sm font-mono text-gray-800 bg-gray-50 p-4 rounded border overflow-auto h-full whitespace-pre-wrap">
-              {JSON.stringify(selectedJsonData, null, 2)}
-            </pre>
+            <ThemeableCodeBlock
+              code={JSON.stringify(selectedJsonData, null, 2)}
+              language="javascript"
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add docs-style syntax highlighting to the DynamoDB JSON viewer modal in the dashboard viewer.
- Add nested expand/collapse rendering for DynamoDB `M` (map) and `L` (list) attribute values on `/manage/dynamodb`.
- Document the DynamoDB UX updates in README, AWS emulator docs, and the unreleased changelog.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [ ] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [x] `README.md` updated if access URLs or features changed
- [ ] `AGENTS.md` / IDE entry (`CLAUDE.md`) updated if architecture, services table, or conventions changed
- [x] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Changed
- **DynamoDB viewer and manager**: JSON values now use docs-style syntax highlighting in the viewer modal, and map/list attributes in `/manage/dynamodb` now support nested expand/collapse inspection.
```

## Validation

- `cd localcloud-gui && npm run lint`
- `cd localcloud-gui && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6918487a-4154-4f7a-9712-2b5a8ae21192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6918487a-4154-4f7a-9712-2b5a8ae21192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

