### PR TITLE
fix(dynamodb): restore item deletion in manager view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 - **Create resource modals**: Backdrop close behavior now only triggers on direct backdrop clicks, preventing DynamoDB and other create forms from closing when inputs lose focus.
 - **Resource viewer/edit modals**: Non-create modals now use the same direct-backdrop click guard, preventing accidental closes during focus and click interactions inside viewer and edit dialogs.
 - **DynamoDB viewer and manager**: JSON values now use docs-style syntax highlighting in the viewer modal, and map/list attributes in `/manage/dynamodb` now support nested expand/collapse inspection.
+- **Manage DynamoDB delete action**: Item deletion now works in `/manage/dynamodb` by loading table schema and scan data with the active project context before issuing delete requests.
 
 ### Removed
 

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -191,7 +191,11 @@ export default function ManageDynamoDBPage() {
 
   const loadTableSchema = async (tableName: string) => {
     try {
-      const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(tableName)}/schema`);
+      const res = await fetch(
+        `/api/dynamodb/table/${encodeURIComponent(
+          tableName
+        )}/schema?projectName=${encodeURIComponent(projectName)}`
+      );
       const result = await res.json();
       if (result.success && result.data?.Table?.KeySchema) {
         const ks = result.data.Table.KeySchema;
@@ -207,7 +211,11 @@ export default function ManageDynamoDBPage() {
   const loadItems = useCallback(async (tableName: string) => {
     setLoadingItems(true);
     try {
-      const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(tableName)}/scan`);
+      const res = await fetch(
+        `/api/dynamodb/table/${encodeURIComponent(
+          tableName
+        )}/scan?projectName=${encodeURIComponent(projectName)}`
+      );
       const result = await res.json();
       if (result.success) {
         // AWS CLI returns "Items" (uppercase); normalize to handle either casing
@@ -248,11 +256,19 @@ export default function ManageDynamoDBPage() {
   };
 
   const handleDeleteItem = async () => {
-    if (!selectedTable || !deleteItemTarget || !schema) return;
+    if (!selectedTable || !deleteItemTarget) return;
+    if (!schema) {
+      toast.error("Unable to load table key schema. Refresh and try again.");
+      return;
+    }
     setDeleteLoading(true);
     try {
       const partitionValue = extractDynamoDBKeyValue(deleteItemTarget[schema.pk]);
-      const sortValue = schema.sk ? extractDynamoDBKeyValue(deleteItemTarget[schema.sk]) : undefined;
+      const sortKeyName = schema.sk;
+      const hasSortKey = typeof sortKeyName === "string" && sortKeyName.length > 0;
+      const sortValue = hasSortKey
+        ? extractDynamoDBKeyValue(deleteItemTarget[sortKeyName])
+        : undefined;
       const res = await fetch(`/api/dynamodb/table/${encodeURIComponent(selectedTable)}/item`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
@@ -260,7 +276,7 @@ export default function ManageDynamoDBPage() {
           projectName,
           partitionKey: schema.pk,
           partitionValue,
-          ...(schema.sk && sortValue ? { sortKey: schema.sk, sortValue } : {}),
+          ...(hasSortKey ? { sortKey: sortKeyName, sortValue } : {}),
         }),
       });
       const result = await res.json();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Fixes `/manage/dynamodb` item deletion by loading table schema with `projectName`, so key metadata is available for delete requests.
- Fixes table scans in the manager to include `projectName`, aligning item loading with the selected project context.
- Improves delete behavior to show a clear error when schema is unavailable and to always send sort-key fields when the table uses a composite key.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [ ] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `AGENTS.md` / IDE entry (`CLAUDE.md`) updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Fixed
- **Manage DynamoDB delete action**: Item deletion now works in `/manage/dynamodb` by loading table schema and scan data with the active project context before issuing delete requests.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d965f3e6-cafd-40b4-8c34-d6587959ba85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d965f3e6-cafd-40b4-8c34-d6587959ba85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

