### PR TITLE
feat(profile): add CLI playbook and shared dashboard navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Added
 
+- **Profile CLI Playbook**: portable `aws` CLI rebuild commands per project (LCK AWS CLI / AWS CLI env blocks, live inventory, saved-config recipes, copy all, download `.sh`); saved configurations managed separately with bulk delete.
+- **DashboardNavBar**: shared dashboard navbar on Profile (Resources, Services, Docs, project switcher) via extracted `DashboardNavBar` and `DashboardNavContext`.
+
 ### Changed
 
 - **README screenshots**: Replaced previous dashboard/S3/DynamoDB screenshot set with updated dashboard flow images covering empty state, DynamoDB table creation, add-resource options, and grouped multi-resource view.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ The header contains three primary dropdowns:
 | **Services** | Platform services (Keycloak, Mailpit, PostgreSQL, PostHog, Redis) with quick **Inspect** actions and links to manager/admin tools |
 | **Docs** | Opens the **Docs Hub** (`/docs`) with all documentation pages, verification checklists, and manager/admin links |
 
+### Profile CLI Playbook
+
+The **Profile** page (`/profile`) includes a **CLI Playbook** for the active project:
+
+- **Live inventory** — resource counts from the AWS emulator
+- **Portable `aws` commands** — no `--endpoint-url` in resource lines; **LCK AWS CLI** sets `AWS_ENDPOINT_URL` for MiniStack; **AWS CLI** includes a note to unset it when targeting real AWS
+- **Saved configs** — full recreate commands from configs saved in creation modals
+- **Copy all** or **Download `.sh`** — one script with environment setup plus all rebuild commands
+
 ### AWS Service Emulation
 
 #### S3 Storage

--- a/localcloud-gui/src/app/profile/page.tsx
+++ b/localcloud-gui/src/app/profile/page.tsx
@@ -2,15 +2,9 @@
 
 import { usePreferences } from "@/context/PreferencesContext";
 import { HighlightTheme, PreferredLanguage, Project } from "@/types";
-import ManageHeaderBrand from "@/components/ManageHeaderBrand";
-import {
-  CircleStackIcon,
-  FolderIcon,
-  KeyIcon,
-  PlusIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline";
-import Link from "next/link";
+import CliPlaybookSection from "@/components/CliPlaybookSection";
+import DashboardNavBar from "@/components/DashboardNavBar";
+import { PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
 import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { Toaster } from "react-hot-toast";
@@ -32,12 +26,6 @@ const THEMES: { value: HighlightTheme; label: string }[] = [
   { value: "atom-one-light", label: "Atom One Light" },
 ];
 
-const RESOURCE_ICONS: Record<string, React.ReactNode> = {
-  s3: <FolderIcon className="h-4 w-4 text-yellow-600" />,
-  dynamodb: <CircleStackIcon className="h-4 w-4 text-indigo-600" />,
-  secrets: <KeyIcon className="h-4 w-4 text-green-600" />,
-};
-
 export default function ProfilePage() {
   const {
     profile,
@@ -56,8 +44,11 @@ export default function ProfilePage() {
 
   if (!profile) {
     return (
-      <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100 flex items-center justify-center">
-        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+      <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
+        <DashboardNavBar activePage="profile" />
+        <div className="flex items-center justify-center py-24">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" />
+        </div>
       </div>
     );
   }
@@ -138,35 +129,10 @@ export default function ProfilePage() {
     }
   };
 
-  const activeProjectConfigs = savedConfigs.filter(
-    (c) => c.project_id === profile.active_project_id
-  );
-
   return (
     <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
       <Toaster position="top-right" />
-
-      {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-3">
-              <ManageHeaderBrand />
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Profile</p>
-              </div>
-              <div className="h-5 w-px bg-gray-200" />
-              <Link
-                href="/"
-                className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Dashboard
-              </Link>
-            </div>
-          </div>
-        </div>
-      </header>
+      <DashboardNavBar activePage="profile" />
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
 
@@ -338,43 +304,7 @@ export default function ProfilePage() {
           </div>
         </div>
 
-        {/* Saved Configs Card */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-1">Saved Configurations</h2>
-          <p className="text-sm text-gray-500 mb-5">
-            Scoped to active project: <span className="font-medium text-gray-700">{profile.active_project_label || "Default"}</span>
-          </p>
-
-          {activeProjectConfigs.length === 0 ? (
-            <p className="text-sm text-gray-400 italic">
-              No saved configs yet. Open a DynamoDB or S3 creation form and click &quot;Save config&quot; to add one.
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {activeProjectConfigs.map((cfg) => (
-                <div
-                  key={cfg.id}
-                  className="flex items-center justify-between px-4 py-3 bg-gray-50 rounded-lg border border-gray-200"
-                >
-                  <div className="flex items-center space-x-3">
-                    <span>{RESOURCE_ICONS[cfg.resource_type] ?? null}</span>
-                    <div>
-                      <p className="text-sm font-medium text-gray-900">{cfg.name}</p>
-                      <p className="text-xs text-gray-500 capitalize">{cfg.resource_type}</p>
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => handleDeleteConfig(cfg.id)}
-                    className="p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-md transition-colors"
-                    title="Delete saved config"
-                  >
-                    <TrashIcon className="h-4 w-4" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <CliPlaybookSection onDeleteSavedConfig={handleDeleteConfig} />
 
       </div>
     </div>

--- a/localcloud-gui/src/components/CliPlaybookSection.tsx
+++ b/localcloud-gui/src/components/CliPlaybookSection.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { usePreferences } from "@/context/PreferencesContext";
+import {
+  AWS_ENV_PREAMBLE,
+  buildFullScript,
+  buildPlaybookEntries,
+  inventorySummary,
+  LOCAL_ENV_PREAMBLE,
+  resourceNameFromConfig,
+  type CliPreambleMode,
+} from "@/lib/cliPlaybook";
+import { resourceApi } from "@/services/api";
+import type { Resource, SavedConfig } from "@/types";
+import {
+  ArrowDownTrayIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ClipboardDocumentIcon,
+  CommandLineIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "react-hot-toast";
+
+const TYPE_LABELS: Record<string, string> = {
+  s3: "S3",
+  dynamodb: "DynamoDB",
+  lambda: "Lambda",
+  apigateway: "API Gateway",
+  secretsmanager: "Secrets Manager",
+  secrets: "Secrets Manager",
+  ssm: "SSM",
+  iam: "IAM",
+};
+
+interface CliPlaybookSectionProps {
+  onDeleteSavedConfig: (id: number) => Promise<void>;
+}
+
+export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookSectionProps) {
+  const { profile, savedConfigs } = usePreferences();
+  const [preambleMode, setPreambleMode] = useState<CliPreambleMode>("local");
+  const [liveResources, setLiveResources] = useState<Resource[]>([]);
+  const [loadingResources, setLoadingResources] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [selectedConfigIds, setSelectedConfigIds] = useState<Set<number>>(new Set());
+  const [deletingConfigs, setDeletingConfigs] = useState(false);
+
+  const projectName = profile?.active_project_name;
+  const projectLabel = profile?.active_project_label || "Default";
+  const projectId = profile?.active_project_id ?? null;
+
+  const projectSavedConfigs = useMemo(
+    () => savedConfigs.filter((c) => c.project_id === projectId),
+    [savedConfigs, projectId]
+  );
+
+  const loadResources = useCallback(async () => {
+    if (!projectName) return;
+    setLoadingResources(true);
+    try {
+      const list = await resourceApi.list(projectName);
+      setLiveResources(list);
+    } catch {
+      setLiveResources([]);
+    } finally {
+      setLoadingResources(false);
+    }
+  }, [projectName]);
+
+  useEffect(() => {
+    loadResources();
+  }, [loadResources]);
+
+  useEffect(() => {
+    setSelectedConfigIds(new Set());
+  }, [projectId]);
+
+  useEffect(() => {
+    setSelectedConfigIds((prev) => {
+      const valid = new Set(projectSavedConfigs.map((c) => c.id));
+      const next = new Set([...prev].filter((id) => valid.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [projectSavedConfigs]);
+
+  const entries = useMemo(
+    () => buildPlaybookEntries(savedConfigs, liveResources, projectId),
+    [savedConfigs, liveResources, projectId]
+  );
+
+  const summary = useMemo(() => inventorySummary(liveResources), [liveResources]);
+  const preamble = preambleMode === "local" ? LOCAL_ENV_PREAMBLE : AWS_ENV_PREAMBLE;
+  const fullScript = useMemo(
+    () => buildFullScript(preambleMode, entries, projectLabel),
+    [preambleMode, entries, projectLabel]
+  );
+
+  const copyText = async (text: string, message: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(message);
+    } catch {
+      toast.error("Copy failed");
+    }
+  };
+
+  const downloadScript = () => {
+    const slug = (projectName || "project").replace(/[^a-z0-9-]/gi, "-");
+    const blob = new Blob([fullScript], { type: "text/x-shellscript" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `localcloud-${slug}-playbook.sh`;
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success("Script downloaded");
+  };
+
+  const sourceBadge = (source: string) => {
+    if (source === "matched") {
+      return (
+        <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-800">
+          full recipe
+        </span>
+      );
+    }
+    if (source === "saved-config") {
+      return (
+        <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-800">
+          saved recipe
+        </span>
+      );
+    }
+    return (
+      <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
+        minimal CLI
+      </span>
+    );
+  };
+
+  const toggleConfigSelection = (id: number) => {
+    setSelectedConfigIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const allConfigsSelected =
+    projectSavedConfigs.length > 0 &&
+    projectSavedConfigs.every((c) => selectedConfigIds.has(c.id));
+
+  const toggleSelectAllConfigs = () => {
+    if (allConfigsSelected) {
+      setSelectedConfigIds(new Set());
+    } else {
+      setSelectedConfigIds(new Set(projectSavedConfigs.map((c) => c.id)));
+    }
+  };
+
+  const handleDeleteSelectedConfigs = async () => {
+    const ids = [...selectedConfigIds];
+    if (ids.length === 0) return;
+    const noun = ids.length === 1 ? "saved configuration" : "saved configurations";
+    if (
+      !confirm(
+        `Delete ${ids.length} ${noun}? This removes stored form recipes only — resources in the emulator are not affected.`
+      )
+    ) {
+      return;
+    }
+    setDeletingConfigs(true);
+    try {
+      for (const id of ids) {
+        await onDeleteSavedConfig(id);
+      }
+      setSelectedConfigIds(new Set());
+      toast.success(`Deleted ${ids.length} ${noun}`);
+    } catch {
+      toast.error("Failed to delete one or more configurations");
+    } finally {
+      setDeletingConfigs(false);
+    }
+  };
+
+  const configResourceLabel = (cfg: SavedConfig) => {
+    const name = resourceNameFromConfig(cfg.resource_type, cfg.config as Record<string, unknown>);
+    return name || cfg.name;
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-start justify-between gap-4 mb-4 flex-wrap">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">CLI Playbook</h2>
+          <p className="text-sm text-gray-500 mt-1">
+            Project: <span className="font-medium text-gray-700">{projectLabel}</span>
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={() => copyText(fullScript, "Full playbook copied")}
+            className="flex items-center px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            <ClipboardDocumentIcon className="h-4 w-4 mr-1" />
+            Copy all
+          </button>
+          <button
+            type="button"
+            onClick={downloadScript}
+            disabled={entries.length === 0}
+            className="flex items-center px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            <ArrowDownTrayIcon className="h-4 w-4 mr-1" />
+            Download .sh
+          </button>
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-500 mb-4">
+        Portable <code className="text-xs bg-gray-100 px-1 rounded">aws</code> commands with no
+        endpoint in each line. Use <strong>LCK AWS CLI</strong> for MiniStack or{" "}
+        <strong>AWS CLI</strong> for real AWS — see the environment block for each.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2 mb-4 w-full">
+        <span className="text-sm font-medium text-gray-700">Environment:</span>
+        {(["local", "aws"] as const).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => setPreambleMode(mode)}
+            className={`px-3 py-1.5 text-sm font-medium rounded-md border transition-colors ${
+              preambleMode === mode
+                ? "bg-blue-600 text-white border-blue-600"
+                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+            }`}
+          >
+            {mode === "local" ? "LCK AWS CLI" : "AWS CLI"}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={loadResources}
+          disabled={loadingResources}
+          className="ml-auto text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
+        >
+          {loadingResources ? "Refreshing…" : "Refresh inventory"}
+        </button>
+      </div>
+
+      <div className="mb-6 mt-4">
+        <h3 className="text-sm font-medium text-gray-700 mb-2">Environment setup</h3>
+        <ThemeableCodeBlock
+          code={preamble}
+          language="bash"
+          showThemeSelector={false}
+        />
+      </div>
+
+      <div className="mb-6">
+        <h3 className="text-sm font-medium text-gray-700 mb-2">Live inventory</h3>
+        {summary.length === 0 ? (
+          <p className="text-sm text-gray-400 italic">
+            {loadingResources
+              ? "Loading resources…"
+              : "No resources in the emulator for this project."}
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {summary.map(({ type, count }) => (
+              <span
+                key={type}
+                className="text-xs px-2.5 py-1 rounded-md bg-gray-100 text-gray-700 border border-gray-200"
+              >
+                {TYPE_LABELS[type] || type}: <strong>{count}</strong>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <h3 className="text-sm font-medium text-gray-700 mb-1">Rebuild commands</h3>
+      <p className="text-xs text-gray-500 mb-3">
+        Copy portable CLI for each resource. Manage stored recipes in Saved configurations below.
+      </p>
+
+      {entries.length === 0 ? (
+        <p className="text-sm text-gray-400 italic">
+          No saved configs or live resources yet. Create resources on the dashboard and save
+          configs from the creation forms for full CLI recipes.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry) => {
+            const isOpen = expandedId === entry.id;
+            return (
+              <div
+                key={entry.id}
+                className="border border-gray-200 rounded-lg overflow-hidden bg-gray-50"
+              >
+                <div className="flex items-center gap-1 px-2 py-2 sm:px-3">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(isOpen ? null : entry.id)}
+                    className="flex-1 flex items-center gap-3 min-w-0 px-2 py-1 text-left rounded-md hover:bg-gray-100 transition-colors"
+                  >
+                    <CommandLineIcon className="h-4 w-4 text-gray-500 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {entry.resourceName}
+                        {entry.savedConfigName && entry.label !== entry.resourceName && (
+                          <span className="text-gray-500 font-normal">
+                            {" "}
+                            ({entry.savedConfigName})
+                          </span>
+                        )}
+                      </p>
+                      <p className="text-xs text-gray-500">
+                        {TYPE_LABELS[entry.resourceType] || entry.resourceType}
+                      </p>
+                    </div>
+                  </button>
+                  <div className="flex items-center gap-1 shrink-0">
+                    {sourceBadge(entry.source)}
+                    <button
+                      type="button"
+                      onClick={() => copyText(entry.command, "Command copied")}
+                      className="p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                      title="Copy command"
+                    >
+                      <ClipboardDocumentIcon className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setExpandedId(isOpen ? null : entry.id)}
+                      className="p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+                      title={isOpen ? "Collapse" : "Expand"}
+                      aria-expanded={isOpen}
+                    >
+                      {isOpen ? (
+                        <ChevronUpIcon className="h-4 w-4" />
+                      ) : (
+                        <ChevronDownIcon className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+                {isOpen && (
+                  <div className="px-4 pb-4 border-t border-gray-200 bg-white">
+                    {entry.note && (
+                      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-md px-3 py-2 mt-3 mb-2">
+                        {entry.note}
+                      </p>
+                    )}
+                    <div className="mt-3">
+                      <ThemeableCodeBlock
+                        code={entry.command}
+                        language="bash"
+                        showThemeSelector={false}
+                        showCopyButton={false}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="border-t border-gray-200 mt-8 pt-6">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+          <div>
+            <h3 className="text-sm font-medium text-gray-700">Saved configurations</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Form recipes saved from creation modals. Deleting does not remove emulator resources.
+            </p>
+          </div>
+          {projectSavedConfigs.length > 0 && selectedConfigIds.size > 0 && (
+            <button
+              type="button"
+              onClick={handleDeleteSelectedConfigs}
+              disabled={deletingConfigs}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 disabled:opacity-50"
+            >
+              <TrashIcon className="h-4 w-4" />
+              Delete selected ({selectedConfigIds.size})
+            </button>
+          )}
+        </div>
+
+        {projectSavedConfigs.length === 0 ? (
+          <p className="text-sm text-gray-400 italic">
+            No saved configurations for this project. Use &quot;Save config&quot; in a resource
+            creation form to store a recipe for the CLI playbook.
+          </p>
+        ) : (
+          <div className="border border-gray-200 rounded-lg overflow-hidden">
+            <label className="flex items-center gap-3 px-4 py-2.5 bg-gray-50 border-b border-gray-200 cursor-pointer hover:bg-gray-100 transition-colors">
+              <input
+                type="checkbox"
+                checked={allConfigsSelected}
+                onChange={toggleSelectAllConfigs}
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-xs font-medium text-gray-600">Select all</span>
+            </label>
+            <ul className="divide-y divide-gray-200">
+              {projectSavedConfigs.map((cfg) => (
+                <li key={cfg.id}>
+                  <label className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors">
+                    <input
+                      type="checkbox"
+                      checked={selectedConfigIds.has(cfg.id)}
+                      onChange={() => toggleConfigSelection(cfg.id)}
+                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium text-gray-900 truncate">{cfg.name}</p>
+                      <p className="text-xs text-gray-500">
+                        {TYPE_LABELS[cfg.resource_type] || cfg.resource_type}
+                        {configResourceLabel(cfg) !== cfg.name && (
+                          <span className="text-gray-400"> · {configResourceLabel(cfg)}</span>
+                        )}
+                      </p>
+                    </div>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -3,29 +3,14 @@
 import { usePreferences } from "@/context/PreferencesContext";
 import { useServicesData } from "@/hooks/useServicesData";
 import { resourceApi } from "@/services/api";
-import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig, ModalKey, Resource } from "@/types";
-import { PLATFORM_SERVICES, PLATFORM_SERVICE_KINDS, SERVICE_KIND_LABEL } from "@/constants/platformServices";
-import {
-  ArrowTopRightOnSquareIcon,
-  Bars3Icon,
-  BookOpenIcon,
-  ChevronDownIcon,
-  ClipboardDocumentCheckIcon,
-  DocumentTextIcon,
-  EyeIcon,
-  ServerIcon,
-  Squares2X2Icon,
-  UserCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { DashboardNavActions, DashboardNavProvider, InspectTargetId } from "@/context/DashboardNavContext";
+import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayConfig, SSMParameterConfig, IAMRoleConfig, Resource } from "@/types";
 import { Icon } from "@iconify/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import ResourceList from "./ResourceList";
 
-import Image from "next/image";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import packageJson from "../../package.json";
 import BucketViewer from "./BucketViewer";
 import DynamoDBConfigModal from "./DynamoDBConfigModal";
@@ -47,20 +32,7 @@ import IAMConfigModal from "./IAMConfigModal";
 import LambdaCodeModal from "./LambdaCodeModal";
 import IAMRolePoliciesModal from "./IAMRolePoliciesModal";
 import QuickInspectModal, { QuickInspectAction } from "./QuickInspectModal";
-
-type InspectTargetId =
-  | "aws-emulator"
-  | "s3"
-  | "dynamodb"
-  | "lambda"
-  | "apigateway"
-  | "secretsmanager"
-  | "ssm"
-  | "iam"
-  | "postgres"
-  | "redis"
-  | "keycloak"
-  | "mailpit";
+import DashboardNavBar from "./DashboardNavBar";
 
 const AWS_RESOURCE_TYPES = new Set<Resource["type"]>([
   "s3",
@@ -72,19 +44,7 @@ const AWS_RESOURCE_TYPES = new Set<Resource["type"]>([
   "iam",
 ]);
 
-const DOC_ROUTES = [
-  "/docs", "/aws-emulator", "/s3", "/dynamodb", "/lambda",
-  "/apigateway", "/secrets", "/ssm", "/iam",
-  "/redis", "/mailpit", "/postgres", "/keycloak",
-];
-
 export default function Dashboard() {
-  const router = useRouter();
-
-  const prefetchDocRoutes = useCallback(() => {
-    DOC_ROUTES.forEach((route) => router.prefetch(route));
-  }, [router]);
-
   const {
     awsEmulator,
     mailpit,
@@ -97,7 +57,7 @@ export default function Dashboard() {
   } = useServicesData();
 
   const { status: emulatorStatus, projectConfig: config, resources } = awsEmulator;
-  const { profile, projects, updateProfile, createProject } = usePreferences();
+  const { profile } = usePreferences();
 
   const projectName = profile?.active_project_name || config.projectName;
 
@@ -178,157 +138,8 @@ export default function Dashboard() {
     return !isFirstResourceCreation;
   };
 
-  // "What's new" dot — shows when the stored version doesn't match the current one
-  const [hasNewVersion, setHasNewVersion] = useState(false);
-  useEffect(() => {
-    const seen = localStorage.getItem("lck_last_seen_version");
-    if (seen !== packageJson.version) setHasNewVersion(true);
-  }, []);
-  const dismissVersionDot = () => {
-    localStorage.setItem("lck_last_seen_version", packageJson.version);
-    setHasNewVersion(false);
-  };
-
-  // Mobile nav
-  const [showMobileMenu, setShowMobileMenu] = useState(false);
-
-  // Dropdowns
-  const [showResourcesMenu, setShowResourcesMenu] = useState(false);
-  const [showServicesMenu, setShowServicesMenu] = useState(false);
-  const [showDocsMenu, setShowDocsMenu] = useState(false);
-  const [showDevToolsMenu, setShowDevToolsMenu] = useState(false);
-  const [showProjectMenu, setShowProjectMenu] = useState(false);
-  const [showProfileMenu, setShowProfileMenu] = useState(false);
-  const resourcesMenuRef = useRef<HTMLDivElement>(null);
-  const servicesMenuRef = useRef<HTMLDivElement>(null);
-  const docsMenuRef = useRef<HTMLDivElement>(null);
-  const devToolsMenuRef = useRef<HTMLDivElement>(null);
-  const projectMenuRef = useRef<HTMLDivElement>(null);
-  const profileMenuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target as Node)) {
-        setShowResourcesMenu(false);
-      }
-      if (servicesMenuRef.current && !servicesMenuRef.current.contains(e.target as Node)) {
-        setShowServicesMenu(false);
-      }
-      if (docsMenuRef.current && !docsMenuRef.current.contains(e.target as Node)) {
-        setShowDocsMenu(false);
-      }
-      if (devToolsMenuRef.current && !devToolsMenuRef.current.contains(e.target as Node)) {
-        setShowDevToolsMenu(false);
-      }
-      if (projectMenuRef.current && !projectMenuRef.current.contains(e.target as Node)) {
-        setShowProjectMenu(false);
-      }
-      if (profileMenuRef.current && !profileMenuRef.current.contains(e.target as Node)) {
-        setShowProfileMenu(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  const closeAllMenus = () => {
-    setShowResourcesMenu(false);
-    setShowServicesMenu(false);
-    setShowDocsMenu(false);
-    setShowDevToolsMenu(false);
-    setShowProjectMenu(false);
-    setShowProfileMenu(false);
-    setShowMobileMenu(false);
-  };
-
   const openInspectTarget = (target: InspectTargetId) => {
-    closeAllMenus();
     setInspectTarget(target);
-  };
-
-  const handleModalOpen = (modalKey: ModalKey) => {
-    if (modalKey === "mailpit") setShowMailpit(true);
-    if (modalKey === "redis") setShowRedis(true);
-  };
-
-  const toggleMenu = (setter: (v: boolean) => void, current: boolean) => {
-    closeAllMenus();
-    setter(!current);
-  };
-
-  const previewActionClass =
-    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
-  const inspectActionClass =
-    "inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors";
-  const manageActionClass =
-    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
-
-  const renderResourceActions = (label: string, target: InspectTargetId, manageHref: string, onPreview?: () => void) => (
-    <div className="flex items-center gap-1">
-      {onPreview && (
-        <button
-          onClick={onPreview}
-          className={previewActionClass}
-          title={`Open ${label} viewer`}
-          aria-label={`Open ${label} viewer`}
-        >
-          <EyeIcon className="h-4 w-4" />
-        </button>
-      )}
-      <button
-        onClick={() => openInspectTarget(target)}
-        className={inspectActionClass}
-        title={`Inspect ${label} checks`}
-        aria-label={`Inspect ${label} checks`}
-      >
-        <ClipboardDocumentCheckIcon className="h-4 w-4" />
-      </button>
-      <Link
-        href={manageHref}
-        onClick={closeAllMenus}
-        className={manageActionClass}
-        title={`Open ${label} page`}
-        aria-label={`Open ${label} page`}
-      >
-        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
-      </Link>
-    </div>
-  );
-
-  const renderInspectAction = (label: string, target: InspectTargetId) => (
-    <button
-      onClick={() => openInspectTarget(target)}
-      className={inspectActionClass}
-      title={`Inspect ${label} checks`}
-      aria-label={`Inspect ${label} checks`}
-    >
-      <ClipboardDocumentCheckIcon className="h-4 w-4" />
-    </button>
-  );
-
-  const handleSwitchProject = async (projectId: number) => {
-    try {
-      await updateProfile({ active_project_id: projectId });
-      setShowProjectMenu(false);
-      await loadInitialData();
-    } catch {
-      toast.error("Failed to switch project");
-    }
-  };
-
-  const handleCreateProject = async () => {
-    const label = prompt("Project name:");
-    if (!label) return;
-    const name = label.toLowerCase().replace(/[^a-z0-9-]/g, "-");
-    try {
-      const project = await createProject(name, label);
-      await updateProfile({ active_project_id: project.id });
-      setShowProjectMenu(false);
-      await loadInitialData();
-      toast.success(`Project "${label}" created`);
-    } catch {
-      toast.error("Failed to create project");
-    }
   };
 
   const handleCreateSingleResource = async (resourceType: string) => {
@@ -739,6 +550,28 @@ export default function Dashboard() {
     setShowIAMRolePolicies(true);
   };
 
+  const dashboardNavActions: DashboardNavActions = {
+    openS3Buckets: () => setShowBuckets(true),
+    openDynamoDBViewer: () => setShowDynamoDB(true),
+    openLambdaConfig: () => setShowLambdaConfig(true),
+    openLambdaViewer: () => openLambdaViewer(),
+    openAPIGatewayConfig: () => setShowAPIGatewayConfig(true),
+    openAPIGatewayViewer: () => openAPIGatewayViewer(),
+    openSecretsConfig: () => setShowSecretsConfig(true),
+    openSecretsViewer: () => openSecretsViewer(),
+    openSSMConfig: () => setShowSSMConfig(true),
+    openSSMViewer: () => openSSMViewer(),
+    openIAMConfig: () => setShowIAMConfig(true),
+    openIAMRoleViewer: () => openIAMRoleViewer(),
+    openInspectTarget,
+    openModal: (modalKey) => {
+      if (modalKey === "mailpit") setShowMailpit(true);
+      if (modalKey === "redis") setShowRedis(true);
+    },
+    openLogs: () => setShowLogs(true),
+    onAfterProjectSwitch: loadInitialData,
+  };
+
   const serviceStatusClass = (status: string) => {
     if (status === "running") return "bg-green-100 text-green-800";
     if (status === "starting") return "bg-yellow-100 text-yellow-700";
@@ -977,649 +810,9 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
-      {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-4">
-            {/* Logo */}
-            <div className="flex items-center space-x-3">
-              <Image src="/logo.svg" alt="LocalCloud Kit" width={90} height={36} />
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Local Cloud Development Environment • v{packageJson.version}</p>
-              </div>
-            </div>
-
-            {/* Desktop Nav */}
-            <div className="hidden md:flex items-center gap-0.5">
-
-              {/* Resources dropdown — AWS resources only */}
-              <div className="relative" ref={resourcesMenuRef}>
-                <button
-                  onClick={() => toggleMenu(setShowResourcesMenu, showResourcesMenu)}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <Squares2X2Icon className="h-4 w-4 mr-2" />
-                  Resources
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showResourcesMenu ? "rotate-180" : ""}`} />
-                </button>
-                {showResourcesMenu && (
-                  <div className="absolute right-0 mt-1 w-80 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1.5">
-                    {/* Storage */}
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowBuckets(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
-                        S3 Buckets
-                      </button>
-                      {renderResourceActions("S3 Buckets", "s3", "/manage/s3", () => {
-                        setShowBuckets(true);
-                        closeAllMenus();
-                      })}
-                    </div>
-
-                    {/* Database */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowDynamoDB(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
-                        DynamoDB
-                      </button>
-                      {renderResourceActions("DynamoDB", "dynamodb", "/manage/dynamodb", () => {
-                        setShowDynamoDB(true);
-                        closeAllMenus();
-                      })}
-                    </div>
-
-                    {/* Compute */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compute</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
-                        Lambda
-                      </button>
-                      {renderResourceActions("Lambda", "lambda", "/manage/lambda", () => {
-                        openLambdaViewer();
-                        closeAllMenus();
-                      })}
-                    </div>
-
-                    {/* Networking */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Networking</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
-                        API Gateway
-                      </button>
-                      {renderResourceActions("API Gateway", "apigateway", "/manage/apigateway", () => {
-                        openAPIGatewayViewer();
-                        closeAllMenus();
-                      })}
-                    </div>
-
-                    {/* Security & Identity */}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Security & Identity</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
-                        Secrets Manager
-                      </button>
-                      {renderResourceActions("Secrets Manager", "secretsmanager", "/manage/secrets", () => {
-                        openSecretsViewer();
-                        closeAllMenus();
-                      })}
-                    </div>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowSSMConfig(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
-                        Parameter Store
-                      </button>
-                      {renderResourceActions("Parameter Store", "ssm", "/manage/ssm", () => {
-                        openSSMViewer();
-                        closeAllMenus();
-                      })}
-                    </div>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
-                      <button
-                        onClick={() => { setShowIAMConfig(true); closeAllMenus(); }}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                      >
-                        <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
-                        IAM Roles
-                      </button>
-                      {renderResourceActions("IAM Roles", "iam", "/manage/iam", () => {
-                        openIAMRoleViewer();
-                        closeAllMenus();
-                      })}
-                    </div>
-
-                  </div>
-                )}
-              </div>
-
-              {/* Services dropdown — platform services */}
-              <div className="relative" ref={servicesMenuRef}>
-                <button
-                  onClick={() => toggleMenu(setShowServicesMenu, showServicesMenu)}
-                  className="relative flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <ServerIcon className="h-4 w-4 mr-2" />
-                  Services
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showServicesMenu ? "rotate-180" : ""}`} />
-                  {mailpit.unread > 0 && (
-                    <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
-                      {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                    </span>
-                  )}
-                </button>
-                {showServicesMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    {PLATFORM_SERVICE_KINDS.map((kind, i) => {
-                      const items = PLATFORM_SERVICES.filter((s) => s.kind === kind);
-                      return (
-                        <div key={kind}>
-                          {i > 0 && <div className="border-t border-gray-100 mt-1" />}
-                          <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
-                            {SERVICE_KIND_LABEL[kind]}
-                          </p>
-                          {items.map((service) => {
-                            const ServiceIcon = service.icon;
-                            const itemContent = (
-                              <>
-                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
-                                {service.label}
-                                {service.id === "mailpit" && mailpit.unread > 0 && (
-                                  <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
-                                    {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                                  </span>
-                                )}
-                              </>
-                            );
-                            const action = service.action;
-                            return (
-                              <div key={service.id} className="flex items-center justify-between px-2">
-                                {action.type === "link" ? (
-                                  <Link
-                                    href={action.href}
-                                    onClick={() => closeAllMenus()}
-                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                                  >
-                                    {itemContent}
-                                  </Link>
-                                ) : (
-                                  <button
-                                    onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
-                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
-                                  >
-                                    {itemContent}
-                                  </button>
-                                )}
-                                {renderInspectAction(service.label, service.id)}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-
-              {/* Docs dropdown */}
-              <div className="relative" ref={docsMenuRef}>
-                <button
-                  onClick={() => toggleMenu(setShowDocsMenu, showDocsMenu)}
-                  onMouseEnter={prefetchDocRoutes}
-                  onFocus={prefetchDocRoutes}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <BookOpenIcon className="h-4 w-4 mr-2" />
-                  Docs
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`} />
-                </button>
-                {showDocsMenu && (
-                  <div className="absolute right-0 mt-1 w-176 max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-md shadow-lg z-50 p-3">
-                    <Link
-                      href="/docs"
-                      onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
-                    >
-                      <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
-                      Docs Hub
-                    </Link>
-
-                    <div className="mt-3 grid grid-cols-3 gap-3 max-h-[65vh] overflow-y-auto">
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
-                        <Link
-                          href="/aws-emulator"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
-                          AWS Emulator
-                        </Link>
-                      </div>
-
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
-                        <Link
-                          href="/dynamodb"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
-                          DynamoDB
-                        </Link>
-                        <Link
-                          href="/s3"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
-                          S3 Buckets
-                        </Link>
-                        <Link
-                          href="/lambda"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
-                          Lambda
-                        </Link>
-                        <Link
-                          href="/apigateway"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
-                          API Gateway
-                        </Link>
-                        <Link
-                          href="/secrets"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
-                          Secrets Manager
-                        </Link>
-                        <Link
-                          href="/ssm"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
-                          Parameter Store
-                        </Link>
-                        <Link
-                          href="/iam"
-                          onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
-                          IAM &amp; STS
-                        </Link>
-                      </div>
-
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Platform Services</p>
-                        {PLATFORM_SERVICES.map((service) => {
-                          const ServiceIcon = service.icon;
-                          const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
-                          return (
-                            <Link
-                              key={service.id}
-                              href={href}
-                              onClick={() => setShowDocsMenu(false)}
-                              className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                            >
-                              <ServiceIcon className="h-4 w-4 mr-3 text-gray-400" />
-                              {service.label}
-                            </Link>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Dev Tools dropdown */}
-              <div className="relative" ref={devToolsMenuRef}>
-                <button
-                  onClick={() => toggleMenu(setShowDevToolsMenu, showDevToolsMenu)}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <ServerIcon className="h-4 w-4 mr-2" />
-                  Dev Tools
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDevToolsMenu ? "rotate-180" : ""}`} />
-                </button>
-                {showDevToolsMenu && (
-                  <div className="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</p>
-                    <button
-                      onClick={() => { setShowLogs(true); closeAllMenus(); }}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      System Logs
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              {/* Divider before project + profile */}
-              <div className="h-5 w-px bg-gray-200 mx-1.5" />
-
-              {/* Project Switcher */}
-              <div className="relative" ref={projectMenuRef}>
-                <button
-                  onClick={() => toggleMenu(setShowProjectMenu, showProjectMenu)}
-                  className="flex items-center gap-1.5 px-2 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
-                >
-                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
-                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500 shrink-0" />
-                    {profile?.active_project_label || "Default"}
-                  </span>
-                  <ChevronDownIcon className={`h-3.5 w-3.5 text-gray-400 transition-transform ${showProjectMenu ? "rotate-180" : ""}`} />
-                </button>
-                {showProjectMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Projects</p>
-                    {projects.map((p) => (
-                      <button
-                        key={p.id}
-                        onClick={() => handleSwitchProject(p.id)}
-                        className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
-                          p.id === profile?.active_project_id
-                            ? "text-blue-700 bg-blue-50 font-medium"
-                            : "text-gray-700 hover:bg-gray-50"
-                        }`}
-                      >
-                        <span className={`h-2 w-2 rounded-full mr-3 shrink-0 ${p.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
-                        {p.label}
-                      </button>
-                    ))}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <button
-                      onClick={handleCreateProject}
-                      className="flex items-center w-full px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors"
-                    >
-                      + New project
-                    </button>
-                    <Link
-                      href="/profile"
-                      onClick={() => setShowProjectMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      Manage projects...
-                    </Link>
-                  </div>
-                )}
-              </div>
-
-              {/* Profile dropdown */}
-              <div className="relative" ref={profileMenuRef}>
-                <button
-                  onClick={() => { toggleMenu(setShowProfileMenu, showProfileMenu); dismissVersionDot(); }}
-                  className="relative p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                  title="Profile & Settings"
-                >
-                  <UserCircleIcon className="h-6 w-6" />
-                  {hasNewVersion && (
-                    <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white" />
-                  )}
-                </button>
-                {showProfileMenu && (
-                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    {hasNewVersion && (
-                      <div className="mx-2 mb-1 px-3 py-2 bg-blue-50 rounded-md border border-blue-100">
-                        <p className="text-xs font-semibold text-blue-700">v{packageJson.version} — What&apos;s new</p>
-                        <Link href="https://github.com/localcloud-kit/localcloud-kit/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">View changelog →</Link>
-                      </div>
-                    )}
-                    <Link
-                      href="/profile"
-                      onClick={() => setShowProfileMenu(false)}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <UserCircleIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      Profile & Preferences
-                    </Link>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* Mobile hamburger */}
-            <div className="flex md:hidden items-center gap-2">
-              {hasNewVersion && (
-                <span className="h-2 w-2 rounded-full bg-red-500" />
-              )}
-              {mailpit.unread > 0 && (
-                <span className="flex items-center justify-center h-5 min-w-5 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
-                  {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                </span>
-              )}
-              <button
-                onClick={() => setShowMobileMenu((v) => !v)}
-                className="p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                aria-label="Open menu"
-              >
-                {showMobileMenu ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
-              </button>
-            </div>
-          </div>
-
-          {/* Mobile menu drawer */}
-          {showMobileMenu && (
-            <div className="md:hidden border-t border-gray-100 pb-3">
-
-              {/* Resources */}
-              <div className="pt-3 px-2">
-                <p className="px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowBuckets(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />S3 Buckets
-                  </button>
-                  <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowDynamoDB(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />DynamoDB Tables
-                  </button>
-                  <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowLambdaConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />Lambda Functions
-                  </button>
-                  <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowAPIGatewayConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />API Gateway
-                  </button>
-                  <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowSecretsConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />Secrets Manager
-                  </button>
-                  <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowSSMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />Parameter Store
-                  </button>
-                  <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button onClick={() => { setShowIAMConfig(true); closeAllMenus(); }} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                    <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />IAM Roles
-                  </button>
-                  <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
-                    Inspect
-                  </button>
-                </div>
-              </div>
-
-              {/* Services — categorised by kind */}
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                {PLATFORM_SERVICE_KINDS.map((kind, i) => {
-                  const items = PLATFORM_SERVICES.filter((s) => s.kind === kind);
-                  return (
-                    <div key={kind}>
-                      <p className={`px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider ${i > 0 ? "pt-2" : "py-1"}`}>
-                        {SERVICE_KIND_LABEL[kind]}
-                      </p>
-                      {items.map((service) => {
-                        const ServiceIcon = service.icon;
-                        const itemContent = (
-                          <>
-                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
-                            {service.label}
-                            {service.id === "mailpit" && mailpit.unread > 0 && (
-                              <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
-                                {mailpit.unread > 99 ? "99+" : mailpit.unread}
-                              </span>
-                            )}
-                          </>
-                        );
-                        const action = service.action;
-                        return (
-                          <div key={service.id} className="flex items-center gap-1">
-                            {action.type === "link" ? (
-                              <Link
-                                href={action.href}
-                                onClick={closeAllMenus}
-                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-                              >
-                                {itemContent}
-                              </Link>
-                            ) : (
-                              <button
-                                onClick={() => { handleModalOpen(action.modalKey); closeAllMenus(); }}
-                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
-                              >
-                                {itemContent}
-                              </button>
-                            )}
-                            <button
-                              onClick={() => openInspectTarget(service.id)}
-                              className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
-                            >
-                              Inspect
-                            </button>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Docs */}
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Docs</p>
-                <Link href="/docs" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm font-medium text-indigo-700 rounded-lg hover:bg-indigo-50 transition-colors">
-                  <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />Docs Hub
-                </Link>
-                <Link href="/aws-emulator" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />AWS Emulator
-                </Link>
-                <Link href="/s3" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />S3 Buckets
-                </Link>
-                <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />DynamoDB
-                </Link>
-                <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />Lambda
-                </Link>
-                <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />API Gateway
-                </Link>
-                <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />Secrets Manager
-                </Link>
-                <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />Parameter Store
-                </Link>
-                <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />IAM &amp; STS
-                </Link>
-                {PLATFORM_SERVICES.map((service) => {
-                  const ServiceIcon = service.icon;
-                  const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
-                  return (
-                    <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />{service.label}
-                    </Link>
-                  );
-                })}
-              </div>
-
-              {/* Dev Tools */}
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Dev Tools</p>
-                <button onClick={() => { setShowLogs(true); closeAllMenus(); }} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />System Logs
-                </button>
-              </div>
-
-              {/* Account */}
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Account</p>
-                <div className="px-3 py-2">
-                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
-                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
-                    {profile?.active_project_label || "Default"}
-                  </span>
-                </div>
-                <Link href="/profile" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <UserCircleIcon className="h-4 w-4 mr-3 text-gray-400" />Profile & Preferences
-                </Link>
-              </div>
-            </div>
-          )}
-        </div>
-      </header>
+    <DashboardNavProvider actions={dashboardNavActions}>
+      <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
+        <DashboardNavBar activePage="dashboard" />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
@@ -1921,15 +1114,16 @@ export default function Dashboard() {
         />
       )}
 
-      {showIAMConfig && (
-        <IAMConfigModal
-          isOpen={showIAMConfig}
-          onClose={() => setShowIAMConfig(false)}
-          onSubmit={handleCreateIAMRole}
-          projectName={projectName}
-          loading={createLoading}
-        />
-      )}
-    </div>
+        {showIAMConfig && (
+          <IAMConfigModal
+            isOpen={showIAMConfig}
+            onClose={() => setShowIAMConfig(false)}
+            onSubmit={handleCreateIAMRole}
+            projectName={projectName}
+            loading={createLoading}
+          />
+        )}
+      </div>
+    </DashboardNavProvider>
   );
 }

--- a/localcloud-gui/src/components/DashboardNavBar.tsx
+++ b/localcloud-gui/src/components/DashboardNavBar.tsx
@@ -1,0 +1,918 @@
+"use client";
+
+import { usePreferences } from "@/context/PreferencesContext";
+import {
+  InspectTargetId,
+  useDashboardNav,
+} from "@/context/DashboardNavContext";
+import { PLATFORM_SERVICES, PLATFORM_SERVICE_KINDS, SERVICE_KIND_LABEL } from "@/constants/platformServices";
+import { useServicesData } from "@/hooks/useServicesData";
+import {
+  ArrowTopRightOnSquareIcon,
+  Bars3Icon,
+  BookOpenIcon,
+  ChevronDownIcon,
+  ClipboardDocumentCheckIcon,
+  DocumentTextIcon,
+  EyeIcon,
+  ServerIcon,
+  Squares2X2Icon,
+  UserCircleIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "react-hot-toast";
+import packageJson from "../../package.json";
+import LogViewer from "./LogViewer";
+import MailpitModal from "./MailpitModal";
+import RedisModal from "./RedisModal";
+
+const DOC_ROUTES = [
+  "/docs", "/aws-emulator", "/s3", "/dynamodb", "/lambda",
+  "/apigateway", "/secrets", "/ssm", "/iam",
+  "/redis", "/mailpit", "/postgres", "/keycloak",
+];
+
+type DashboardNavBarProps = {
+  activePage?: "dashboard" | "profile";
+};
+
+type ResourceActionOptions = {
+  label: string;
+  target: InspectTargetId;
+  manageHref: string;
+  onPreview?: () => void;
+};
+
+const INSPECT_FALLBACK_HREF = "/";
+const DASHBOARD_FALLBACK_HREF = "/";
+
+export default function DashboardNavBar({
+  activePage = "dashboard",
+}: DashboardNavBarProps) {
+  const router = useRouter();
+  const actions = useDashboardNav();
+  const { profile, projects, updateProfile, createProject } = usePreferences();
+  const {
+    mailpit,
+  } = useServicesData();
+
+  const prefetchDocRoutes = useCallback(() => {
+    DOC_ROUTES.forEach((route) => router.prefetch(route));
+  }, [router]);
+
+  const [showLogs, setShowLogs] = useState(false);
+  const [showMailpit, setShowMailpit] = useState(false);
+  const [showRedis, setShowRedis] = useState(false);
+
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const [showResourcesMenu, setShowResourcesMenu] = useState(false);
+  const [showServicesMenu, setShowServicesMenu] = useState(false);
+  const [showDocsMenu, setShowDocsMenu] = useState(false);
+  const [showDevToolsMenu, setShowDevToolsMenu] = useState(false);
+  const [showProjectMenu, setShowProjectMenu] = useState(false);
+  const [showProfileMenu, setShowProfileMenu] = useState(false);
+  const resourcesMenuRef = useRef<HTMLDivElement>(null);
+  const servicesMenuRef = useRef<HTMLDivElement>(null);
+  const docsMenuRef = useRef<HTMLDivElement>(null);
+  const devToolsMenuRef = useRef<HTMLDivElement>(null);
+  const projectMenuRef = useRef<HTMLDivElement>(null);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
+
+  const [hasNewVersion, setHasNewVersion] = useState(false);
+  useEffect(() => {
+    const seen = localStorage.getItem("lck_last_seen_version");
+    if (seen !== packageJson.version) setHasNewVersion(true);
+  }, []);
+
+  const dismissVersionDot = () => {
+    localStorage.setItem("lck_last_seen_version", packageJson.version);
+    setHasNewVersion(false);
+  };
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (resourcesMenuRef.current && !resourcesMenuRef.current.contains(e.target as Node)) {
+        setShowResourcesMenu(false);
+      }
+      if (servicesMenuRef.current && !servicesMenuRef.current.contains(e.target as Node)) {
+        setShowServicesMenu(false);
+      }
+      if (docsMenuRef.current && !docsMenuRef.current.contains(e.target as Node)) {
+        setShowDocsMenu(false);
+      }
+      if (devToolsMenuRef.current && !devToolsMenuRef.current.contains(e.target as Node)) {
+        setShowDevToolsMenu(false);
+      }
+      if (projectMenuRef.current && !projectMenuRef.current.contains(e.target as Node)) {
+        setShowProjectMenu(false);
+      }
+      if (profileMenuRef.current && !profileMenuRef.current.contains(e.target as Node)) {
+        setShowProfileMenu(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const closeAllMenus = () => {
+    setShowResourcesMenu(false);
+    setShowServicesMenu(false);
+    setShowDocsMenu(false);
+    setShowDevToolsMenu(false);
+    setShowProjectMenu(false);
+    setShowProfileMenu(false);
+    setShowMobileMenu(false);
+  };
+
+  const toggleMenu = (setter: (v: boolean) => void, current: boolean) => {
+    closeAllMenus();
+    setter(!current);
+  };
+
+  const openInspectTarget = (target: InspectTargetId) => {
+    closeAllMenus();
+    if (actions) {
+      actions.openInspectTarget(target);
+      return;
+    }
+    router.push(INSPECT_FALLBACK_HREF);
+  };
+
+  const openActionOrFallback = (
+    action: (() => void) | undefined,
+    fallbackHref: string
+  ) => {
+    closeAllMenus();
+    if (action) {
+      action();
+      return;
+    }
+    router.push(fallbackHref);
+  };
+
+  const openModal = (
+    modal: "mailpit" | "redis" | "logs"
+  ) => {
+    closeAllMenus();
+    if (actions) {
+      if (modal === "logs") {
+        actions.openLogs();
+      } else {
+        actions.openModal(modal);
+      }
+      return;
+    }
+
+    if (modal === "logs") setShowLogs(true);
+    if (modal === "mailpit") setShowMailpit(true);
+    if (modal === "redis") setShowRedis(true);
+  };
+
+  const handleSwitchProject = async (projectId: number) => {
+    try {
+      await updateProfile({ active_project_id: projectId });
+      setShowProjectMenu(false);
+      await actions?.onAfterProjectSwitch?.();
+    } catch {
+      toast.error("Failed to switch project");
+    }
+  };
+
+  const handleCreateProject = async () => {
+    const label = prompt("Project name:");
+    if (!label) return;
+    const name = label.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+    try {
+      const project = await createProject(name, label);
+      await updateProfile({ active_project_id: project.id });
+      setShowProjectMenu(false);
+      await actions?.onAfterProjectSwitch?.();
+      toast.success(`Project "${label}" created`);
+    } catch {
+      toast.error("Failed to create project");
+    }
+  };
+
+  const previewActionClass =
+    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
+  const inspectActionClass =
+    "inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors";
+  const manageActionClass =
+    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
+
+  const renderResourceActions = ({
+    label,
+    target,
+    manageHref,
+    onPreview,
+  }: ResourceActionOptions) => (
+    <div className="flex items-center gap-1">
+      {onPreview && (
+        <button
+          onClick={onPreview}
+          className={previewActionClass}
+          title={`Open ${label} viewer`}
+          aria-label={`Open ${label} viewer`}
+        >
+          <EyeIcon className="h-4 w-4" />
+        </button>
+      )}
+      <button
+        onClick={() => openInspectTarget(target)}
+        className={inspectActionClass}
+        title={`Inspect ${label} checks`}
+        aria-label={`Inspect ${label} checks`}
+      >
+        <ClipboardDocumentCheckIcon className="h-4 w-4" />
+      </button>
+      <Link
+        href={manageHref}
+        onClick={closeAllMenus}
+        className={manageActionClass}
+        title={`Open ${label} page`}
+        aria-label={`Open ${label} page`}
+      >
+        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+      </Link>
+    </div>
+  );
+
+  const renderInspectAction = (label: string, target: InspectTargetId) => (
+    <button
+      onClick={() => openInspectTarget(target)}
+      className={inspectActionClass}
+      title={`Inspect ${label} checks`}
+      aria-label={`Inspect ${label} checks`}
+    >
+      <ClipboardDocumentCheckIcon className="h-4 w-4" />
+    </button>
+  );
+
+  return (
+    <>
+      <header className="bg-white shadow-sm border-b border-gray-200">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center py-4">
+            <div className="flex items-center space-x-3">
+              <Link href="/" onClick={closeAllMenus} aria-label="Go to dashboard">
+                <Image src="/logo.svg" alt="LocalCloud Kit" width={90} height={36} />
+              </Link>
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900">LocalCloud Kit</h1>
+                <p className="text-xs text-gray-500">
+                  Local Cloud Development Environment
+                  {" "}
+                  •
+                  {" "}
+                  v
+                  {packageJson.version}
+                </p>
+              </div>
+            </div>
+
+            <div className="hidden md:flex items-center gap-0.5">
+              <div className="relative" ref={resourcesMenuRef}>
+                <button
+                  onClick={() => toggleMenu(setShowResourcesMenu, showResourcesMenu)}
+                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <Squares2X2Icon className="h-4 w-4 mr-2" />
+                  Resources
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showResourcesMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showResourcesMenu && (
+                  <div className="absolute right-0 mt-1 w-80 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1.5">
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openS3Buckets, "/manage/s3")}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
+                        S3 Buckets
+                      </button>
+                      {renderResourceActions({
+                        label: "S3 Buckets",
+                        target: "s3",
+                        manageHref: "/manage/s3",
+                        onPreview: () => openActionOrFallback(actions?.openS3Buckets, "/manage/s3"),
+                      })}
+                    </div>
+
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb")}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
+                        DynamoDB
+                      </button>
+                      {renderResourceActions({
+                        label: "DynamoDB",
+                        target: "dynamodb",
+                        manageHref: "/manage/dynamodb",
+                        onPreview: () => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb"),
+                      })}
+                    </div>
+
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compute</p>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openLambdaConfig, DASHBOARD_FALLBACK_HREF)}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
+                        Lambda
+                      </button>
+                      {renderResourceActions({
+                        label: "Lambda",
+                        target: "lambda",
+                        manageHref: "/manage/lambda",
+                        onPreview: () => openActionOrFallback(actions?.openLambdaViewer, "/manage/lambda"),
+                      })}
+                    </div>
+
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Networking</p>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openAPIGatewayConfig, DASHBOARD_FALLBACK_HREF)}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
+                        API Gateway
+                      </button>
+                      {renderResourceActions({
+                        label: "API Gateway",
+                        target: "apigateway",
+                        manageHref: "/manage/apigateway",
+                        onPreview: () => openActionOrFallback(actions?.openAPIGatewayViewer, "/manage/apigateway"),
+                      })}
+                    </div>
+
+                    <div className="border-t border-gray-100 mt-1" />
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Security & Identity</p>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openSecretsConfig, DASHBOARD_FALLBACK_HREF)}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
+                        Secrets Manager
+                      </button>
+                      {renderResourceActions({
+                        label: "Secrets Manager",
+                        target: "secretsmanager",
+                        manageHref: "/manage/secrets",
+                        onPreview: () => openActionOrFallback(actions?.openSecretsViewer, "/manage/secrets"),
+                      })}
+                    </div>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openSSMConfig, DASHBOARD_FALLBACK_HREF)}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
+                        Parameter Store
+                      </button>
+                      {renderResourceActions({
+                        label: "Parameter Store",
+                        target: "ssm",
+                        manageHref: "/manage/ssm",
+                        onPreview: () => openActionOrFallback(actions?.openSSMViewer, "/manage/ssm"),
+                      })}
+                    </div>
+                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                      <button
+                        onClick={() => openActionOrFallback(actions?.openIAMConfig, DASHBOARD_FALLBACK_HREF)}
+                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                      >
+                        <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
+                        IAM Roles
+                      </button>
+                      {renderResourceActions({
+                        label: "IAM Roles",
+                        target: "iam",
+                        manageHref: "/manage/iam",
+                        onPreview: () => openActionOrFallback(actions?.openIAMRoleViewer, "/manage/iam"),
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="relative" ref={servicesMenuRef}>
+                <button
+                  onClick={() => toggleMenu(setShowServicesMenu, showServicesMenu)}
+                  className="relative flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <ServerIcon className="h-4 w-4 mr-2" />
+                  Services
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showServicesMenu ? "rotate-180" : ""}`} />
+                  {mailpit.unread > 0 && (
+                    <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
+                      {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                    </span>
+                  )}
+                </button>
+                {showServicesMenu && (
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    {PLATFORM_SERVICE_KINDS.map((kind, i) => {
+                      const items = PLATFORM_SERVICES.filter((service) => service.kind === kind);
+                      return (
+                        <div key={kind}>
+                          {i > 0 && <div className="border-t border-gray-100 mt-1" />}
+                          <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                            {SERVICE_KIND_LABEL[kind]}
+                          </p>
+                          {items.map((service) => {
+                            const ServiceIcon = service.icon;
+                            const itemContent = (
+                              <>
+                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                                {service.label}
+                                {service.id === "mailpit" && mailpit.unread > 0 && (
+                                  <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
+                                    {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                                  </span>
+                                )}
+                              </>
+                            );
+                            const action = service.action;
+                            return (
+                              <div key={service.id} className="flex items-center justify-between px-2">
+                                {action.type === "link" ? (
+                                  <Link
+                                    href={action.href}
+                                    onClick={closeAllMenus}
+                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                  >
+                                    {itemContent}
+                                  </Link>
+                                ) : (
+                                  <button
+                                    onClick={() => openModal(action.modalKey)}
+                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                  >
+                                    {itemContent}
+                                  </button>
+                                )}
+                                {renderInspectAction(service.label, service.id)}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className="relative" ref={docsMenuRef}>
+                <button
+                  onClick={() => toggleMenu(setShowDocsMenu, showDocsMenu)}
+                  onMouseEnter={prefetchDocRoutes}
+                  onFocus={prefetchDocRoutes}
+                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <BookOpenIcon className="h-4 w-4 mr-2" />
+                  Docs
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showDocsMenu && (
+                  <div className="absolute right-0 mt-1 w-176 max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-md shadow-lg z-50 p-3">
+                    <Link
+                      href="/docs"
+                      onClick={() => setShowDocsMenu(false)}
+                      className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
+                    >
+                      <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+                      Docs Hub
+                    </Link>
+
+                    <div className="mt-3 grid grid-cols-3 gap-3 max-h-[65vh] overflow-y-auto">
+                      <div className="rounded-md border border-gray-100 py-1">
+                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
+                        <Link
+                          href="/aws-emulator"
+                          onClick={() => setShowDocsMenu(false)}
+                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                        >
+                          <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                          AWS Emulator
+                        </Link>
+                      </div>
+
+                      <div className="rounded-md border border-gray-100 py-1">
+                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
+                        <Link href="/dynamodb" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
+                          DynamoDB
+                        </Link>
+                        <Link href="/s3" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
+                          S3 Buckets
+                        </Link>
+                        <Link href="/lambda" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
+                          Lambda
+                        </Link>
+                        <Link href="/apigateway" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
+                          API Gateway
+                        </Link>
+                        <Link href="/secrets" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
+                          Secrets Manager
+                        </Link>
+                        <Link href="/ssm" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
+                          Parameter Store
+                        </Link>
+                        <Link href="/iam" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                          <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
+                          IAM &amp; STS
+                        </Link>
+                      </div>
+
+                      <div className="rounded-md border border-gray-100 py-1">
+                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Platform Services</p>
+                        {PLATFORM_SERVICES.map((service) => {
+                          const ServiceIcon = service.icon;
+                          const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
+                          return (
+                            <Link
+                              key={service.id}
+                              href={href}
+                              onClick={() => setShowDocsMenu(false)}
+                              className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                            >
+                              <ServiceIcon className="h-4 w-4 mr-3 text-gray-400" />
+                              {service.label}
+                            </Link>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="relative" ref={devToolsMenuRef}>
+                <button
+                  onClick={() => toggleMenu(setShowDevToolsMenu, showDevToolsMenu)}
+                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <ServerIcon className="h-4 w-4 mr-2" />
+                  Dev Tools
+                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDevToolsMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showDevToolsMenu && (
+                  <div className="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</p>
+                    <button
+                      onClick={() => openModal("logs")}
+                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                    >
+                      <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
+                      System Logs
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <div className="h-5 w-px bg-gray-200 mx-1.5" />
+
+              <div className="relative" ref={projectMenuRef}>
+                <button
+                  onClick={() => toggleMenu(setShowProjectMenu, showProjectMenu)}
+                  className="flex items-center gap-1.5 px-2 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                >
+                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500 shrink-0" />
+                    {profile?.active_project_label || "Default"}
+                  </span>
+                  <ChevronDownIcon className={`h-3.5 w-3.5 text-gray-400 transition-transform ${showProjectMenu ? "rotate-180" : ""}`} />
+                </button>
+                {showProjectMenu && (
+                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Projects</p>
+                    {projects.map((project) => (
+                      <button
+                        key={project.id}
+                        onClick={() => handleSwitchProject(project.id)}
+                        className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
+                          project.id === profile?.active_project_id
+                            ? "text-blue-700 bg-blue-50 font-medium"
+                            : "text-gray-700 hover:bg-gray-50"
+                        }`}
+                      >
+                        <span className={`h-2 w-2 rounded-full mr-3 shrink-0 ${project.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
+                        {project.label}
+                      </button>
+                    ))}
+                    <div className="border-t border-gray-100 mt-1" />
+                    <button
+                      onClick={handleCreateProject}
+                      className="flex items-center w-full px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors"
+                    >
+                      + New project
+                    </button>
+                    <Link
+                      href="/profile"
+                      onClick={() => setShowProjectMenu(false)}
+                      className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
+                        activePage === "profile"
+                          ? "text-blue-700 bg-blue-50 font-medium"
+                          : "text-gray-700 hover:bg-gray-50"
+                      }`}
+                    >
+                      Manage projects...
+                    </Link>
+                  </div>
+                )}
+              </div>
+
+              <div className="relative" ref={profileMenuRef}>
+                <button
+                  onClick={() => {
+                    toggleMenu(setShowProfileMenu, showProfileMenu);
+                    dismissVersionDot();
+                  }}
+                  className="relative p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                  title="Profile & Settings"
+                >
+                  <UserCircleIcon className={`h-6 w-6 ${activePage === "profile" ? "text-blue-600" : ""}`} />
+                  {hasNewVersion && (
+                    <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white" />
+                  )}
+                </button>
+                {showProfileMenu && (
+                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                    {hasNewVersion && (
+                      <div className="mx-2 mb-1 px-3 py-2 bg-blue-50 rounded-md border border-blue-100">
+                        <p className="text-xs font-semibold text-blue-700">v{packageJson.version} — What&apos;s new</p>
+                        <Link href="https://github.com/localcloud-kit/localcloud-kit/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">View changelog →</Link>
+                      </div>
+                    )}
+                    <Link
+                      href="/profile"
+                      onClick={() => setShowProfileMenu(false)}
+                      className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
+                        activePage === "profile"
+                          ? "text-blue-700 bg-blue-50 font-medium"
+                          : "text-gray-700 hover:bg-gray-50"
+                      }`}
+                    >
+                      <UserCircleIcon className={`h-4 w-4 mr-3 ${activePage === "profile" ? "text-blue-500" : "text-gray-400"}`} />
+                      Profile & Preferences
+                    </Link>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex md:hidden items-center gap-2">
+              {hasNewVersion && (
+                <span className="h-2 w-2 rounded-full bg-red-500" />
+              )}
+              {mailpit.unread > 0 && (
+                <span className="flex items-center justify-center h-5 min-w-5 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
+                  {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                </span>
+              )}
+              <button
+                onClick={() => setShowMobileMenu((value) => !value)}
+                className="p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                aria-label="Open menu"
+              >
+                {showMobileMenu ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+              </button>
+            </div>
+          </div>
+
+          {showMobileMenu && (
+            <div className="md:hidden border-t border-gray-100 pb-3">
+              <div className="pt-3 px-2">
+                <p className="px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openS3Buckets, "/manage/s3")} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
+                    S3 Buckets
+                  </button>
+                  <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb")} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
+                    DynamoDB Tables
+                  </button>
+                  <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openLambdaConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
+                    Lambda Functions
+                  </button>
+                  <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openAPIGatewayConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
+                    API Gateway
+                  </button>
+                  <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openSecretsConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
+                    Secrets Manager
+                  </button>
+                  <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openSSMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
+                    Parameter Store
+                  </button>
+                  <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => openActionOrFallback(actions?.openIAMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                    <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
+                    IAM Roles
+                  </button>
+                  <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                    Inspect
+                  </button>
+                </div>
+              </div>
+
+              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
+                {PLATFORM_SERVICE_KINDS.map((kind, i) => {
+                  const items = PLATFORM_SERVICES.filter((service) => service.kind === kind);
+                  return (
+                    <div key={kind}>
+                      <p className={`px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider ${i > 0 ? "pt-2" : "py-1"}`}>
+                        {SERVICE_KIND_LABEL[kind]}
+                      </p>
+                      {items.map((service) => {
+                        const ServiceIcon = service.icon;
+                        const itemContent = (
+                          <>
+                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                            {service.label}
+                            {service.id === "mailpit" && mailpit.unread > 0 && (
+                              <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
+                                {mailpit.unread > 99 ? "99+" : mailpit.unread}
+                              </span>
+                            )}
+                          </>
+                        );
+                        const action = service.action;
+                        return (
+                          <div key={service.id} className="flex items-center gap-1">
+                            {action.type === "link" ? (
+                              <Link
+                                href={action.href}
+                                onClick={closeAllMenus}
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </Link>
+                            ) : (
+                              <button
+                                onClick={() => openModal(action.modalKey)}
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                              >
+                                {itemContent}
+                              </button>
+                            )}
+                            <button
+                              onClick={() => openInspectTarget(service.id)}
+                              className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                            >
+                              Inspect
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
+                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Docs</p>
+                <Link href="/docs" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm font-medium text-indigo-700 rounded-lg hover:bg-indigo-50 transition-colors">
+                  <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+                  Docs Hub
+                </Link>
+                <Link href="/aws-emulator" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                  AWS Emulator
+                </Link>
+                <Link href="/s3" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
+                  S3 Buckets
+                </Link>
+                <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
+                  DynamoDB
+                </Link>
+                <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
+                  Lambda
+                </Link>
+                <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
+                  API Gateway
+                </Link>
+                <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
+                  Secrets Manager
+                </Link>
+                <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
+                  Parameter Store
+                </Link>
+                <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
+                  IAM &amp; STS
+                </Link>
+                {PLATFORM_SERVICES.map((service) => {
+                  const ServiceIcon = service.icon;
+                  const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
+                  return (
+                    <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                      {service.label}
+                    </Link>
+                  );
+                })}
+              </div>
+
+              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
+                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Dev Tools</p>
+                <button onClick={() => openModal("logs")} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
+                  System Logs
+                </button>
+              </div>
+
+              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
+                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Account</p>
+                <div className="px-3 py-2">
+                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+                    {profile?.active_project_label || "Default"}
+                  </span>
+                </div>
+                <Link href="/profile" onClick={closeAllMenus} className={`flex items-center w-full px-3 py-2 text-sm rounded-lg transition-colors ${
+                  activePage === "profile"
+                    ? "text-blue-700 bg-blue-50"
+                    : "text-gray-700 hover:bg-gray-50"
+                }`}>
+                  <UserCircleIcon className={`h-4 w-4 mr-3 ${activePage === "profile" ? "text-blue-500" : "text-gray-400"}`} />
+                  Profile & Preferences
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      </header>
+
+      {showLogs && !actions && (
+        <LogViewer isOpen={showLogs} onClose={() => setShowLogs(false)} />
+      )}
+
+      {showMailpit && !actions && (
+        <MailpitModal onClose={() => setShowMailpit(false)} />
+      )}
+
+      {showRedis && !actions && (
+        <RedisModal onClose={() => setShowRedis(false)} />
+      )}
+    </>
+  );
+}

--- a/localcloud-gui/src/components/ThemeableCodeBlock.tsx
+++ b/localcloud-gui/src/components/ThemeableCodeBlock.tsx
@@ -35,12 +35,14 @@ interface ThemeableCodeBlockProps {
   code: string;
   language: string;
   showThemeSelector?: boolean;
+  showCopyButton?: boolean;
 }
 
 export default function ThemeableCodeBlock({
   code,
   language,
   showThemeSelector = true,
+  showCopyButton = true,
 }: ThemeableCodeBlockProps) {
   const { profile, updateProfile } = usePreferences();
   const defaultTheme = (profile?.highlight_theme as HighlightTheme) || "github";
@@ -86,6 +88,7 @@ export default function ThemeableCodeBlock({
 
   return (
     <div className="relative group">
+      {(showThemeSelector || showCopyButton) && (
       <div className="flex items-center justify-end gap-2 mb-2">
         {showThemeSelector && (
           <>
@@ -113,6 +116,7 @@ export default function ThemeableCodeBlock({
             </select>
           </>
         )}
+        {showCopyButton && (
         <button
           onClick={copy}
           className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100"
@@ -120,7 +124,9 @@ export default function ThemeableCodeBlock({
         >
           <ClipboardDocumentIcon className="h-4 w-4" />
         </button>
+        )}
       </div>
+      )}
       <pre
         className={`rounded-lg p-4 overflow-x-auto text-sm whitespace-pre-wrap ${
           isDarkTheme ? "bg-gray-900" : "bg-gray-100"

--- a/localcloud-gui/src/context/DashboardNavContext.tsx
+++ b/localcloud-gui/src/context/DashboardNavContext.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { createContext, ReactNode, useContext } from "react";
+import { ModalKey } from "@/types";
+
+export type InspectTargetId =
+  | "aws-emulator"
+  | "s3"
+  | "dynamodb"
+  | "lambda"
+  | "apigateway"
+  | "secretsmanager"
+  | "ssm"
+  | "iam"
+  | "postgres"
+  | "redis"
+  | "keycloak"
+  | "mailpit";
+
+export type DashboardNavActions = {
+  openS3Buckets: () => void;
+  openDynamoDBViewer: () => void;
+  openLambdaConfig: () => void;
+  openLambdaViewer: () => void;
+  openAPIGatewayConfig: () => void;
+  openAPIGatewayViewer: () => void;
+  openSecretsConfig: () => void;
+  openSecretsViewer: () => void;
+  openSSMConfig: () => void;
+  openSSMViewer: () => void;
+  openIAMConfig: () => void;
+  openIAMRoleViewer: () => void;
+  openInspectTarget: (target: InspectTargetId) => void;
+  openModal: (modalKey: ModalKey) => void;
+  openLogs: () => void;
+  onAfterProjectSwitch?: () => Promise<void>;
+};
+
+const DashboardNavContext = createContext<DashboardNavActions | null>(null);
+
+type DashboardNavProviderProps = {
+  actions: DashboardNavActions | null;
+  children: ReactNode;
+};
+
+export function DashboardNavProvider({
+  actions,
+  children,
+}: DashboardNavProviderProps) {
+  return (
+    <DashboardNavContext.Provider value={actions}>
+      {children}
+    </DashboardNavContext.Provider>
+  );
+}
+
+export function useDashboardNav() {
+  return useContext(DashboardNavContext);
+}

--- a/localcloud-gui/src/lib/cliPlaybook.ts
+++ b/localcloud-gui/src/lib/cliPlaybook.ts
@@ -1,0 +1,493 @@
+import type {
+  APIGatewayConfig,
+  DynamoDBTableConfig,
+  IAMRoleConfig,
+  LambdaFunctionConfig,
+  Resource,
+  S3BucketConfig,
+  SavedConfig,
+  SecretsManagerConfig,
+  SSMParameterConfig,
+} from "@/types";
+
+export type CliPreambleMode = "local" | "aws";
+
+export interface CliPlaybookEntry {
+  id: string;
+  label: string;
+  resourceType: string;
+  resourceName: string;
+  source: "saved-config" | "live-only" | "matched";
+  savedConfigId?: number;
+  savedConfigName?: string;
+  command: string;
+  isLive: boolean;
+  note?: string;
+}
+
+export const LOCAL_ENV_PREAMBLE = `# LCK AWS CLI — LocalCloud Kit / MiniStack (run once per shell)
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_ENDPOINT_URL=http://localhost:4566
+# Optional for some S3 emulator setups:
+# export AWS_S3_FORCE_PATH_STYLE=true`;
+
+export const AWS_ENV_PREAMBLE = `# AWS CLI (run once per shell — use your profile, SSO, or role)
+export AWS_DEFAULT_REGION=us-east-1
+# If AWS_ENDPOINT_URL is set from a prior LCK session, unset it before targeting real AWS:
+# unset AWS_ENDPOINT_URL
+# aws sso login
+# or: export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...`;
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function normalizeResourceType(type: string): string {
+  if (type === "secrets") return "secretsmanager";
+  return type;
+}
+
+/** Resolve the AWS resource name from a saved config payload. */
+export function resourceNameFromConfig(
+  resourceType: string,
+  config: Record<string, unknown>
+): string | null {
+  const t = normalizeResourceType(resourceType);
+  switch (t) {
+    case "s3":
+      return (config.bucketName as string) || null;
+    case "dynamodb":
+      return (config.tableName as string) || null;
+    case "lambda":
+      return (config.functionName as string) || null;
+    case "apigateway":
+      return (config.apiName as string) || null;
+    case "secretsmanager":
+      return (config.secretName as string) || null;
+    case "ssm":
+      return (config.parameterName as string) || null;
+    case "iam":
+      return (config.roleName as string) || null;
+    default:
+      return null;
+  }
+}
+
+function lines(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter(Boolean).join("\n");
+}
+
+export function configToAwsCli(
+  resourceType: string,
+  config: Record<string, unknown>
+): { command: string; note?: string } {
+  const t = normalizeResourceType(resourceType);
+
+  switch (t) {
+    case "s3":
+      return s3Command(config as unknown as S3BucketConfig);
+    case "dynamodb":
+      return dynamodbCommand(config as unknown as DynamoDBTableConfig);
+    case "lambda":
+      return lambdaCommand(config as unknown as LambdaFunctionConfig);
+    case "apigateway":
+      return apigatewayCommand(config as unknown as APIGatewayConfig);
+    case "secretsmanager":
+      return secretsCommand(config as unknown as SecretsManagerConfig);
+    case "ssm":
+      return ssmCommand(config as unknown as SSMParameterConfig);
+    case "iam":
+      return iamCommand(config as unknown as IAMRoleConfig);
+    default:
+      return { command: `# Unsupported resource type: ${resourceType}` };
+  }
+}
+
+function s3Command(config: S3BucketConfig): { command: string } {
+  const bucket = config.bucketName;
+  const region = config.region || "us-east-1";
+  const parts: string[] = [];
+
+  if (region !== "us-east-1") {
+    parts.push(
+      `aws s3api create-bucket --bucket ${shellQuote(bucket)} --region ${region} \\`,
+      `  --create-bucket-configuration LocationConstraint=${region}`
+    );
+  } else {
+    parts.push(`aws s3api create-bucket --bucket ${shellQuote(bucket)}`);
+  }
+
+  if (config.versioning) {
+    parts.push(
+      `aws s3api put-bucket-versioning --bucket ${shellQuote(bucket)} \\`,
+      `  --versioning-configuration Status=Enabled`
+    );
+  }
+
+  if (config.encryption) {
+    parts.push(
+      `aws s3api put-bucket-encryption --bucket ${shellQuote(bucket)} \\`,
+      `  --server-side-encryption-configuration '${JSON.stringify({
+        Rules: [
+          {
+            ApplyServerSideEncryptionByDefault: { SSEAlgorithm: "AES256" },
+          },
+        ],
+      })}'`
+    );
+  }
+
+  return { command: parts.join("\n\n") };
+}
+
+function dynamodbCommand(config: DynamoDBTableConfig): { command: string } {
+  const attrNames = new Set<string>();
+  attrNames.add(config.partitionKey);
+  if (config.sortKey) attrNames.add(config.sortKey);
+  for (const gsi of config.gsis || []) {
+    attrNames.add(gsi.partitionKey);
+    if (gsi.sortKey) attrNames.add(gsi.sortKey);
+  }
+
+  const attributeDefinitions = [...attrNames].map((name) => ({
+    AttributeName: name,
+    AttributeType: "S",
+  }));
+
+  const keySchema: { AttributeName: string; KeyType: string }[] = [
+    { AttributeName: config.partitionKey, KeyType: "HASH" },
+  ];
+  if (config.sortKey) {
+    keySchema.push({ AttributeName: config.sortKey, KeyType: "RANGE" });
+  }
+
+  const billingMode = config.billingMode || "PAY_PER_REQUEST";
+  const gsis = config.gsis || [];
+  const cmdParts = [
+    `aws dynamodb create-table \\`,
+    `  --table-name ${shellQuote(config.tableName)} \\`,
+    `  --attribute-definitions '${JSON.stringify(attributeDefinitions)}' \\`,
+    `  --key-schema '${JSON.stringify(keySchema)}' \\`,
+    `  --billing-mode ${billingMode}`,
+  ];
+
+  if (billingMode === "PROVISIONED") {
+    const last = cmdParts.length - 1;
+    cmdParts[last] = `${cmdParts[last]} \\`;
+    cmdParts.push(
+      `  --provisioned-throughput ReadCapacityUnits=${config.readCapacity ?? 5},WriteCapacityUnits=${config.writeCapacity ?? 5}`
+    );
+  }
+
+  if (gsis.length > 0) {
+    const last = cmdParts.length - 1;
+    if (!cmdParts[last].endsWith(" \\")) {
+      cmdParts[last] = `${cmdParts[last]} \\`;
+    }
+    const globalSecondaryIndexes = gsis.map((gsi) => {
+      const gsiKeySchema: { AttributeName: string; KeyType: string }[] = [
+        { AttributeName: gsi.partitionKey, KeyType: "HASH" },
+      ];
+      if (gsi.sortKey) {
+        gsiKeySchema.push({ AttributeName: gsi.sortKey, KeyType: "RANGE" });
+      }
+      const index: Record<string, unknown> = {
+        IndexName: gsi.indexName,
+        KeySchema: gsiKeySchema,
+        Projection: { ProjectionType: gsi.projectionType || "ALL" },
+      };
+      if (gsi.projectionType === "INCLUDE" && gsi.nonKeyAttributes?.length) {
+        (index.Projection as Record<string, unknown>).NonKeyAttributes =
+          gsi.nonKeyAttributes;
+      }
+      if (billingMode === "PROVISIONED") {
+        index.ProvisionedThroughput = {
+          ReadCapacityUnits: config.readCapacity ?? 5,
+          WriteCapacityUnits: config.writeCapacity ?? 5,
+        };
+      }
+      return index;
+    });
+    cmdParts.push(`  --global-secondary-indexes '${JSON.stringify(globalSecondaryIndexes)}'`);
+  }
+
+  return { command: cmdParts.join(" \\\n") };
+}
+
+function lambdaCommand(config: LambdaFunctionConfig): { command: string; note?: string } {
+  const name = config.functionName;
+  const runtime = config.runtime || "python3.12";
+  const handler = config.handler || "lambda_function.lambda_handler";
+  const desc =
+    config.description && config.description.trim()
+      ? ` \\\n  --description ${shellQuote(config.description)}`
+      : "";
+
+  return {
+    command: lines(
+      "# Package your handler first, e.g.: zip -j function.zip lambda_function.py",
+      `aws lambda create-function \\`,
+      `  --function-name ${shellQuote(name)} \\`,
+      `  --runtime ${runtime} \\`,
+      `  --role arn:aws:iam::000000000000:role/service-role/placeholder \\`,
+      `  --handler ${handler} \\`,
+      `  --zip-file fileb://function.zip${desc}`
+    ),
+    note: "Replace the IAM role ARN and function.zip path for your environment.",
+  };
+}
+
+function apigatewayCommand(config: APIGatewayConfig): { command: string } {
+  const name = shellQuote(config.apiName);
+  if (config.description?.trim()) {
+    return {
+      command: `aws apigateway create-rest-api --name ${name} --description ${shellQuote(config.description)}`,
+    };
+  }
+  return { command: `aws apigateway create-rest-api --name ${name}` };
+}
+
+function secretsCommand(config: SecretsManagerConfig): { command: string; note?: string } {
+  const parts = [
+    `aws secretsmanager create-secret \\`,
+    `  --name ${shellQuote(config.secretName)} \\`,
+    `  --secret-string ${shellQuote("<your-secret-value>")}`,
+  ];
+  if (config.description?.trim()) {
+    parts.push(`  --description ${shellQuote(config.description)}`);
+  }
+  if (config.kmsKeyId?.trim()) {
+    parts.push(`  --kms-key-id ${shellQuote(config.kmsKeyId)}`);
+  }
+  if (config.tags && Object.keys(config.tags).length > 0) {
+    const tagPairs = Object.entries(config.tags)
+      .map(([k, v]) => `Key=${k},Value=${v}`)
+      .join(" ");
+    parts.push(`  --tags ${tagPairs}`);
+  }
+  return {
+    command: parts.join(" \\\n"),
+    note: config.secretValue
+      ? "Secret value is not shown in the playbook. Set --secret-string or use a env var."
+      : undefined,
+  };
+}
+
+function ssmCommand(config: SSMParameterConfig): { command: string } {
+  const parts = [
+    `aws ssm put-parameter \\`,
+    `  --name ${shellQuote(config.parameterName)} \\`,
+    `  --value ${shellQuote(config.parameterValue)} \\`,
+    `  --type ${config.parameterType || "String"} \\`,
+    `  --overwrite`,
+  ];
+  if (config.description?.trim()) {
+    parts.push(`  --description ${shellQuote(config.description)}`);
+  }
+  return { command: parts.join(" \\\n") };
+}
+
+function iamCommand(config: IAMRoleConfig): { command: string } {
+  const trustPolicy =
+    config.trustPolicy?.trim() ||
+    JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "lambda.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    });
+
+  const parts = [
+    `aws iam create-role \\`,
+    `  --role-name ${shellQuote(config.roleName)} \\`,
+    `  --assume-role-policy-document ${shellQuote(trustPolicy)}`,
+  ];
+  if (config.description?.trim()) {
+    parts.push(`  --description ${shellQuote(config.description)}`);
+  }
+  if (config.path && config.path !== "/") {
+    parts.push(`  --path ${shellQuote(config.path)}`);
+  }
+  return { command: parts.join(" \\\n") };
+}
+
+export function minimalCliForResource(resource: Resource): { command: string; note?: string } {
+  const name = shellQuote(resource.name);
+  switch (resource.type) {
+    case "s3":
+      return { command: `aws s3api create-bucket --bucket ${name}` };
+    case "dynamodb":
+      return {
+        command: lines(
+          `aws dynamodb create-table \\`,
+          `  --table-name ${name} \\`,
+          `  --attribute-definitions AttributeName=pk,AttributeType=S \\`,
+          `  --key-schema AttributeName=pk,KeyType=HASH \\`,
+          `  --billing-mode PAY_PER_REQUEST`
+        ),
+        note: "Minimal schema only. Save a config when creating for full CLI.",
+      };
+    case "lambda":
+      return {
+        command: lines(
+          "# Package code: zip -j function.zip lambda_function.py",
+          `aws lambda create-function \\`,
+          `  --function-name ${name} \\`,
+          `  --runtime python3.12 \\`,
+          `  --role arn:aws:iam::000000000000:role/service-role/placeholder \\`,
+          `  --handler lambda_function.lambda_handler \\`,
+          `  --zip-file fileb://function.zip`
+        ),
+        note: "Save a config when creating for runtime/handler details.",
+      };
+    case "apigateway":
+      return { command: `aws apigateway create-rest-api --name ${name}` };
+    case "secretsmanager":
+      return {
+        command: `aws secretsmanager create-secret --name ${name} --secret-string ${shellQuote("<your-secret-value>")}`,
+        note: "Secret value is not recoverable from the emulator. Set your own --secret-string.",
+      };
+    case "ssm":
+      return {
+        command: lines(
+          `aws ssm put-parameter \\`,
+          `  --name ${name} \\`,
+          `  --value ${shellQuote("<value>")} \\`,
+          `  --type String \\`,
+          `  --overwrite`
+        ),
+        note: "Save a config when creating for type and value.",
+      };
+    case "iam":
+      return {
+        command: lines(
+          `aws iam create-role \\`,
+          `  --role-name ${name} \\`,
+          `  --assume-role-policy-document '${JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          })}'`
+        ),
+        note: "Save a config when creating for trust policy details.",
+      };
+    default:
+      return { command: `# No CLI template for ${resource.type}` };
+  }
+}
+
+export function buildPlaybookEntries(
+  savedConfigs: SavedConfig[],
+  liveResources: Resource[],
+  projectId: number | null
+): CliPlaybookEntry[] {
+  const projectConfigs = savedConfigs.filter((c) => c.project_id === projectId);
+  const liveByName = new Map<string, Resource>();
+  for (const r of liveResources) {
+    liveByName.set(`${r.type}:${r.name}`, r);
+  }
+
+  const entries: CliPlaybookEntry[] = [];
+  const coveredLive = new Set<string>();
+
+  for (const cfg of projectConfigs) {
+    const normalizedType = normalizeResourceType(cfg.resource_type);
+    const config = cfg.config as Record<string, unknown>;
+    const resourceName = resourceNameFromConfig(cfg.resource_type, config);
+    const { command, note } = configToAwsCli(cfg.resource_type, config);
+    const liveKey =
+      resourceName != null ? `${normalizedType}:${resourceName}` : null;
+    const isLive = liveKey != null && liveByName.has(liveKey);
+    if (isLive && liveKey) coveredLive.add(liveKey);
+
+    entries.push({
+      id: `config-${cfg.id}`,
+      label: cfg.name,
+      resourceType: normalizedType,
+      resourceName: resourceName || cfg.name,
+      source: isLive ? "matched" : "saved-config",
+      savedConfigId: cfg.id,
+      savedConfigName: cfg.name,
+      command,
+      isLive,
+      note,
+    });
+  }
+
+  for (const resource of liveResources) {
+    const key = `${resource.type}:${resource.name}`;
+    if (coveredLive.has(key)) continue;
+    const { command, note } = minimalCliForResource(resource);
+    entries.push({
+      id: resource.id,
+      label: resource.name,
+      resourceType: resource.type,
+      resourceName: resource.name,
+      source: "live-only",
+      command,
+      isLive: true,
+      note,
+    });
+  }
+
+  const typeOrder = [
+    "s3",
+    "dynamodb",
+    "lambda",
+    "apigateway",
+    "secretsmanager",
+    "ssm",
+    "iam",
+  ];
+  entries.sort((a, b) => {
+    const ta = typeOrder.indexOf(a.resourceType);
+    const tb = typeOrder.indexOf(b.resourceType);
+    if (ta !== tb) return (ta === -1 ? 99 : ta) - (tb === -1 ? 99 : tb);
+    return a.resourceName.localeCompare(b.resourceName);
+  });
+
+  return entries;
+}
+
+export function buildFullScript(
+  preambleMode: CliPreambleMode,
+  entries: CliPlaybookEntry[],
+  projectLabel: string
+): string {
+  const preamble = preambleMode === "local" ? LOCAL_ENV_PREAMBLE : AWS_ENV_PREAMBLE;
+  const header = `#!/usr/bin/env bash
+# LocalCloud Kit CLI playbook — ${projectLabel}
+# Resource commands use plain AWS CLI (no --endpoint-url).
+# Set AWS_ENDPOINT_URL in the preamble for LCK AWS CLI, or see the note in the AWS CLI block.
+set -euo pipefail
+
+`;
+  const blocks = entries.map((e) => {
+    const comment = `# ${e.resourceType}: ${e.resourceName}${e.savedConfigName ? ` (${e.savedConfigName})` : ""}`;
+    return `${comment}\n${e.command}`;
+  });
+  return `${header}${preamble}\n\n${blocks.join("\n\n")}\n`;
+}
+
+export function inventorySummary(
+  liveResources: Resource[]
+): { type: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const r of liveResources) {
+    counts.set(r.type, (counts.get(r.type) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => a.type.localeCompare(b.type));
+}


### PR DESCRIPTION
## Summary
- **Profile CLI Playbook**: per-project portable `aws` rebuild commands from saved configs and live inventory, with LCK AWS CLI / AWS CLI environment blocks, copy-all, and `.sh` download; saved configurations managed separately with checkbox bulk delete.
- **DashboardNavBar**: extracted shared navbar (`DashboardNavBar` + `DashboardNavContext`) so Profile uses the same Resources / Services / Docs / project navigation as the dashboard.
- **README**: updated dashboard screenshot set (empty state through multi-resource view).

## Test plan
- [ ] Open `/profile` — full dashboard navbar visible; Profile highlighted in account menu
- [ ] CLI Playbook: toggle LCK AWS CLI vs AWS CLI env blocks; verify `unset AWS_ENDPOINT_URL` is a comment only on AWS CLI tab
- [ ] Expand rebuild command rows — single clipboard on row header; no trash on command rows
- [ ] Saved configurations: select configs, bulk delete; confirm emulator resources unchanged
- [ ] Copy all / Download `.sh` produces valid script with preamble + commands
- [ ] Dashboard `/` still opens resource modals/viewers from navbar dropdowns
- [ ] `cd localcloud-gui && npm run lint && npm run build` pass