### PR TITLE
fix(resource-list): simplify dashboard empty state icons and copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Changed
 
-- **ResourceList empty state**: Dashboard AWS resources panel now uses a single colored icon card set (removed decorative faded icons) with neutral copy that emphasizes creating any resource type in any order.
+- **ResourceList empty/building states**: Dashboard AWS resources panel now uses a single colored icon card set (removed decorative faded icons) with neutral status copy: no resources yet, create resources for the active project, no required order, and "Resource creation in progress" messaging while provisioning.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Changed
 
+- **ResourceList empty state**: Dashboard AWS resources panel now uses a single colored icon card set (removed decorative faded icons) with neutral copy that emphasizes creating any resource type in any order.
+
 ### Fixed
 
 - **DocPageNav / AWS resource docs**: "Open Manager" buttons now remain visible on smaller screens and use higher-contrast styling across S3, DynamoDB, Lambda, API Gateway, IAM, Secrets Manager, and Parameter Store pages.

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -423,9 +423,9 @@ export default function ResourceList({
             transition={listTransition}
             className="px-6 py-12 min-h-[23rem] flex flex-col justify-center"
           >
-            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">Building your first AWS resource...</h4>
+            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">Resource creation in progress...</h4>
             <p className="text-sm text-gray-500 text-center">
-              This can take a few seconds while the emulator provisions and saves it.
+              Setting up your resource for the active project.
             </p>
             <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl mx-auto">
               {[0, 1, 2, 3].map((idx) => (
@@ -442,7 +442,7 @@ export default function ResourceList({
               ))}
             </div>
             <p className="mt-4 text-xs text-gray-500 text-center">
-              Your new resource will appear here automatically.
+              It will appear here automatically when ready.
             </p>
           </motion.div>
         )}

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -383,16 +383,9 @@ export default function ResourceList({
             transition={listTransition}
             className="px-6 py-12 min-h-[23rem] flex flex-col justify-center"
           >
-            <div className="flex items-center justify-center space-x-4 mb-6 opacity-20">
-              <Icon icon="logos:aws-s3" className="w-10 h-10" />
-              <Icon icon="logos:aws-dynamodb" className="w-10 h-10" />
-              <Icon icon="logos:aws-lambda" className="w-10 h-10" />
-              <Icon icon="logos:aws-api-gateway" className="w-10 h-10" />
-              <Icon icon="logos:aws-secrets-manager" className="w-10 h-10" />
-            </div>
-            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">Create your first AWS resource</h4>
+            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">No AWS resources yet</h4>
             <p className="text-sm text-gray-500 text-center">
-              Start with S3 or DynamoDB, or pick from other resource types.
+              Create resources for your active project.
             </p>
 
             {emptyStateActions.length > 0 && (
@@ -415,7 +408,7 @@ export default function ResourceList({
             )}
 
             <p className="mt-4 text-xs text-gray-500 text-center">
-              You can also use the <span className="font-medium">+ Add</span> menu for Secrets Manager, Parameter Store, and IAM.
+              Pick any service; there&apos;s no required order.
             </p>
           </motion.div>
         )}
@@ -430,13 +423,6 @@ export default function ResourceList({
             transition={listTransition}
             className="px-6 py-12 min-h-[23rem] flex flex-col justify-center"
           >
-            <div className="flex items-center justify-center space-x-4 mb-6 opacity-20">
-              <Icon icon="logos:aws-s3" className="w-10 h-10" />
-              <Icon icon="logos:aws-dynamodb" className="w-10 h-10" />
-              <Icon icon="logos:aws-lambda" className="w-10 h-10" />
-              <Icon icon="logos:aws-api-gateway" className="w-10 h-10" />
-              <Icon icon="logos:aws-secrets-manager" className="w-10 h-10" />
-            </div>
             <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">Building your first AWS resource...</h4>
             <p className="text-sm text-gray-500 text-center">
               This can take a few seconds while the emulator provisions and saves it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- remove the decorative faded AWS icon row from the dashboard AWS resources empty and first-resource building states
- keep only the colored actionable resource cards so the empty state has a single icon set
- update empty/building state copy to technical, non-prescriptive language: "No AWS resources yet", "Create resources for your active project", "Pick any service; there's no required order", and "Resource creation in progress..."

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code restructure, no behavior change
- [ ] `docs` — documentation only
- [ ] `build` / `chore` — infra, deps, tooling
- [ ] `BREAKING CHANGE` — existing behavior changed or removed

## Pre-merge checklist

### Code
- [x] All commits follow Angular Conventional Commits (`<type>(<scope>): <subject>`)
- [x] No hardcoded secrets, credentials, or localhost-only assumptions
- [x] TypeScript strict mode — no `any` types introduced without justification

### New service (skip if not applicable — run `/verify-new-service <Name>` for full check)
- [ ] `docker-compose.yml` service block added
- [ ] Traefik router + TLS entry added
- [ ] GUI doc page uses `DocPageNav` + `ThemeableCodeBlock` + `usePreferences`
- [ ] Dashboard Resources dropdown + Docs dropdown + status bar updated
- [ ] `DocPageNav` Docs dropdown updated
- [ ] `docs/<SERVICE>.md` created with both Traefik and direct localhost URLs

### Documentation & changelog
- [x] `CHANGELOG.md` updated under `## [Unreleased]` with user-facing summary
- [ ] `README.md` updated if access URLs or features changed
- [ ] `AGENTS.md` / IDE entry (`CLAUDE.md`) updated if architecture, services table, or conventions changed
- [ ] Relevant `docs/*.md` files updated with current domain/URL info

## CHANGELOG entry

```markdown
### Changed
- **ResourceList empty/building states**: Dashboard AWS resources panel now uses a single colored icon card set (removed decorative faded icons) with neutral status copy: no resources yet, create resources for the active project, no required order, and "Resource creation in progress" messaging while provisioning.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73eae0e6-b170-499a-bff2-e127dab5d257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73eae0e6-b170-499a-bff2-e127dab5d257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

