### PR TITLE
feat: introduce design system with UI primitives and dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ All notable changes to LocalCloud Kit will be documented in this file.
 
 ### Added
 
+- **Design System**: IBM Plex Sans/Mono typography, indigo-accent design tokens with light/dark palettes, and a shared UI primitives set (buttons, badges, inputs, cards) applied across the Dashboard, Create Resource, S3, DynamoDB, Redis, Connect, and header/navigation screens.
+- **Profile**: Auto/Light/Dark theme preference, toggleable from the profile menu and persisted per user.
+
 ### Changed
+
+- **GUI**: Redesigned the Dashboard, create-resource flow, S3 browser, DynamoDB viewer, Redis cache browser, Connect page, and app header/status bar onto the new design system — no changes to underlying data flow or API calls.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ The **Profile** page (`/profile`) includes a **CLI Playbook** for the active pro
 - **Live Monitoring**: Real-time status tracking and health checks
 - **Log Viewer**: Stream logs with filtering and search capabilities
 - **Hot Reloading**: Instant updates during development
+- **Design System**: Consistent IBM Plex typography, indigo accent, and light/dark theming across every screen
+- **Theme Preference**: Auto/Light/Dark toggle from the profile menu, synced across sessions
 
 #### Shell Automation
 

--- a/localcloud-api/db.js
+++ b/localcloud-api/db.js
@@ -24,6 +24,7 @@ db.exec(`
     id                 INTEGER PRIMARY KEY DEFAULT 1,
     preferred_language TEXT NOT NULL DEFAULT 'typescript',
     highlight_theme    TEXT NOT NULL DEFAULT 'github-dark',
+    theme              TEXT NOT NULL DEFAULT 'auto',
     display_name       TEXT DEFAULT 'Developer',
     active_project_id  INTEGER REFERENCES projects(id) ON DELETE SET NULL,
     created_at         DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -46,6 +47,14 @@ db.exec(`
     fetched_at    DATETIME DEFAULT CURRENT_TIMESTAMP
   );
 `);
+
+// Migrate existing databases created before the `theme` column existed
+const profileColumns = db.prepare("PRAGMA table_info(user_profile)").all();
+if (!profileColumns.some((col) => col.name === "theme")) {
+  db.exec(
+    "ALTER TABLE user_profile ADD COLUMN theme TEXT NOT NULL DEFAULT 'auto'"
+  );
+}
 
 // Seed default project
 let defaultProject = db

--- a/localcloud-api/routes/profile.js
+++ b/localcloud-api/routes/profile.js
@@ -16,11 +16,12 @@ router.get("/profile", (req, res) => {
 });
 
 router.put("/profile", (req, res) => {
-  const { preferred_language, highlight_theme, display_name, active_project_id } = req.body;
+  const { preferred_language, highlight_theme, theme, display_name, active_project_id } = req.body;
   const sets = [];
   const vals = [];
   if (preferred_language !== undefined) { sets.push("preferred_language = ?"); vals.push(preferred_language); }
   if (highlight_theme !== undefined) { sets.push("highlight_theme = ?"); vals.push(highlight_theme); }
+  if (theme !== undefined) { sets.push("theme = ?"); vals.push(theme); }
   if (display_name !== undefined) { sets.push("display_name = ?"); vals.push(display_name); }
   if (active_project_id !== undefined) { sets.push("active_project_id = ?"); vals.push(active_project_id); }
   if (sets.length === 0) return res.status(400).json({ success: false, error: "No fields to update" });

--- a/localcloud-gui/package-lock.json
+++ b/localcloud-gui/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.0.18",
         "@iconify/react": "^6.0.2",
         "axios": "^1.20.0",
+        "clsx": "^2.1.1",
         "fflate": "^0.8.3",
         "framer-motion": "^12.43.0",
         "highlight.js": "^11.12.0",
@@ -2374,6 +2375,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/localcloud-gui/package.json
+++ b/localcloud-gui/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^2.0.18",
     "@iconify/react": "^6.0.2",
     "axios": "^1.20.0",
+    "clsx": "^2.1.1",
     "fflate": "^0.8.3",
     "framer-motion": "^12.43.0",
     "highlight.js": "^11.12.0",

--- a/localcloud-gui/src/app/cache/page.tsx
+++ b/localcloud-gui/src/app/cache/page.tsx
@@ -1,21 +1,13 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from "react";
-import {
-  ArrowPathIcon,
-  ChevronDownIcon,
-  DocumentTextIcon,
-  KeyIcon,
-  LinkIcon,
-  TrashIcon,
-  PlusCircleIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { AnimatePresence, motion, type Variants } from "framer-motion";
 import { cacheApi } from "@/services/api";
 import DocPageNav from "@/components/DocPageNav";
 import ServiceStatusBadge from "@/components/ServiceStatusBadge";
 import Link from "next/link";
+import { Badge, Button, Card, IconButton, Input, SearchInput, SegmentedControl } from "@/components/ui";
 
 const formVariants: Variants = {
   hidden: { opacity: 0, y: -8 },
@@ -31,6 +23,8 @@ const formVariants: Variants = {
   },
 };
 
+type CacheAction = "set" | "get" | "delete";
+
 export default function CachePage() {
   const [key, setKey] = useState("");
   const [value, setValue] = useState("");
@@ -39,10 +33,10 @@ export default function CachePage() {
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<{ status: string; info?: unknown } | null>(null);
   const [allKeys, setAllKeys] = useState<{ key: string; value: string }[]>([]);
-  const [activeAction, setActiveAction] = useState<
-    "set" | "get" | "delete" | null
-  >("set");
+  const [activeAction, setActiveAction] = useState<CacheAction | null>("set");
   const [showConnection, setShowConnection] = useState(false);
+  const [confirmFlush, setConfirmFlush] = useState(false);
+  const [keyFilter, setKeyFilter] = useState("");
   const connectionRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -175,6 +169,11 @@ export default function CachePage() {
     }
   };
 
+  const handleConfirmFlush = async () => {
+    await handleFlush();
+    setConfirmFlush(false);
+  };
+
   const handleShowAllKeys = async () => {
     setLoading(true);
     setError(null);
@@ -197,63 +196,73 @@ export default function CachePage() {
     handleShowAllKeys();
   }, []);
 
+  const isRunning = status?.status === "running";
+  const filteredKeys = keyFilter.trim()
+    ? allKeys.filter((item) =>
+        item.key.toLowerCase().includes(keyFilter.trim().toLowerCase())
+      )
+    : allKeys;
+
   return (
-    <main className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
+    <main className="min-h-screen bg-bg">
       <DocPageNav title="LocalCloud Kit" subtitle="Redis">
         <ServiceStatusBadge service="redis" name="Redis" />
         <div className="relative" ref={connectionRef}>
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="lucide:link"
             onClick={() => setShowConnection((v) => !v)}
-            className="flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors"
           >
-            <LinkIcon className="h-4 w-4 mr-1.5" />
             Connection
-            <ChevronDownIcon
-              className={`h-4 w-4 ml-1.5 transition-transform ${showConnection ? "rotate-180" : ""}`}
+            <Icon
+              icon="lucide:chevron-down"
+              width={13}
+              className={`transition-transform ${showConnection ? "rotate-180" : ""}`}
             />
-          </button>
+          </Button>
           {showConnection && (
-            <div className="absolute right-0 mt-1 w-80 bg-white rounded-xl shadow-lg border border-gray-200 p-4 z-50">
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+            <div className="absolute right-0 mt-1.5 w-80 bg-surface border border-border rounded-xl shadow-e2 p-4 z-50">
+              <p className="text-[11px] font-semibold text-faint uppercase tracking-wider mb-3">
                 Connection details
               </p>
-              <div className="space-y-4 text-sm">
+              <div className="flex flex-col gap-4 text-sm">
                 <div>
-                  <p className="text-xs font-medium text-gray-500 mb-1.5">
+                  <p className="text-xs font-medium text-muted mb-1.5">
                     From your app (localhost)
                   </p>
-                  <div className="grid grid-cols-2 gap-2">
+                  <div className="grid grid-cols-2 gap-1.5 text-xs">
                     <div className="flex justify-between">
-                      <span className="text-gray-500">Host</span>
-                      <span className="font-mono text-gray-900">localhost</span>
+                      <span className="text-muted">Host</span>
+                      <span className="font-mono text-ink">localhost</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500">Port</span>
-                      <span className="font-mono text-gray-900">6380</span>
+                      <span className="text-muted">Port</span>
+                      <span className="font-mono text-ink">6380</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500">Password</span>
-                      <span className="font-mono text-gray-900">(none)</span>
+                      <span className="text-muted">Password</span>
+                      <span className="font-mono text-ink">(none)</span>
                     </div>
                     <div className="flex justify-between">
-                      <span className="text-gray-500">Database</span>
-                      <span className="font-mono text-gray-900">0</span>
+                      <span className="text-muted">Database</span>
+                      <span className="font-mono text-ink">0</span>
                     </div>
                   </div>
-                  <p className="mt-2 text-xs text-gray-500">
-                    <span className="font-medium">Connection string:</span>{" "}
-                    <code className="bg-gray-100 px-1.5 py-0.5 rounded font-mono block mt-1">
+                  <p className="mt-2 text-xs text-muted">
+                    <span className="font-medium text-ink-2">Connection string:</span>
+                    <code className="block mt-1 bg-surface-2 border border-border px-1.5 py-1 rounded font-mono text-ink-2">
                       redis://localhost:6380
                     </code>
                   </p>
                 </div>
-                <div className="pt-3 border-t border-gray-100">
-                  <p className="text-xs font-medium text-gray-500 mb-1.5">
+                <div className="pt-3 border-t border-divider">
+                  <p className="text-xs font-medium text-muted mb-1.5">
                     From Docker (same network)
                   </p>
-                  <p className="text-gray-600">
-                    Host: <code className="font-mono">localcloud-redis</code>,
-                    Port: <code className="font-mono">6379</code>
+                  <p className="text-xs text-muted">
+                    Host: <code className="font-mono text-ink-2">localcloud-redis</code>, Port:{" "}
+                    <code className="font-mono text-ink-2">6379</code>
                   </p>
                 </div>
               </div>
@@ -262,79 +271,50 @@ export default function CachePage() {
         </div>
         <Link
           href="/redis"
-          className="flex items-center px-3 py-1.5 text-sm font-medium text-indigo-700 bg-indigo-50 rounded-lg hover:bg-indigo-100 transition-colors"
+          className="no-underline inline-flex items-center gap-1.5 h-8 px-3.5 rounded-lg border border-border-strong bg-surface text-ink-2 text-[13px] font-medium transition-colors hover:bg-surface-2"
         >
-          <DocumentTextIcon className="h-4 w-4 mr-1.5" />
+          <Icon icon="lucide:book-open" width={14} />
           Documentation
         </Link>
       </DocPageNav>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:items-stretch">
-          {/* Left: Operations */}
-          <div className="space-y-6">
-            {/* Operations */}
-            <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 min-h-[32rem] flex flex-col">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-base font-semibold text-gray-900">
-                  Operations
-                </h2>
-                {status && (
-                  <div className="flex items-center gap-3 text-sm">
-                    {status.status === "running" ? (
-                      <>
-                        <span className="flex items-center gap-1.5">
-                          <span className="h-2 w-2 rounded-full bg-emerald-500" />
-                          <span className="text-emerald-700">Connected</span>
-                        </span>
-                        <span className="text-gray-500">
-                          {allKeys.length} key{allKeys.length !== 1 ? "s" : ""}
-                        </span>
-                      </>
-                    ) : (
-                      <span className="flex items-center gap-1.5 text-red-600">
-                        <span className="h-2 w-2 rounded-full bg-red-500" />
-                        Not connected
-                      </span>
-                    )}
-                  </div>
-                )}
-              </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-5">
+        <div className="flex items-center gap-3 flex-wrap">
+          <Icon icon="logos:redis" width={22} />
+          <div className="flex flex-col">
+            <h1 className="text-lg font-semibold text-ink tracking-tight">Redis cache</h1>
+            <p className="text-xs text-muted">Set, get, delete or flush keys</p>
+          </div>
+          {status ? (
+            <Badge tone={isRunning ? "success" : "danger"}>
+              {isRunning ? "Running" : "Not connected"}
+            </Badge>
+          ) : (
+            <Badge tone="neutral">Checking…</Badge>
+          )}
+          <span className="ml-auto font-mono text-xs text-muted">
+            {allKeys.length} key{allKeys.length !== 1 ? "s" : ""}
+          </span>
+        </div>
 
-              <div className="flex flex-wrap gap-2 mb-6">
-                <button
-                  onClick={() => setActiveAction("set")}
-                  className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    activeAction === "set"
-                      ? "bg-emerald-600 text-white"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                  }`}
-                >
-                  <PlusCircleIcon className="h-4 w-4" />
-                  Set
-                </button>
-                <button
-                  onClick={() => setActiveAction("get")}
-                  className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    activeAction === "get"
-                      ? "bg-blue-600 text-white"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                  }`}
-                >
-                  <MagnifyingGlassIcon className="h-4 w-4" />
-                  Get
-                </button>
-                <button
-                  onClick={() => setActiveAction("delete")}
-                  className={`flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-                    activeAction === "delete"
-                      ? "bg-red-600 text-white"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
-                  }`}
-                >
-                  <TrashIcon className="h-4 w-4" />
-                  Delete
-                </button>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+          {/* Left: Operations */}
+          <div className="flex flex-col gap-6">
+            <Card className="p-4 flex flex-col gap-4">
+              <div className="flex items-center justify-between flex-wrap gap-3">
+                <div className="flex items-center gap-2">
+                  <Icon icon="lucide:plus-circle" width={15} className="text-primary" />
+                  <span className="text-[13px] font-semibold text-ink">Operations</span>
+                </div>
+                <SegmentedControl
+                  options={[
+                    { value: "set", label: "Set" },
+                    { value: "get", label: "Get" },
+                    { value: "delete", label: "Delete" },
+                  ]}
+                  value={activeAction ?? "set"}
+                  onChange={(v) => setActiveAction(v)}
+                />
               </div>
 
               <AnimatePresence mode="wait">
@@ -345,38 +325,36 @@ export default function CachePage() {
                     initial="hidden"
                     animate="visible"
                     exit="exit"
-                    className="space-y-4"
+                    className="flex flex-col gap-3"
                   >
-                    <label className="block text-xs font-medium text-gray-500 mb-1">
-                      Key
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-ink-2">Key</span>
+                      <Input
+                        mono
+                        placeholder="session:user#42"
+                        value={key}
+                        onChange={(e) => setKey(e.target.value)}
+                      />
                     </label>
-                    <input
-                      type="text"
-                      placeholder="Enter key"
-                      value={key}
-                      onChange={(e) => setKey(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500"
-                    />
-                    <label className="block text-xs font-medium text-gray-500 mb-1">
-                      Value
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-ink-2">Value</span>
+                      <textarea
+                        placeholder="Plain text or JSON"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                        rows={3}
+                        className="min-h-[72px] px-2.5 py-2 rounded-lg border border-border-strong bg-surface-2 font-mono text-[13px] leading-relaxed text-ink outline-none transition-colors placeholder:text-faint resize-y focus:bg-surface focus:border-primary focus:ring-3 focus:ring-focus"
+                      />
                     </label>
-                    <textarea
-                      placeholder="Enter value (plain text or JSON)"
-                      value={value}
-                      onChange={(e) => setValue(e.target.value)}
-                      rows={3}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500 resize-none"
-                    />
-                    <button
+                    <Button
+                      variant="primary"
+                      icon="lucide:save"
                       onClick={handleSet}
-                      disabled={loading || !key || !value}
-                      className="w-full px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-lg hover:bg-emerald-700 disabled:opacity-50 flex items-center justify-center gap-2"
+                      disabled={!key || !value}
+                      loading={loading}
                     >
-                      {loading ? (
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                      ) : null}
-                      Set
-                    </button>
+                      Set key
+                    </Button>
                   </motion.div>
                 )}
 
@@ -387,28 +365,26 @@ export default function CachePage() {
                     initial="hidden"
                     animate="visible"
                     exit="exit"
-                    className="space-y-4"
+                    className="flex flex-col gap-3"
                   >
-                    <label className="block text-xs font-medium text-gray-500 mb-1">
-                      Key
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-ink-2">Key</span>
+                      <Input
+                        mono
+                        placeholder="session:user#42"
+                        value={key}
+                        onChange={(e) => setKey(e.target.value)}
+                      />
                     </label>
-                    <input
-                      type="text"
-                      placeholder="Enter key"
-                      value={key}
-                      onChange={(e) => setKey(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500"
-                    />
-                    <button
+                    <Button
+                      variant="primary"
+                      icon="lucide:search"
                       onClick={handleGet}
-                      disabled={loading || !key}
-                      className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center justify-center gap-2"
+                      disabled={!key}
+                      loading={loading}
                     >
-                      {loading ? (
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                      ) : null}
-                      Get
-                    </button>
+                      Get key
+                    </Button>
                   </motion.div>
                 )}
 
@@ -419,152 +395,165 @@ export default function CachePage() {
                     initial="hidden"
                     animate="visible"
                     exit="exit"
-                    className="space-y-4"
+                    className="flex flex-col gap-3"
                   >
-                    <label className="block text-xs font-medium text-gray-500 mb-1">
-                      Key
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-xs font-medium text-ink-2">Key</span>
+                      <Input
+                        mono
+                        placeholder="session:user#42"
+                        value={key}
+                        onChange={(e) => setKey(e.target.value)}
+                      />
                     </label>
-                    <input
-                      type="text"
-                      placeholder="Enter key"
-                      value={key}
-                      onChange={(e) => setKey(e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/50 focus:border-indigo-500"
-                    />
-                    <button
+                    <Button
+                      variant="danger"
+                      icon="lucide:trash-2"
                       onClick={handleDel}
-                      disabled={loading || !key}
-                      className="w-full px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50 flex items-center justify-center gap-2"
+                      disabled={!key}
+                      loading={loading}
                     >
-                      {loading ? (
-                        <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                      ) : null}
-                      Delete
-                    </button>
+                      Delete key
+                    </Button>
                   </motion.div>
                 )}
               </AnimatePresence>
-
-              <div className="mt-6 pt-6 border-t border-gray-100 flex gap-3">
-                <button
-                  onClick={handleFlush}
-                  disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-amber-700 bg-amber-50 rounded-lg hover:bg-amber-100 disabled:opacity-50 flex items-center gap-2"
-                >
-                  {loading ? (
-                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <TrashIcon className="h-4 w-4" />
-                  )}
-                  Flush All
-                </button>
-                <button
-                  onClick={handleShowAllKeys}
-                  disabled={loading}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 disabled:opacity-50 flex items-center gap-2"
-                >
-                  {loading ? (
-                    <ArrowPathIcon className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <ArrowPathIcon className="h-4 w-4" />
-                  )}
-                  Refresh Keys
-                </button>
-              </div>
-            </section>
+            </Card>
 
             {/* Result */}
             {(result || error) && (
-              <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-                <h2 className="text-base font-semibold text-gray-900 mb-3">
+              <Card className="p-4 flex flex-col gap-2">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-faint">
                   Result
-                </h2>
+                </span>
                 {result && (
-                  <pre className="bg-gray-50 p-4 rounded-lg text-sm text-gray-900 overflow-auto max-h-40 border border-gray-100 font-mono">
+                  <pre className="m-0 p-2.5 rounded-lg bg-surface-2 border border-border font-mono text-[11px] leading-relaxed text-ink-2 overflow-auto max-h-40">
                     {isJson(result) ? formatValue(result) : result}
                   </pre>
                 )}
                 {error && (
-                  <div className="bg-red-50 text-red-800 rounded-lg p-3 text-sm border border-red-100">
+                  <div className="rounded-lg border border-danger bg-danger-soft text-danger-ink text-xs p-2.5">
                     {error}
                   </div>
                 )}
-              </section>
+              </Card>
             )}
           </div>
 
           {/* Right: Keys */}
-          <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 min-h-[32rem] flex flex-col lg:sticky lg:top-8 lg:self-start">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-base font-semibold text-gray-900">
-                All Keys ({allKeys.length})
-              </h2>
-              <button
-                onClick={handleShowAllKeys}
-                disabled={loading}
-                className="p-1.5 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 disabled:opacity-50"
-                title="Refresh"
-              >
-                <ArrowPathIcon
-                  className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
+          <div className="flex flex-col gap-6">
+            <Card className="overflow-hidden">
+              <div className="flex items-center gap-2 px-3.5 py-3 border-b border-divider flex-wrap">
+                <span className="text-[13px] font-semibold text-ink">Keys</span>
+                <span className="font-mono text-[11px] text-faint">{allKeys.length}</span>
+                <SearchInput
+                  placeholder="Filter keys…"
+                  value={keyFilter}
+                  onChange={(e) => setKeyFilter(e.target.value)}
+                  containerClassName="ml-auto min-w-[140px] h-7"
                 />
-              </button>
-            </div>
+                <IconButton
+                  icon="lucide:refresh-cw"
+                  label="Refresh keys"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleShowAllKeys}
+                  disabled={loading}
+                  className={loading ? "animate-spin" : undefined}
+                />
+              </div>
 
-            <div className="flex-1 min-h-0 overflow-y-auto -mx-1">
-              {allKeys.length === 0 ? (
-                <div className="text-center py-12">
-                  <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 text-gray-400 mb-3">
-                    <KeyIcon className="h-6 w-6" />
-                  </div>
-                  <p className="text-sm text-gray-500">No keys in cache</p>
+              {filteredKeys.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-10 px-4 text-center">
+                  <span className="flex items-center justify-center w-10 h-10 rounded-full bg-surface-3 text-faint">
+                    <Icon icon="lucide:key" width={18} />
+                  </span>
+                  <p className="text-sm text-muted">
+                    {allKeys.length === 0 ? "No keys in cache" : "No keys match your filter"}
+                  </p>
                 </div>
               ) : (
-                <div className="space-y-3">
-                  {allKeys.map((item, index) => (
+                <div className="max-h-96 overflow-y-auto">
+                  {filteredKeys.map((item) => (
                     <div
-                      key={index}
-                      className="border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors"
+                      key={item.key}
+                      className="grid grid-cols-[1fr_auto] items-center gap-2 px-3.5 h-10 border-b border-divider last:border-b-0 hover:bg-surface-2 transition-colors"
                     >
-                      <div className="flex items-center justify-between mb-2">
-                        <div>
-                          <p className="text-xs font-medium text-gray-500 mb-0.5">
-                            Key
-                          </p>
-                          <code className="text-sm font-medium text-gray-900 truncate block">
-                            {item.key}
-                          </code>
-                        </div>
-                        <button
+                      <span className="font-mono text-xs text-ink truncate" title={item.key}>
+                        {item.key}
+                      </span>
+                      <span className="flex items-center gap-0.5">
+                        <IconButton
+                          icon="lucide:eye"
+                          label={`View ${item.key}`}
+                          variant="ghost"
+                          size="sm"
                           onClick={() => {
                             setKey(item.key);
                             setActiveAction("get");
                           }}
-                          className="px-2 py-1 text-xs font-medium text-blue-600 bg-blue-50 rounded-md hover:bg-blue-100"
-                        >
-                          Get
-                        </button>
-                      </div>
-                      <div>
-                        <p className="text-xs font-medium text-gray-500 mb-0.5">
-                          Value
-                        </p>
-                        {isJson(item.value) ? (
-                          <pre className="whitespace-pre-wrap break-all bg-gray-50 p-2 rounded text-xs overflow-auto max-h-24 font-mono text-gray-900">
-                            {formatValue(item.value)}
-                          </pre>
-                        ) : (
-                          <div className="break-all text-sm text-gray-900">
-                            {item.value}
-                          </div>
-                        )}
-                      </div>
+                        />
+                        <IconButton
+                          icon="lucide:trash-2"
+                          label={`Delete ${item.key}`}
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => {
+                            setKey(item.key);
+                            setActiveAction("delete");
+                          }}
+                        />
+                      </span>
                     </div>
                   ))}
                 </div>
               )}
+            </Card>
+
+            {/* Guarded flush */}
+            <div className="flex items-center gap-2.5 p-3.5 rounded-xl border border-danger bg-danger-soft flex-wrap">
+              <Icon icon="lucide:alert-triangle" width={16} className="text-danger shrink-0" />
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="text-xs font-semibold text-danger-ink">Flush all keys</span>
+                <span className="text-[11px] text-danger-ink/85">
+                  Drops all {allKeys.length} key{allKeys.length !== 1 ? "s" : ""} immediately. Dev
+                  only, no undo.
+                </span>
+              </div>
+              {confirmFlush ? (
+                <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setConfirmFlush(false)}
+                    disabled={loading}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    icon="lucide:trash-2"
+                    loading={loading}
+                    onClick={handleConfirmFlush}
+                  >
+                    Confirm flush
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  variant="danger"
+                  size="sm"
+                  icon="lucide:trash-2"
+                  className="ml-auto shrink-0"
+                  onClick={() => setConfirmFlush(true)}
+                  disabled={loading || allKeys.length === 0}
+                >
+                  Flush all
+                </Button>
+              )}
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </main>

--- a/localcloud-gui/src/app/globals.css
+++ b/localcloud-gui/src/app/globals.css
@@ -41,7 +41,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --bg: #101014;
     --surface: #18181c;
     --surface-2: #1d1d22;
@@ -74,6 +74,40 @@
     --shadow-e2: 0 14px 34px -12px rgba(0, 0, 0, 0.75);
     --shadow-e3: 0 28px 70px -20px rgba(0, 0, 0, 0.85);
   }
+}
+
+:root[data-theme="dark"] {
+  --bg: #101014;
+  --surface: #18181c;
+  --surface-2: #1d1d22;
+  --surface-3: #232329;
+  --border: #2c2c34;
+  --border-strong: #3a3a43;
+  --divider: #26262c;
+  --ink: #f4f4f5;
+  --ink-2: #d4d4d8;
+  --muted: #a1a1aa;
+  --faint: #71717a;
+  --primary: #6366f1;
+  --primary-hover: #818cf8;
+  --primary-soft: #282842;
+  --primary-ink: #c7d2fe;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
+  --danger-soft: #2a1618;
+  --danger-ink: #fca5a5;
+  --success: #22c55e;
+  --success-soft: #14371f;
+  --success-ink: #4ade80;
+  --warn: #f59e0b;
+  --warn-soft: #3a2a10;
+  --warn-ink: #fcd34d;
+  --focus: rgba(99, 102, 241, 0.25);
+  --skeleton: #26262c;
+  --scrim: rgba(0, 0, 0, 0.6);
+  --shadow-e1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-e2: 0 14px 34px -12px rgba(0, 0, 0, 0.75);
+  --shadow-e3: 0 28px 70px -20px rgba(0, 0, 0, 0.85);
 }
 
 @theme inline {

--- a/localcloud-gui/src/app/globals.css
+++ b/localcloud-gui/src/app/globals.css
@@ -1,20 +1,129 @@
 @import "tailwindcss";
 @config "../../tailwind.config.js";
 
+/*
+ * LocalCloud Kit design tokens.
+ * Source of truth: Claude Design "LocalCloud Screens" project.
+ * Dark palette activates automatically via prefers-color-scheme.
+ */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --bg: #f4f4f7;
+  --surface: #ffffff;
+  --surface-2: #fafafb;
+  --surface-3: #f1f1f5;
+  --border: #e6e6ec;
+  --border-strong: #d9d9e0;
+  --divider: #f2f2f5;
+  --ink: #18181b;
+  --ink-2: #3f3f46;
+  --muted: #71717a;
+  --faint: #9a9aa3;
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --primary-soft: #eef2ff;
+  --primary-ink: #312e81;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --danger-soft: #fef2f2;
+  --danger-ink: #991b1b;
+  --success: #16a34a;
+  --success-soft: #dcfce7;
+  --success-ink: #15803d;
+  --warn: #d97706;
+  --warn-soft: #fef3c7;
+  --warn-ink: #92400e;
+  --focus: rgba(79, 70, 229, 0.14);
+  --skeleton: #ececf1;
+  --scrim: rgba(24, 24, 27, 0.45);
+  --shadow-e1: 0 1px 2px rgba(24, 24, 27, 0.05), 0 6px 20px -8px rgba(24, 24, 27, 0.12);
+  --shadow-e2: 0 10px 30px -10px rgba(24, 24, 27, 0.28);
+  --shadow-e3: 0 24px 60px -20px rgba(24, 24, 27, 0.45);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --bg: #101014;
+    --surface: #18181c;
+    --surface-2: #1d1d22;
+    --surface-3: #232329;
+    --border: #2c2c34;
+    --border-strong: #3a3a43;
+    --divider: #26262c;
+    --ink: #f4f4f5;
+    --ink-2: #d4d4d8;
+    --muted: #a1a1aa;
+    --faint: #71717a;
+    --primary: #6366f1;
+    --primary-hover: #818cf8;
+    --primary-soft: #282842;
+    --primary-ink: #c7d2fe;
+    --danger: #ef4444;
+    --danger-hover: #dc2626;
+    --danger-soft: #2a1618;
+    --danger-ink: #fca5a5;
+    --success: #22c55e;
+    --success-soft: #14371f;
+    --success-ink: #4ade80;
+    --warn: #f59e0b;
+    --warn-soft: #3a2a10;
+    --warn-ink: #fcd34d;
+    --focus: rgba(99, 102, 241, 0.25);
+    --skeleton: #26262c;
+    --scrim: rgba(0, 0, 0, 0.6);
+    --shadow-e1: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-e2: 0 14px 34px -12px rgba(0, 0, 0, 0.75);
+    --shadow-e3: 0 28px 70px -20px rgba(0, 0, 0, 0.85);
   }
 }
 
+@theme inline {
+  --color-bg: var(--bg);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-divider: var(--divider);
+  --color-ink: var(--ink);
+  --color-ink-2: var(--ink-2);
+  --color-muted: var(--muted);
+  --color-faint: var(--faint);
+  --color-primary: var(--primary);
+  --color-primary-hover: var(--primary-hover);
+  --color-primary-soft: var(--primary-soft);
+  --color-primary-ink: var(--primary-ink);
+  --color-danger: var(--danger);
+  --color-danger-hover: var(--danger-hover);
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-ink: var(--danger-ink);
+  --color-success: var(--success);
+  --color-success-soft: var(--success-soft);
+  --color-success-ink: var(--success-ink);
+  --color-warn: var(--warn);
+  --color-warn-soft: var(--warn-soft);
+  --color-warn-ink: var(--warn-ink);
+  --color-focus: var(--focus);
+  --color-skeleton: var(--skeleton);
+  --color-scrim: var(--scrim);
+
+  --shadow-e1: var(--shadow-e1);
+  --shadow-e2: var(--shadow-e2);
+  --shadow-e3: var(--shadow-e3);
+}
+
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--primary-hover);
+  text-decoration: underline;
 }

--- a/localcloud-gui/src/app/layout.tsx
+++ b/localcloud-gui/src/app/layout.tsx
@@ -1,7 +1,22 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { PreferencesProvider } from "@/context/PreferencesContext";
+
+const plexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-plex-sans",
+  display: "swap",
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  variable: "--font-plex-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "LocalCloud Kit",
@@ -14,8 +29,8 @@ export default function RootLayout({
   children: ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased font-sans">
+    <html lang="en" className={`${plexSans.variable} ${plexMono.variable}`}>
+      <body className="antialiased font-sans bg-bg text-ink">
         <PreferencesProvider>{children}</PreferencesProvider>
       </body>
     </html>

--- a/localcloud-gui/src/app/manage/dynamodb/page.tsx
+++ b/localcloud-gui/src/app/manage/dynamodb/page.tsx
@@ -3,16 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
-import {
-  PlusIcon,
-  CircleStackIcon,
-  ArrowPathIcon,
-  BookOpenIcon,
-  TrashIcon,
-  MagnifyingGlassIcon,
-  ArrowsPointingOutIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { resourceApi } from "@/services/api";
 import ManageHeaderBrand from "@/components/ManageHeaderBrand";
 import { DynamoDBTableConfig } from "@/types";
@@ -23,6 +14,7 @@ import DynamoDBItemDetailPanel from "@/components/DynamoDBItemDetailPanel";
 import SystemLogsButton from "@/components/SystemLogsButton";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 import { parseDynamoDBItem } from "@/lib/dynamodbValue";
+import { Button, IconButton } from "@/components/ui";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DynamoDBItem = Record<string, any>;
@@ -245,17 +237,17 @@ export default function ManageDynamoDBPage() {
             e.stopPropagation();
             handleJsonClick(value, `${columnName} - ${selectedTable}`);
           }}
-          className="mx-auto flex max-w-xs items-center justify-center gap-1.5 rounded border border-indigo-200 bg-indigo-50 px-2 py-1 text-left font-mono text-xs text-gray-800 transition-colors hover:bg-indigo-100"
+          className="mx-auto flex max-w-xs cursor-pointer items-center justify-center gap-1.5 rounded border border-primary bg-primary-soft px-2 py-1 text-left font-mono text-xs text-ink transition-colors hover:bg-primary/10"
           title="Click to view full JSON"
         >
-          <ArrowsPointingOutIcon className="h-3.5 w-3.5 shrink-0 text-indigo-600" />
+          <Icon icon="lucide:maximize-2" width={13} className="shrink-0 text-primary" />
           <span className="truncate">{formatDisplayValue(value)}</span>
         </button>
       );
     }
 
     return (
-      <span className="mx-auto block max-w-xs truncate text-center" title={formatDisplayValue(value)}>
+      <span className="mx-auto block max-w-xs truncate text-center font-mono text-xs text-ink-2" title={formatDisplayValue(value)}>
         {formatDisplayValue(value)}
       </span>
     );
@@ -272,258 +264,265 @@ export default function ManageDynamoDBPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
+    <div className="flex min-h-screen flex-col bg-bg">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
-        <div className="max-w-full px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-3">
-              <ManageHeaderBrand />
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Manage tables</p>
-              </div>
-              <div className="h-5 w-px bg-gray-200" />
-              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
-                Dashboard
-              </Link>
-            </div>
-            <div className="flex items-center space-x-3">
-              <SystemLogsButton />
-              <Link href="/dynamodb" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
-                <BookOpenIcon className="h-4 w-4" />
-                <span>Docs</span>
-              </Link>
-              <button
-                type="button"
-                onClick={() => {
-                  void loadTables();
-                  if (selectedTable) void loadItems(selectedTable);
+      <header className="shrink-0 border-b border-border bg-surface">
+        <div className="flex flex-wrap items-center gap-3 px-6 py-3.5">
+          <ManageHeaderBrand />
+          <span className="h-[18px] w-px bg-border" />
+          <div className="flex items-center gap-2">
+            <Icon icon="logos:aws-dynamodb" width={18} />
+            <h1 className="text-[18px] font-semibold tracking-tight text-ink">Manage DynamoDB</h1>
+          </div>
+          <Link href="/" className="text-sm font-medium text-muted transition-colors hover:text-ink">
+            Dashboard
+          </Link>
+
+          <div className="ml-auto flex flex-wrap items-center gap-2">
+            <SystemLogsButton />
+            <Link
+              href="/dynamodb"
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium text-muted transition-colors hover:bg-surface-3 hover:text-ink"
+            >
+              <Icon icon="lucide:book-open" width={15} />
+              Docs
+            </Link>
+
+            <div className="relative">
+              <select
+                value={selectedTable ?? ""}
+                onChange={(e) => {
+                  if (e.target.value) void selectTable(e.target.value);
                 }}
-                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg"
-                title="Refresh tables and items"
+                disabled={loadingTables}
+                className="h-8 min-w-[180px] cursor-pointer appearance-none rounded-lg border border-border-strong bg-surface pl-2.5 pr-8 font-mono text-[13px] text-ink outline-none transition-colors focus:border-primary focus:ring-3 focus:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
               >
-                <ArrowPathIcon
-                  className={`h-4 w-4 ${loadingTables || loadingItems ? "animate-spin" : ""}`}
-                />
-              </button>
-              <button
-                onClick={() => setShowCreate(true)}
-                className="flex items-center space-x-2 px-4 py-2 text-sm font-medium bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
-              >
-                <PlusIcon className="h-4 w-4" />
-                <span>Create Table</span>
-              </button>
+                <option value="">{loadingTables ? "Loading…" : "Choose a table…"}</option>
+                {tables.map((t) => (
+                  <option key={t.TableName} value={t.TableName}>
+                    {t.TableName}
+                  </option>
+                ))}
+              </select>
+              <Icon
+                icon="lucide:chevron-down"
+                width={14}
+                className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+              />
             </div>
+            <IconButton
+              icon="lucide:refresh-cw"
+              variant="outline"
+              label="Refresh tables and items"
+              disabled={loadingTables || loadingItems}
+              className={loadingTables || loadingItems ? "[&_svg]:animate-spin" : ""}
+              onClick={() => {
+                void loadTables();
+                if (selectedTable) void loadItems(selectedTable);
+              }}
+            />
+            <Button variant="secondary" size="sm" icon="lucide:plus" onClick={() => setShowCreate(true)}>
+              New table
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              icon="lucide:plus"
+              disabled={!selectedTable}
+              onClick={() => setShowAddItem(true)}
+            >
+              Add item
+            </Button>
           </div>
         </div>
       </header>
 
-      {/* Two-panel layout */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Table sidebar */}
-        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
-          <div className="px-3 py-3 border-b border-gray-100">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Tables ({tables.length})</p>
+      {/* Content */}
+      <main className="mx-auto flex w-full max-w-[1180px] flex-1 flex-col gap-4 p-6">
+        {!selectedTable ? (
+          <div className="flex flex-1 flex-col items-center justify-center py-24 text-center">
+            {loadingTables ? (
+              <>
+                <Icon icon="lucide:loader-2" width={40} className="mb-4 animate-spin text-faint" />
+                <p className="text-sm text-muted">Loading tables…</p>
+              </>
+            ) : tables.length === 0 ? (
+              <>
+                <Icon icon="logos:aws-dynamodb" width={64} height={64} className="mb-4 opacity-20" />
+                <p className="mb-1 text-sm font-medium text-ink-2">No DynamoDB tables yet</p>
+                <p className="mb-5 text-xs text-faint">Create your first table to start storing data.</p>
+                <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setShowCreate(true)}>
+                  Create table
+                </Button>
+              </>
+            ) : (
+              <>
+                <Icon icon="logos:aws-dynamodb" width={64} height={64} className="mb-4 opacity-20" />
+                <p className="text-sm text-muted">Select a table above to view and manage its items</p>
+              </>
+            )}
           </div>
-          {loadingTables ? (
-            <div className="p-4 space-y-2">
-              {[0,1,2].map((i) => <div key={i} className="h-8 bg-gray-100 rounded animate-pulse" />)}
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted">
+              <span>
+                Showing <strong className="text-ink-2">{items.length} items</strong>
+              </span>
+              {schema && (
+                <span className="font-mono">
+                  · pk: {schema.pk}
+                  {schema.sk ? ` / sk: ${schema.sk}` : ""}
+                </span>
+              )}
             </div>
-          ) : tables.length === 0 ? (
-            <div className="p-6 text-center">
-              <CircleStackIcon className="h-8 w-8 text-gray-300 mx-auto mb-2" />
-              <p className="text-xs text-gray-500">No tables</p>
-            </div>
-          ) : (
-            <ul className="py-1">
-              {tables.map((t) => (
-                <li key={t.TableName}>
-                  <button
-                    onClick={() => selectTable(t.TableName)}
-                    className={`w-full flex items-center space-x-2 px-4 py-2 text-sm text-left transition-colors ${
-                      selectedTable === t.TableName
-                        ? "bg-indigo-50 text-indigo-700 font-medium"
-                        : "text-gray-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <CircleStackIcon className="h-4 w-4 shrink-0" />
-                    <span className="truncate">{t.TableName}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </aside>
 
-        {/* Items panel */}
-        <main className="flex-1 overflow-y-auto p-6">
-          {!selectedTable ? (
-            <div className="flex flex-col items-center justify-center h-full text-center py-24">
-              <CircleStackIcon className="h-16 w-16 text-gray-200 mb-4" />
-              <p className="text-sm text-gray-400">Select a table to view and manage items</p>
-            </div>
-          ) : (
-            <div>
-              <div className="mb-4 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2 sm:gap-3">
-                  <h2 className="shrink-0 text-base font-semibold text-gray-900">{selectedTable}</h2>
-                  {schema && (
-                    <span className="min-w-0 truncate text-xs text-gray-400 font-mono">
-                      PK: {schema.pk}
-                      {schema.sk ? ` · SK: ${schema.sk}` : ""}
-                    </span>
-                  )}
-                  <span className="shrink-0 text-xs text-gray-400">{items.length} items</span>
-                </div>
-                <div className="flex shrink-0 items-center justify-end">
-                  <button
-                    type="button"
-                    onClick={() => setShowAddItem(true)}
-                    className="flex items-center space-x-1.5 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white shadow-sm hover:bg-indigo-700"
-                  >
-                    <PlusIcon className="h-3.5 w-3.5" />
-                    <span>Add Item</span>
-                  </button>
-                </div>
+            {loadingItems ? (
+              <div className="flex-1 animate-pulse space-y-2">
+                {[0, 1, 2, 3].map((i) => (
+                  <div key={i} className="h-10 rounded-lg bg-skeleton" />
+                ))}
               </div>
-
-              {loadingItems ? (
-                <div className="space-y-2">
-                  {[0,1,2,3].map((i) => <div key={i} className="h-10 bg-gray-100 rounded animate-pulse" />)}
-                </div>
-              ) : items.length === 0 ? (
-                <div className="text-center py-16 bg-white border border-gray-200 rounded-lg">
-                  <MagnifyingGlassIcon className="h-12 w-12 text-gray-200 mx-auto mb-3" />
-                  <p className="text-sm text-gray-400">No items in this table</p>
-                  <button
-                    onClick={() => setShowAddItem(true)}
-                    className="mt-3 inline-flex items-center px-3 py-1.5 text-xs font-medium bg-indigo-600 text-white rounded-lg shadow-sm hover:bg-indigo-700"
-                  >
-                    <PlusIcon className="h-3.5 w-3.5 mr-1" />
-                    Add first item
-                  </button>
-                </div>
-              ) : (
-                <div className="flex min-h-[28rem] gap-4">
-                  <div className="min-w-0 flex-1 overflow-x-auto rounded-lg border border-gray-200 bg-white">
-                  <table className="min-w-full divide-y divide-gray-100 text-sm">
-                    <thead className="bg-gray-50">
+            ) : items.length === 0 ? (
+              <div className="flex flex-col items-center rounded-xl border border-border bg-surface py-16 text-center shadow-e1">
+                <Icon icon="lucide:search" width={40} className="mb-3 text-faint" />
+                <p className="mb-3 text-sm text-muted">No items in this table</p>
+                <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setShowAddItem(true)}>
+                  Add first item
+                </Button>
+              </div>
+            ) : (
+              <div className="flex min-h-[28rem] flex-1 gap-4">
+                <div className="min-w-0 flex-1 overflow-hidden overflow-x-auto rounded-xl border border-border bg-surface shadow-e1">
+                  <table className="min-w-full border-collapse text-sm">
+                    <thead className="border-b border-divider bg-surface-2">
                       <tr>
                         {orderedKeys.map((k) => (
                           <th
                             key={k}
-                            className={`px-4 py-2.5 font-medium whitespace-nowrap ${
-                              isKeyColumn(k)
-                                ? "min-w-[200px] bg-indigo-50 text-left text-indigo-800"
-                                : "text-center text-gray-500"
+                            className={`whitespace-nowrap px-3.5 py-2.5 text-[10px] font-semibold uppercase tracking-wide ${
+                              isKeyColumn(k) ? "min-w-[200px] bg-primary-soft text-left text-primary-ink" : "text-center text-faint"
                             }`}
                           >
                             <span>{k}</span>
                             {isKeyColumn(k) ? (
-                              <span className="ml-1.5 text-xs font-normal text-indigo-500 normal-case">
+                              <span className="ml-1.5 text-[10px] font-normal normal-case text-primary">
                                 ({getKeyType(k)})
                               </span>
                             ) : null}
                           </th>
                         ))}
-                        <th className="px-4 py-2.5 text-right font-medium text-gray-500">Actions</th>
+                        <th className="px-3.5 py-2.5 text-right text-[10px] font-semibold uppercase tracking-wide text-faint">
+                          Actions
+                        </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-50">
+                    <tbody>
                       {items.map((item, i) => (
                         <tr
                           key={i}
                           onClick={() => setSelectedItemIndex(i)}
-                          className={`cursor-pointer transition-colors hover:bg-gray-50 ${
-                            selectedItemIndex === i
-                              ? "bg-indigo-50 ring-2 ring-inset ring-indigo-400"
-                              : ""
+                          className={`cursor-pointer border-b border-divider transition-colors last:border-b-0 hover:bg-surface-2 ${
+                            selectedItemIndex === i ? "bg-primary-soft" : ""
                           }`}
                         >
                           {orderedKeys.map((k) => (
                             <td
                               key={k}
-                              className={`px-4 py-2.5 ${
+                              className={`px-3.5 py-2.5 ${
                                 isKeyColumn(k)
-                                  ? "min-w-[200px] max-w-[240px] align-top bg-indigo-50/60 text-left"
-                                  : "text-center align-middle text-xs font-mono text-gray-700"
+                                  ? "min-w-[200px] max-w-[240px] bg-primary-soft/60 text-left align-top"
+                                  : "text-center align-middle"
                               }`}
                             >
                               {renderCellValue(k, item[k])}
                             </td>
                           ))}
-                          <td className="px-4 py-2.5 text-right">
-                            <button
-                              type="button"
+                          <td className="px-3.5 py-2.5 text-right">
+                            <IconButton
+                              icon="lucide:trash-2"
+                              variant="ghost"
+                              size="sm"
+                              label="Delete item"
+                              className="!text-danger hover:!bg-danger-soft hover:!text-danger"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 setDeleteItemTarget(item);
                               }}
-                              className="p-1.5 text-gray-400 hover:text-red-600 transition-colors"
-                              title="Delete item"
-                            >
-                              <TrashIcon className="h-4 w-4" />
-                            </button>
+                            />
                           </td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
+                  <div className="flex items-center gap-2 border-t border-border bg-surface-2 px-3.5 py-2.5">
+                    <span className="text-[11px] text-muted">
+                      Wide attributes truncate — open an item for the full document
+                    </span>
                   </div>
-
-                  {selectedItem && selectedTable ? (
-                    <DynamoDBItemDetailPanel
-                      item={selectedItem}
-                      tableName={selectedTable}
-                      keyColumnNames={getKeyColumnNames()}
-                      getKeyType={getKeyType}
-                      onDelete={() => setDeleteItemTarget(selectedItem)}
-                      onClose={() => setSelectedItemIndex(null)}
-                      onJsonClick={handleJsonClick}
-                      accent="indigo"
-                    />
-                  ) : null}
                 </div>
-              )}
-            </div>
-          )}
-        </main>
-      </div>
+
+                {selectedItem && selectedTable ? (
+                  <DynamoDBItemDetailPanel
+                    item={selectedItem}
+                    tableName={selectedTable}
+                    keyColumnNames={getKeyColumnNames()}
+                    getKeyType={getKeyType}
+                    onDelete={() => setDeleteItemTarget(selectedItem)}
+                    onClose={() => setSelectedItemIndex(null)}
+                    onJsonClick={handleJsonClick}
+                  />
+                ) : null}
+              </div>
+            )}
+          </>
+        )}
+      </main>
 
       {/* Delete item confirmation */}
       {deleteItemTarget && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={() => setDeleteItemTarget(null)}>
-          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md p-6" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-base font-semibold text-gray-900 mb-2">Delete item?</h3>
-            <pre className="text-xs bg-gray-50 rounded p-3 mb-4 overflow-auto max-h-32 text-gray-700">{JSON.stringify(deleteItemTarget, null, 2)}</pre>
-            <div className="flex space-x-3">
-              <button onClick={handleDeleteItem} disabled={deleteLoading} className="flex-1 px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4"
+          onClick={() => setDeleteItemTarget(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl border border-border bg-surface p-5 shadow-e3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-2 text-[15px] font-semibold text-ink">Delete item?</h3>
+            <pre className="mb-4 max-h-32 overflow-auto rounded-lg bg-surface-2 p-3 font-mono text-xs text-ink-2">
+              {JSON.stringify(deleteItemTarget, null, 2)}
+            </pre>
+            <div className="flex gap-2.5">
+              <Button
+                variant="danger"
+                icon="lucide:trash-2"
+                loading={deleteLoading}
+                onClick={handleDeleteItem}
+                className="flex-1 justify-center"
+              >
                 {deleteLoading ? "Deleting…" : "Delete"}
-              </button>
-              <button onClick={() => setDeleteItemTarget(null)} className="flex-1 px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200">
+              </Button>
+              <Button
+                variant="secondary"
+                onClick={() => setDeleteItemTarget(null)}
+                className="flex-1 justify-center"
+              >
                 Cancel
-              </button>
+              </Button>
             </div>
           </div>
         </div>
       )}
 
       {jsonViewerOpen && (
-        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-          <div className="flex max-h-[80vh] w-full max-w-3xl flex-col rounded-xl bg-white shadow-2xl">
-            <div className="flex items-center justify-between border-b border-gray-200 px-6 py-4 shrink-0">
+        <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-scrim p-4">
+          <div className="flex max-h-[80vh] w-full max-w-3xl flex-col rounded-xl border border-border bg-surface shadow-e3">
+            <div className="flex shrink-0 items-center justify-between border-b border-divider px-6 py-4">
               <div>
-                <h2 className="text-lg font-semibold text-gray-900">JSON Viewer</h2>
-                <p className="text-xs text-gray-500">{selectedJsonTitle}</p>
+                <h2 className="text-[15px] font-semibold text-ink">JSON viewer</h2>
+                <p className="text-[11px] text-muted">{selectedJsonTitle}</p>
               </div>
-              <button
-                onClick={() => setJsonViewerOpen(false)}
-                className="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
-                aria-label="Close"
-              >
-                <XMarkIcon className="h-5 w-5" />
-              </button>
+              <IconButton icon="lucide:x" variant="ghost" label="Close" onClick={() => setJsonViewerOpen(false)} />
             </div>
             <div className="flex-1 overflow-auto p-6">
               <ThemeableCodeBlock

--- a/localcloud-gui/src/app/manage/s3/page.tsx
+++ b/localcloud-gui/src/app/manage/s3/page.tsx
@@ -1,20 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import { toast } from "react-hot-toast";
-import {
-  PlusIcon,
-  FolderIcon,
-  DocumentIcon,
-  ArrowPathIcon,
-  BookOpenIcon,
-  TrashIcon,
-  ArrowUpTrayIcon,
-  EyeIcon,
-  ChevronRightIcon,
-  ArrowLeftIcon as BackIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { s3Api, resourceApi } from "@/services/api";
 import ManageHeaderBrand from "@/components/ManageHeaderBrand";
 import { useProjectName } from "@/hooks/useProjectName";
@@ -24,6 +13,7 @@ import FileViewerModal from "@/components/FileViewerModal";
 import UploadFileModal from "@/components/UploadFileModal";
 import SystemLogsButton from "@/components/SystemLogsButton";
 import { listS3ObjectsAtPrefix } from "@/lib/s3PrefixListing";
+import { Button, Card, SearchInput } from "@/components/ui";
 
 interface BucketItem {
   Name?: string;
@@ -42,6 +32,36 @@ const formatSize = (bytes?: number) => {
 
 const formatDate = (d?: string) => (d ? new Date(d).toLocaleString() : "—");
 const isFolder = (key: string) => key.endsWith("/");
+
+/** Iconify name + short mime-ish label shown in the Type column, guessed from the key's extension. */
+const FILE_TYPE_BY_EXT: Record<string, { icon: string; label: string }> = {
+  json: { icon: "lucide:file-json", label: "app/json" },
+  png: { icon: "lucide:file-image", label: "image/png" },
+  jpg: { icon: "lucide:file-image", label: "image/jpeg" },
+  jpeg: { icon: "lucide:file-image", label: "image/jpeg" },
+  gif: { icon: "lucide:file-image", label: "image/gif" },
+  svg: { icon: "lucide:file-image", label: "image/svg" },
+  webp: { icon: "lucide:file-image", label: "image/webp" },
+  bmp: { icon: "lucide:file-image", label: "image/bmp" },
+  csv: { icon: "lucide:file-text", label: "text/csv" },
+  txt: { icon: "lucide:file-text", label: "text/plain" },
+  md: { icon: "lucide:file-text", label: "text/markdown" },
+  pdf: { icon: "lucide:file-text", label: "app/pdf" },
+  xml: { icon: "lucide:file-code", label: "app/xml" },
+  yml: { icon: "lucide:file-code", label: "text/yaml" },
+  yaml: { icon: "lucide:file-code", label: "text/yaml" },
+  js: { icon: "lucide:file-code", label: "text/js" },
+  ts: { icon: "lucide:file-code", label: "text/ts" },
+  tsx: { icon: "lucide:file-code", label: "text/tsx" },
+  html: { icon: "lucide:file-code", label: "text/html" },
+  css: { icon: "lucide:file-code", label: "text/css" },
+};
+const DEFAULT_FILE_TYPE = { icon: "lucide:file", label: "binary" };
+
+function getFileTypeInfo(key: string) {
+  const ext = key.split(".").pop()?.toLowerCase() || "";
+  return FILE_TYPE_BY_EXT[ext] || DEFAULT_FILE_TYPE;
+}
 
 /** Stack for the Back button when jumping to `prefix` via breadcrumbs (e.g. photos/2024/ → ['', 'photos/']). */
 function pathHistoryForPrefix(prefix: string): string[] {
@@ -77,6 +97,7 @@ export default function ManageS3Page() {
   const [buckets, setBuckets] = useState<BucketItem[]>([]);
   const [selectedBucket, setSelectedBucket] = useState<string | null>(null);
   const [contents, setContents] = useState<BucketItem[]>([]);
+  const [rawContents, setRawContents] = useState<BucketItem[]>([]);
   const [currentPath, setCurrentPath] = useState("");
   const [pathHistory, setPathHistory] = useState<string[]>([]);
   const [loadingBuckets, setLoadingBuckets] = useState(false);
@@ -85,6 +106,20 @@ export default function ManageS3Page() {
   const [createLoading, setCreateLoading] = useState(false);
   const [showUpload, setShowUpload] = useState(false);
   const [fileViewer, setFileViewer] = useState<{ bucketName: string; objectKey: string } | null>(null);
+  const [filterText, setFilterText] = useState("");
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [bucketMenuOpen, setBucketMenuOpen] = useState(false);
+  const bucketMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (bucketMenuRef.current && !bucketMenuRef.current.contains(e.target as Node)) {
+        setBucketMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, []);
 
   const loadBuckets = useCallback(async () => {
     setLoadingBuckets(true);
@@ -107,6 +142,7 @@ export default function ManageS3Page() {
       const res = await s3Api.getBucketContents(projectName, bucket);
       if (res.success) {
         const all = res.data || [];
+        setRawContents(all);
         setContents(listS3ObjectsAtPrefix(all, path));
         setCurrentPath(path);
       } else {
@@ -123,6 +159,9 @@ export default function ManageS3Page() {
     setSelectedBucket(name);
     setCurrentPath("");
     setPathHistory([]);
+    setSelectedKey(null);
+    setFilterText("");
+    setBucketMenuOpen(false);
     loadContents(name, "");
   };
 
@@ -130,6 +169,7 @@ export default function ManageS3Page() {
     if (!selectedBucket) return;
     const newPath = key;
     setPathHistory((h) => [...h, currentPath]);
+    setSelectedKey(null);
     loadContents(selectedBucket, newPath);
   };
 
@@ -137,6 +177,7 @@ export default function ManageS3Page() {
     if (!selectedBucket) return;
     const prev = pathHistory[pathHistory.length - 1] ?? "";
     setPathHistory((h) => h.slice(0, -1));
+    setSelectedKey(null);
     loadContents(selectedBucket, prev);
   };
 
@@ -146,6 +187,7 @@ export default function ManageS3Page() {
       const norm =
         targetPrefix === "" ? "" : targetPrefix.endsWith("/") ? targetPrefix : `${targetPrefix}/`;
       setPathHistory(pathHistoryForPrefix(norm));
+      setSelectedKey(null);
       void loadContents(selectedBucket, norm);
     },
     [selectedBucket, loadContents]
@@ -176,6 +218,7 @@ export default function ManageS3Page() {
       const res = await s3Api.deleteObject(projectName, selectedBucket, key);
       if (res.success) {
         toast.success("Object deleted");
+        if (selectedKey === key) setSelectedKey(null);
         loadContents(selectedBucket, currentPath);
       } else {
         toast.error(res.error || "Failed to delete object");
@@ -185,121 +228,144 @@ export default function ManageS3Page() {
     }
   };
 
+  const folderObjectCount = (folderPrefix: string) =>
+    rawContents.filter((i) => (i.Key || "").startsWith(folderPrefix) && i.Key !== folderPrefix).length;
+
+  const visibleContents = filterText.trim()
+    ? contents.filter((item) => {
+        const key = item.Key || item.Name || "";
+        const displayName = currentPath ? key.slice(currentPath.length) : key;
+        return displayName.toLowerCase().includes(filterText.trim().toLowerCase());
+      })
+    : contents;
+
+  const selectedItem = selectedKey
+    ? contents.find((c) => (c.Key || c.Name) === selectedKey)
+    : undefined;
+
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
+    <div className="min-h-screen bg-bg flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 shadow-sm shrink-0">
-        <div className="max-w-full px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center space-x-3">
-              <ManageHeaderBrand />
-              <div>
-                <h1 className="text-xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Manage buckets</p>
-              </div>
-              <div className="h-5 w-px bg-gray-200" />
-              <Link href="/" className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors">
-                Dashboard
-              </Link>
-            </div>
-            <div className="flex items-center space-x-3">
-              <SystemLogsButton />
-              <Link href="/s3" className="flex items-center space-x-1.5 px-3 py-1.5 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
-                <BookOpenIcon className="h-4 w-4" />
-                <span>Docs</span>
-              </Link>
+      <header className="bg-surface border-b border-border shrink-0">
+        <div className="max-w-[1180px] mx-auto w-full px-6 py-4 flex items-center gap-3 flex-wrap">
+          <ManageHeaderBrand />
+          <span className="w-px h-[18px] bg-border shrink-0" />
+          <div className="flex items-center gap-2 shrink-0">
+            <Icon icon="logos:aws-s3" width={18} />
+            <h1 className="text-lg font-semibold tracking-tight text-ink">Manage S3</h1>
+          </div>
+          <Link href="/" className="text-sm font-medium text-muted hover:text-ink transition-colors shrink-0">
+            Dashboard
+          </Link>
+
+          <div className="flex items-center gap-2 ml-auto flex-wrap">
+            <SystemLogsButton />
+            <Link
+              href="/s3"
+              className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm font-medium text-muted hover:text-ink hover:bg-surface-2 transition-colors"
+            >
+              <Icon icon="lucide:book-open" width={14} />
+              Docs
+            </Link>
+            <Button variant="secondary" icon="lucide:plus" onClick={() => setShowCreate(true)}>
+              Create bucket
+            </Button>
+
+            <span className="w-px h-[18px] bg-border shrink-0" />
+
+            {/* Bucket selector */}
+            <div className="relative shrink-0" ref={bucketMenuRef}>
               <button
                 type="button"
-                onClick={() => {
-                  void loadBuckets();
-                  if (selectedBucket) void loadContents(selectedBucket, currentPath);
-                }}
-                className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg"
-                title="Refresh buckets and current folder"
+                onClick={() => setBucketMenuOpen((v) => !v)}
+                disabled={buckets.length === 0}
+                className="flex items-center justify-between gap-2 h-8 min-w-[200px] px-2.5 rounded-lg border border-border-strong bg-surface text-sm hover:border-ink-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <ArrowPathIcon
-                  className={`h-4 w-4 ${loadingBuckets || loadingContents ? "animate-spin" : ""}`}
-                />
+                <span className="font-mono text-[13px] text-ink truncate">
+                  {selectedBucket || "Select a bucket"}
+                </span>
+                <Icon icon="lucide:chevron-down" width={14} className="text-faint shrink-0" />
               </button>
-              <button
-                onClick={() => setShowCreate(true)}
-                className="flex items-center space-x-2 px-4 py-2 text-sm font-medium bg-indigo-600 text-white rounded-lg hover:bg-indigo-700"
-              >
-                <PlusIcon className="h-4 w-4" />
-                <span>Create Bucket</span>
-              </button>
+              {bucketMenuOpen && buckets.length > 0 && (
+                <div className="absolute right-0 z-20 mt-1 w-64 max-h-72 overflow-y-auto rounded-lg border border-border bg-surface shadow-e2 py-1">
+                  {buckets.map((b) => (
+                    <button
+                      key={b.Name}
+                      type="button"
+                      onClick={() => selectBucket(b.Name!)}
+                      className={`flex w-full items-center gap-2 px-3 py-2 text-left font-mono text-[13px] transition-colors ${
+                        selectedBucket === b.Name
+                          ? "bg-primary-soft text-primary-ink"
+                          : "text-ink-2 hover:bg-surface-2"
+                      }`}
+                    >
+                      <Icon icon="lucide:folder" width={14} className="shrink-0 text-faint" />
+                      <span className="truncate">{b.Name}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
             </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                void loadBuckets();
+                if (selectedBucket) void loadContents(selectedBucket, currentPath);
+              }}
+              className="flex items-center justify-center w-8 h-8 rounded-lg border border-border-strong bg-surface text-ink-2 hover:bg-surface-2 transition-colors shrink-0"
+              title="Refresh buckets and current folder"
+              aria-label="Refresh buckets and current folder"
+            >
+              <Icon
+                icon="lucide:refresh-cw"
+                width={15}
+                className={loadingBuckets || loadingContents ? "animate-spin" : ""}
+              />
+            </button>
+
+            <Button
+              variant="primary"
+              icon="lucide:upload"
+              onClick={() => setShowUpload(true)}
+              disabled={!selectedBucket}
+            >
+              Upload file
+            </Button>
           </div>
         </div>
       </header>
 
-      {/* Body — two-panel layout */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Sidebar: bucket list */}
-        <aside className="w-64 bg-white border-r border-gray-200 overflow-y-auto shrink-0">
-          <div className="px-3 py-3 border-b border-gray-100">
-            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Buckets ({buckets.length})</p>
-          </div>
-          {loadingBuckets ? (
-            <div className="p-4 space-y-2">
-              {[0,1,2].map((i) => <div key={i} className="h-8 bg-gray-100 rounded animate-pulse" />)}
-            </div>
-          ) : buckets.length === 0 ? (
-            <div className="p-6 text-center">
-              <FolderIcon className="h-8 w-8 text-gray-300 mx-auto mb-2" />
-              <p className="text-xs text-gray-500">No buckets</p>
-            </div>
-          ) : (
-            <ul className="py-1">
-              {buckets.map((b) => (
-                <li key={b.Name}>
-                  <button
-                    onClick={() => selectBucket(b.Name!)}
-                    className={`w-full flex items-center space-x-2 px-4 py-2 text-sm text-left transition-colors ${
-                      selectedBucket === b.Name
-                        ? "bg-indigo-50 text-indigo-700 font-medium"
-                        : "text-gray-700 hover:bg-gray-50"
-                    }`}
-                  >
-                    <FolderIcon className="h-4 w-4 shrink-0" />
-                    <span className="truncate">{b.Name}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </aside>
-
-        {/* Main content: object browser */}
-        <main className="flex-1 overflow-y-auto p-6">
+      {/* Body */}
+      <main className="flex-1 px-6 py-6">
+        <div className="max-w-[1180px] mx-auto w-full flex flex-col gap-4">
           {!selectedBucket ? (
-            <div className="flex flex-col items-center justify-center h-full text-center py-24">
-              <FolderIcon className="h-16 w-16 text-gray-200 mb-4" />
-              <p className="text-sm text-gray-400">Select a bucket to browse its contents</p>
+            <div className="flex flex-col items-center justify-center text-center py-24">
+              <Icon icon="logos:aws-s3" width={64} className="mb-4 opacity-30" />
+              <p className="text-sm text-muted">
+                {buckets.length === 0
+                  ? "No buckets yet — create one to get started."
+                  : "Select a bucket to browse its contents."}
+              </p>
+              {buckets.length === 0 && (
+                <Button variant="primary" icon="lucide:plus" className="mt-4" onClick={() => setShowCreate(true)}>
+                  Create bucket
+                </Button>
+              )}
             </div>
           ) : (
-            <div>
-              {/* Toolbar */}
-              <div className="mb-4 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  {pathHistory.length > 0 && (
-                    <button
-                      type="button"
-                      onClick={goBack}
-                      className="shrink-0 p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded"
-                      title="Go to parent folder"
-                    >
-                      <BackIcon className="h-4 w-4" />
-                    </button>
-                  )}
+            <div className="grid grid-cols-1 lg:grid-cols-[1.7fr_1fr] gap-4 items-start">
+              {/* Object table */}
+              <Card className="overflow-hidden">
+                <div className="flex items-center gap-2.5 px-3.5 py-2.5 border-b border-divider flex-wrap">
                   <nav
                     aria-label="Bucket path"
-                    className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-0.5 text-sm"
+                    className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs text-muted"
                   >
                     <button
                       type="button"
                       onClick={() => navigateToPrefix("")}
-                      className="shrink-0 max-w-[40vw] truncate text-left font-medium text-indigo-700 hover:text-indigo-900 hover:underline sm:max-w-xs"
+                      className="shrink-0 font-medium text-primary hover:text-primary-hover"
                       title="Bucket root"
                     >
                       {selectedBucket}
@@ -307,123 +373,270 @@ export default function ManageS3Page() {
                     {breadcrumbFolderSegments(currentPath).map((seg, idx, arr) => {
                       const isLast = idx === arr.length - 1;
                       return (
-                        <span key={seg.prefix} className="flex min-w-0 items-center gap-1">
-                          <ChevronRightIcon className="h-3.5 w-3.5 shrink-0 text-gray-400" aria-hidden />
+                        <span key={seg.prefix} className="flex min-w-0 items-center gap-1.5">
+                          <Icon icon="lucide:chevron-right" width={13} className="shrink-0 text-faint" />
                           {isLast ? (
-                            <span
-                              className="truncate font-mono text-xs font-medium text-gray-900"
-                              title={seg.prefix}
-                            >
-                              {seg.label}
+                            <span className="truncate font-mono text-ink" title={seg.prefix}>
+                              {seg.label}/
                             </span>
                           ) : (
                             <button
                               type="button"
                               onClick={() => navigateToPrefix(seg.prefix)}
-                              className="truncate font-mono text-xs text-indigo-600 hover:text-indigo-800 hover:underline"
+                              className="truncate font-mono text-primary hover:text-primary-hover"
                               title={seg.prefix}
                             >
-                              {seg.label}
+                              {seg.label}/
                             </button>
                           )}
                         </span>
                       );
                     })}
                   </nav>
+                  <SearchInput
+                    placeholder="Filter by prefix…"
+                    value={filterText}
+                    onChange={(e) => setFilterText(e.target.value)}
+                    containerClassName="h-7 min-w-[160px] shrink-0"
+                  />
                 </div>
-                <div className="flex shrink-0 items-center justify-end">
-                  <button
-                    type="button"
-                    onClick={() => setShowUpload(true)}
-                    className="flex items-center space-x-1.5 rounded-lg bg-indigo-600 px-3 py-2 text-xs font-medium text-white shadow-sm hover:bg-indigo-700"
-                  >
-                    <ArrowUpTrayIcon className="h-3.5 w-3.5" />
-                    <span>Upload file</span>
-                  </button>
-                </div>
-              </div>
 
-              {/* Object table */}
-              {loadingContents ? (
-                <div className="space-y-2">
-                  {[0,1,2,3].map((i) => <div key={i} className="h-10 bg-gray-100 rounded animate-pulse" />)}
+                <div className="grid grid-cols-[22px_1fr_120px_110px_96px] gap-3 items-center px-3.5 py-2 bg-surface-2 border-b border-divider text-[10px] font-semibold uppercase tracking-wider text-faint">
+                  <span />
+                  <span>Key</span>
+                  <span>Type</span>
+                  <span>Size</span>
+                  <span>Modified</span>
                 </div>
-              ) : contents.length === 0 ? (
-                <div className="text-center py-16">
-                  <DocumentIcon className="h-12 w-12 text-gray-200 mx-auto mb-3" />
-                  <p className="text-sm text-gray-400">Bucket is empty</p>
-                </div>
-              ) : (
-                <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-                  <table className="min-w-full divide-y divide-gray-100 text-sm">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th className="px-4 py-2.5 text-left font-medium text-gray-500">Name</th>
-                        <th className="px-4 py-2.5 text-left font-medium text-gray-500">Size</th>
-                        <th className="px-4 py-2.5 text-left font-medium text-gray-500">Last Modified</th>
-                        <th className="px-4 py-2.5 text-right font-medium text-gray-500">Actions</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-50">
-                      {contents.map((item, i) => {
-                        const key = item.Key || item.Name || "";
-                        const displayName = currentPath ? key.slice(currentPath.length) : key;
-                        const displayLabel = displayName.replace(/\/$/, "") || displayName;
-                        const folder = isFolder(key);
+
+                {loadingContents ? (
+                  <div className="p-3.5 space-y-2">
+                    {[0, 1, 2, 3].map((i) => (
+                      <div key={i} className="h-9 rounded bg-skeleton animate-pulse" />
+                    ))}
+                  </div>
+                ) : visibleContents.length === 0 && pathHistory.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center text-center py-14 px-6">
+                    <Icon icon="lucide:folder-open" width={36} className="mb-3 text-faint" />
+                    <p className="text-sm text-muted">
+                      {filterText ? "No objects match this filter." : "Bucket is empty."}
+                    </p>
+                  </div>
+                ) : (
+                  <div>
+                    {pathHistory.length > 0 && (
+                      <button
+                        type="button"
+                        onClick={goBack}
+                        className="grid w-full grid-cols-[22px_1fr_120px_110px_96px] gap-3 items-center h-9 px-3.5 border-b border-divider text-left hover:bg-surface-2 transition-colors"
+                      >
+                        <span />
+                        <span className="flex items-center gap-2">
+                          <Icon icon="lucide:corner-left-up" width={14} className="text-faint" />
+                          <span className="text-sm text-muted">..</span>
+                        </span>
+                        <span />
+                        <span />
+                        <span />
+                      </button>
+                    )}
+                    {visibleContents.map((item, i) => {
+                      const key = item.Key || item.Name || "";
+                      const displayName = currentPath ? key.slice(currentPath.length) : key;
+                      const displayLabel = displayName.replace(/\/$/, "") || displayName;
+                      const folder = isFolder(key);
+
+                      if (folder) {
                         return (
-                          <tr key={`${key}-${i}`} className="hover:bg-gray-50">
-                            <td className="px-4 py-2.5">
-                              <div className="flex items-center space-x-2">
-                                {folder ? (
-                                  <FolderIcon className="h-4 w-4 text-amber-500 shrink-0" />
-                                ) : (
-                                  <DocumentIcon className="h-4 w-4 text-gray-400 shrink-0" />
-                                )}
-                                {folder ? (
-                                  <button
-                                    onClick={() => openFolder(key)}
-                                    className="text-indigo-600 hover:text-indigo-800 font-mono text-xs hover:underline"
-                                  >
-                                    {displayLabel}
-                                  </button>
-                                ) : (
-                                  <span className="font-mono text-xs text-gray-700">{displayLabel}</span>
-                                )}
-                              </div>
-                            </td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500">{folder ? "—" : formatSize(item.Size)}</td>
-                            <td className="px-4 py-2.5 text-xs text-gray-500">{formatDate(item.LastModified)}</td>
-                            <td className="px-4 py-2.5 text-right">
-                              {!folder && (
-                                <div className="flex items-center justify-end space-x-1">
-                                  <button
-                                    onClick={() => setFileViewer({ bucketName: selectedBucket, objectKey: key })}
-                                    className="p-1.5 text-gray-400 hover:text-indigo-600 transition-colors"
-                                    title="View file"
-                                  >
-                                    <EyeIcon className="h-4 w-4" />
-                                  </button>
-                                  <button
-                                    onClick={() => handleDeleteObject(key)}
-                                    className="p-1.5 text-gray-400 hover:text-red-600 transition-colors"
-                                    title="Delete file"
-                                  >
-                                    <TrashIcon className="h-4 w-4" />
-                                  </button>
-                                </div>
-                              )}
-                            </td>
-                          </tr>
+                          <button
+                            key={`${key}-${i}`}
+                            type="button"
+                            onClick={() => openFolder(key)}
+                            className="grid w-full grid-cols-[22px_1fr_120px_110px_96px] gap-3 items-center h-9 px-3.5 border-b border-divider text-left hover:bg-surface-2 transition-colors"
+                          >
+                            <span />
+                            <span className="flex items-center gap-2 min-w-0">
+                              <Icon icon="lucide:folder" width={14} className="shrink-0 text-muted" />
+                              <span className="truncate font-mono text-[13px] text-ink">{displayLabel}/</span>
+                            </span>
+                            <span className="text-xs text-faint">prefix</span>
+                            <span className="text-xs text-faint">{folderObjectCount(key)} objects</span>
+                            <span className="text-xs text-muted">—</span>
+                          </button>
                         );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
-              )}
+                      }
+
+                      const selected = selectedKey === key;
+                      const typeInfo = getFileTypeInfo(key);
+
+                      return (
+                        <div
+                          key={`${key}-${i}`}
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => setSelectedKey(key)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") setSelectedKey(key);
+                          }}
+                          className={`group grid grid-cols-[22px_1fr_120px_110px_96px] gap-3 items-center h-9 px-3.5 border-b border-divider cursor-pointer transition-colors ${
+                            selected ? "bg-primary-soft" : "hover:bg-surface-2"
+                          }`}
+                        >
+                          <span className="flex items-center justify-center">
+                            {selected ? (
+                              <span className="flex items-center justify-center w-3.5 h-3.5 rounded bg-primary text-white">
+                                <Icon icon="lucide:check" width={10} />
+                              </span>
+                            ) : (
+                              <span className="w-3.5 h-3.5 rounded border border-border-strong bg-surface" />
+                            )}
+                          </span>
+                          <span className="flex items-center gap-2 min-w-0">
+                            <Icon
+                              icon={typeInfo.icon}
+                              width={14}
+                              className={`shrink-0 ${selected ? "text-primary" : "text-muted"}`}
+                            />
+                            <span
+                              className={`truncate font-mono text-[13px] ${
+                                selected ? "text-primary-ink" : "text-ink"
+                              }`}
+                            >
+                              {displayLabel}
+                            </span>
+                          </span>
+                          <span
+                            className={`truncate font-mono text-[11px] ${
+                              selected ? "text-primary" : "text-muted"
+                            }`}
+                          >
+                            {typeInfo.label}
+                          </span>
+                          <span className={`text-xs ${selected ? "text-primary" : "text-muted"}`}>
+                            {formatSize(item.Size)}
+                          </span>
+                          <span
+                            className={`flex items-center justify-between gap-1 text-xs ${
+                              selected ? "text-primary" : "text-muted"
+                            }`}
+                          >
+                            <span className="truncate">{formatDate(item.LastModified)}</span>
+                            <span className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setFileViewer({ bucketName: selectedBucket, objectKey: key });
+                                }}
+                                className="p-1 rounded text-faint hover:text-primary hover:bg-surface-3"
+                                title="View file"
+                                aria-label="View file"
+                              >
+                                <Icon icon="lucide:eye" width={13} />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleDeleteObject(key);
+                                }}
+                                className="p-1 rounded text-faint hover:text-danger hover:bg-danger-soft"
+                                title="Delete file"
+                                aria-label="Delete file"
+                              >
+                                <Icon icon="lucide:trash-2" width={13} />
+                              </button>
+                            </span>
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </Card>
+
+              {/* Details panel */}
+              <div className="flex flex-col gap-4">
+                <Card className="overflow-hidden">
+                  {selectedItem ? (
+                    <>
+                      <div className="flex items-center gap-2.5 px-3.5 py-3 border-b border-divider">
+                        <Icon
+                          icon={getFileTypeInfo(selectedItem.Key || "").icon}
+                          width={16}
+                          className="shrink-0 text-muted"
+                        />
+                        <span className="truncate font-mono text-[13px] font-medium text-ink">
+                          {(selectedItem.Key || "").slice(currentPath.length)}
+                        </span>
+                      </div>
+                      <div className="flex flex-col gap-1.5 px-3.5 py-3">
+                        <div className="flex justify-between text-[11px]">
+                          <span className="text-muted">Type</span>
+                          <span className="font-mono text-ink-2">
+                            {getFileTypeInfo(selectedItem.Key || "").label}
+                          </span>
+                        </div>
+                        <div className="flex justify-between text-[11px]">
+                          <span className="text-muted">Size</span>
+                          <span className="font-mono text-ink-2">{formatSize(selectedItem.Size)}</span>
+                        </div>
+                        <div className="flex justify-between text-[11px]">
+                          <span className="text-muted">Modified</span>
+                          <span className="font-mono text-ink-2">{formatDate(selectedItem.LastModified)}</span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2 px-3.5 py-3 border-t border-divider">
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          icon="lucide:eye"
+                          onClick={() =>
+                            setFileViewer({ bucketName: selectedBucket, objectKey: selectedItem.Key || "" })
+                          }
+                        >
+                          Preview
+                        </Button>
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          icon="lucide:trash-2"
+                          className="ml-auto"
+                          onClick={() => handleDeleteObject(selectedItem.Key || "")}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center px-6 py-10 text-center">
+                      <Icon icon="lucide:file" width={28} className="mb-2 text-faint" />
+                      <p className="text-xs text-muted">Select an object to see its details.</p>
+                    </div>
+                  )}
+                </Card>
+
+                {selectedItem && (
+                  <Card className="flex flex-col gap-2.5 p-3.5">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-faint">
+                      Read it from your app
+                    </span>
+                    <pre className="m-0 overflow-auto rounded-lg border border-border bg-surface-2 p-2.5 font-mono text-[11px] leading-relaxed text-ink-2">
+{`await s3.send(new GetObjectCommand({
+  Bucket: "${selectedBucket}",
+  Key: "${selectedItem.Key || ""}",
+}));`}
+                    </pre>
+                    <Link href="/s3" className="text-[11px] font-medium">
+                      Full connection guide →
+                    </Link>
+                  </Card>
+                )}
+              </div>
             </div>
           )}
-        </main>
-      </div>
+        </div>
+      </main>
 
       {/* Modals */}
       <S3ConfigModal

--- a/localcloud-gui/src/components/BucketViewer.tsx
+++ b/localcloud-gui/src/components/BucketViewer.tsx
@@ -1,19 +1,6 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import {
-  XMarkIcon,
-  FolderIcon,
-  DocumentIcon,
-  ArrowLeftIcon,
-  EyeIcon,
-  TrashIcon,
-  PlusIcon,
-  ArrowPathIcon,
-  ChevronUpIcon,
-  ChevronDownIcon,
-  ArrowTopRightOnSquareIcon,
-} from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { s3Api, resourceApi } from "@/services/api";
 import { S3BucketConfig } from "@/types";
@@ -22,6 +9,7 @@ import UploadFileModal from "./UploadFileModal";
 import S3ConfigModal from "./S3ConfigModal";
 import { highlightThemes, HighlightTheme } from "./highlightThemes";
 import { Icon } from "@iconify/react";
+import { Button, IconButton } from "@/components/ui";
 import { AnimatePresence, motion } from "framer-motion";
 import { toast } from "react-hot-toast";
 import { listS3ObjectsAtPrefix } from "@/lib/s3PrefixListing";
@@ -46,6 +34,36 @@ interface BucketItem {
   LastModified?: string;
   StorageClass?: string;
   CreationDate?: string;
+}
+
+/** Iconify name + short mime-ish label shown in the Type column, guessed from the key's extension. */
+const FILE_TYPE_BY_EXT: Record<string, { icon: string; label: string }> = {
+  json: { icon: "lucide:file-json", label: "app/json" },
+  png: { icon: "lucide:file-image", label: "image/png" },
+  jpg: { icon: "lucide:file-image", label: "image/jpeg" },
+  jpeg: { icon: "lucide:file-image", label: "image/jpeg" },
+  gif: { icon: "lucide:file-image", label: "image/gif" },
+  svg: { icon: "lucide:file-image", label: "image/svg" },
+  webp: { icon: "lucide:file-image", label: "image/webp" },
+  bmp: { icon: "lucide:file-image", label: "image/bmp" },
+  csv: { icon: "lucide:file-text", label: "text/csv" },
+  txt: { icon: "lucide:file-text", label: "text/plain" },
+  md: { icon: "lucide:file-text", label: "text/markdown" },
+  pdf: { icon: "lucide:file-text", label: "app/pdf" },
+  xml: { icon: "lucide:file-code", label: "app/xml" },
+  yml: { icon: "lucide:file-code", label: "text/yaml" },
+  yaml: { icon: "lucide:file-code", label: "text/yaml" },
+  js: { icon: "lucide:file-code", label: "text/js" },
+  ts: { icon: "lucide:file-code", label: "text/ts" },
+  tsx: { icon: "lucide:file-code", label: "text/tsx" },
+  html: { icon: "lucide:file-code", label: "text/html" },
+  css: { icon: "lucide:file-code", label: "text/css" },
+};
+const DEFAULT_FILE_TYPE = { icon: "lucide:file", label: "binary" };
+
+function getFileTypeInfo(key: string) {
+  const ext = key.split(".").pop()?.toLowerCase() || "";
+  return FILE_TYPE_BY_EXT[ext] || DEFAULT_FILE_TYPE;
 }
 
 export default function BucketViewer({
@@ -340,10 +358,15 @@ export default function BucketViewer({
     }
   };
 
+  const sortIcon = (key: "name" | "size" | "modified" | "storage") =>
+    sortConfig?.key === key ? (
+      <Icon icon={sortConfig.direction === "asc" ? "lucide:chevron-up" : "lucide:chevron-down"} width={13} />
+    ) : null;
+
   return (
   <>
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4"
       onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
@@ -351,48 +374,54 @@ export default function BucketViewer({
         animate={{ opacity: 1, y: 0, scale: 1 }}
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
-        className="bg-white rounded-xl shadow-2xl w-full max-w-4xl h-[88vh] flex flex-col"
+        className="bg-surface border border-border rounded-xl shadow-e3 w-full max-w-4xl h-[88vh] flex flex-col overflow-hidden"
       >
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200 shrink-0">
+        <div className="px-6 py-4 border-b border-divider shrink-0">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4 min-w-0 flex-1">
               {selectedBucket && (
-                <button
+                <IconButton
+                  icon="lucide:arrow-left"
+                  label="Back to bucket list"
+                  variant="ghost"
                   onClick={() => {
                     setSelectedBucket(null);
                     setBucketContents([]);
                     setCurrentPath("");
                     setPathHistory([]);
                   }}
-                  className="p-2 text-gray-400 hover:text-gray-600 shrink-0"
-                >
-                  <ArrowLeftIcon className="h-5 w-5" />
-                </button>
+                  className="shrink-0"
+                />
               )}
               <div className="min-w-0 flex-1">
-                <h2 className="text-lg font-semibold text-gray-900">
-                  {selectedBucket ? `Bucket: ${selectedBucket}` : "S3 Buckets"}
+                <h2 className="text-lg font-semibold text-ink flex items-center gap-2">
+                  {!selectedBucket && <Icon icon="logos:aws-s3" width={18} />}
+                  {selectedBucket ? (
+                    <span className="font-mono">{selectedBucket}</span>
+                  ) : (
+                    "S3 Buckets"
+                  )}
                 </h2>
                 {selectedBucket && currentPath && (
-                  <div className="flex items-center space-x-2 text-sm text-gray-600 mt-2 flex-wrap">
-                    <span className="text-gray-400">Path:</span>
+                  <div className="flex items-center space-x-2 text-sm text-muted mt-1.5 flex-wrap">
+                    <span className="text-faint">Path:</span>
                     <button
                       onClick={handleRootClick}
-                      className="text-blue-600 hover:text-blue-800"
+                      className="text-primary hover:text-primary-hover"
                     >
                       root
                     </button>
                     {pathHistory.map((path, index) => (
                       <div key={index} className="flex items-center space-x-2">
-                        <span>/</span>
+                        <Icon icon="lucide:chevron-right" width={12} className="text-faint" />
                         <button
                           onClick={() => {
                             const newHistory = pathHistory.slice(0, index + 1);
                             setPathHistory(newHistory);
                             loadBucketContents(selectedBucket, path);
                           }}
-                          className="text-blue-600 hover:text-blue-800"
+                          className="font-mono text-primary hover:text-primary-hover"
                         >
                           {getDisplayName(path)}
                         </button>
@@ -400,8 +429,8 @@ export default function BucketViewer({
                     ))}
                     {currentPath && (
                       <>
-                        <span>/</span>
-                        <span className="text-gray-900 font-medium">
+                        <Icon icon="lucide:chevron-right" width={12} className="text-faint" />
+                        <span className="font-mono font-medium text-ink">
                           {getDisplayName(currentPath)}
                         </span>
                       </>
@@ -410,54 +439,38 @@ export default function BucketViewer({
                 )}
               </div>
             </div>
-            <div className="flex items-center space-x-4 shrink-0 ml-4">
+            <div className="flex items-center gap-2 shrink-0 ml-4">
               {selectedBucket && currentPath && pathHistory.length > 0 && (
-                <button
-                  onClick={handleBackClick}
-                  className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500"
-                >
-                  <ArrowLeftIcon className="h-4 w-4 mr-2" />
+                <Button variant="secondary" size="sm" icon="lucide:arrow-left" onClick={handleBackClick}>
                   Back
-                </button>
+                </Button>
               )}
               {selectedBucket && (
-                <button
-                  onClick={() =>
-                    loadBucketContents(selectedBucket, currentPath)
-                  }
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  icon="lucide:refresh-cw"
+                  onClick={() => loadBucketContents(selectedBucket, currentPath)}
                   disabled={loading}
-                  className="flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Refresh bucket contents"
                 >
-                  <ArrowPathIcon
-                    className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`}
-                  />
                   Refresh
-                </button>
+                </Button>
               )}
               <Link
                 href="/manage/s3"
-                className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors"
+                onClick={onClose}
+                className="no-underline inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-primary text-xs font-medium hover:bg-primary-soft transition-colors"
               >
-                <span>Open Manager</span>
-                <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                Open Manager
+                <Icon icon="lucide:external-link" width={13} />
               </Link>
               {selectedBucket && (
-                <button
-                  onClick={() => setUploadModalOpen(true)}
-                  className="flex items-center px-3 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                >
-                  <PlusIcon className="h-4 w-4 mr-2" />
+                <Button variant="primary" size="sm" icon="lucide:upload" onClick={() => setUploadModalOpen(true)}>
                   Upload File
-                </button>
+                </Button>
               )}
-              <button
-                onClick={onClose}
-                className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-                aria-label="Close"
-              >
-                <XMarkIcon className="h-5 w-5" />
-              </button>
+              <IconButton icon="lucide:x" label="Close" variant="ghost" onClick={onClose} />
             </div>
           </div>
         </div>
@@ -478,17 +491,17 @@ export default function BucketViewer({
               {[1, 0.85, 0.7, 0.55].map((op, i) => (
                 <div
                   key={i}
-                  className="border border-gray-200 rounded-lg p-4 flex items-center justify-between"
+                  className="border border-border rounded-lg p-4 flex items-center justify-between"
                   style={{ opacity: op }}
                 >
                   <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded bg-blue-100 shrink-0" />
+                    <div className="h-8 w-8 rounded bg-skeleton shrink-0" />
                     <div className="space-y-1.5">
-                      <div className="h-4 w-44 bg-gray-200 rounded" />
-                      <div className="h-3 w-32 bg-gray-100 rounded" />
+                      <div className="h-4 w-44 bg-skeleton rounded" />
+                      <div className="h-3 w-32 bg-skeleton rounded" />
                     </div>
                   </div>
-                  <div className="h-3 w-24 bg-gray-100 rounded" />
+                  <div className="h-3 w-24 bg-skeleton rounded" />
                 </div>
               ))}
             </motion.div>
@@ -503,45 +516,45 @@ export default function BucketViewer({
               className="h-full overflow-auto animate-pulse"
             >
               {/* Fake table header */}
-              <div className="flex bg-gray-50 border-b border-gray-200 px-6 py-3 gap-6">
-                <div className="h-3 w-2/5 bg-gray-200 rounded" />
-                <div className="h-3 w-16 bg-gray-100 rounded" />
-                <div className="h-3 w-32 bg-gray-100 rounded" />
-                <div className="h-3 w-28 bg-gray-100 rounded" />
-                <div className="h-3 w-16 bg-gray-100 rounded ml-auto" />
+              <div className="flex bg-surface-2 border-b border-divider px-6 py-3 gap-6">
+                <div className="h-3 w-2/5 bg-skeleton rounded" />
+                <div className="h-3 w-16 bg-skeleton rounded" />
+                <div className="h-3 w-32 bg-skeleton rounded" />
+                <div className="h-3 w-28 bg-skeleton rounded" />
+                <div className="h-3 w-16 bg-skeleton rounded ml-auto" />
               </div>
               {/* Fake rows */}
               {Array.from({ length: 8 }).map((_, i) => (
                 <div
                   key={i}
-                  className="flex items-center border-b border-gray-100 px-6 py-4 gap-6"
+                  className="flex items-center border-b border-divider px-6 py-4 gap-6"
                   style={{ opacity: 1 - i * 0.09 }}
                 >
                   <div className="flex items-center gap-2 w-2/5">
-                    <div className="h-5 w-5 rounded bg-gray-200 shrink-0" />
-                    <div className="h-3 flex-1 bg-gray-200 rounded" />
+                    <div className="h-5 w-5 rounded bg-skeleton shrink-0" />
+                    <div className="h-3 flex-1 bg-skeleton rounded" />
                   </div>
-                  <div className="h-3 w-16 bg-gray-100 rounded" />
-                  <div className="h-3 w-32 bg-gray-100 rounded" />
-                  <div className="h-3 w-20 bg-gray-100 rounded" />
-                  <div className="h-3 w-12 bg-gray-100 rounded ml-auto" />
+                  <div className="h-3 w-16 bg-skeleton rounded" />
+                  <div className="h-3 w-32 bg-skeleton rounded" />
+                  <div className="h-3 w-20 bg-skeleton rounded" />
+                  <div className="h-3 w-12 bg-skeleton rounded ml-auto" />
                 </div>
               ))}
             </motion.div>
           ) : error ? (
             <motion.div key="error" variants={panelVariants} initial="hidden" animate="visible" exit="exit" className="flex items-center justify-center h-full">
               <div className="text-center">
-                <p className="text-red-600 mb-4">{error}</p>
-                <button
+                <p className="text-danger mb-4">{error}</p>
+                <Button
+                  variant="primary"
                   onClick={
                     selectedBucket
                       ? () => loadBucketContents(selectedBucket, currentPath)
                       : loadBuckets
                   }
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
                 >
                   Retry
-                </button>
+                </Button>
               </div>
             </motion.div>
           ) : selectedBucket ? (
@@ -550,100 +563,83 @@ export default function BucketViewer({
               {bucketContents.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full text-center py-16 px-6">
                   <Icon icon="logos:aws-s3" className="w-20 h-20 mb-4 opacity-20" />
-                  <p className="text-sm font-medium text-gray-700">This bucket is empty</p>
-                  <p className="text-xs text-gray-400 mt-1">Upload a file using the button above to get started.</p>
+                  <p className="text-sm font-medium text-ink-2">This bucket is empty</p>
+                  <p className="text-xs text-faint mt-1">Upload a file using the button above to get started.</p>
                 </div>
               ) : (
                 <div className="p-6">
-                  <div className="overflow-x-auto">
-                    <table className="min-w-full divide-y divide-gray-200">
-                      <thead className="bg-gray-50">
+                  <div className="overflow-x-auto rounded-lg border border-border">
+                    <table className="min-w-full divide-y divide-divider">
+                      <thead className="bg-surface-2">
                         <tr>
                           <th
-                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-2/5 cursor-pointer hover:bg-gray-100 select-none"
+                            className="px-6 py-3 text-left text-[10px] font-semibold text-faint uppercase tracking-wider w-2/5 cursor-pointer hover:bg-surface-3 select-none"
                             onClick={() => handleSort("name")}
                           >
                             <div className="flex items-center space-x-1">
-                              <span>Name</span>
-                              {sortConfig?.key === "name" &&
-                                (sortConfig.direction === "asc" ? (
-                                  <ChevronUpIcon className="h-4 w-4" />
-                                ) : (
-                                  <ChevronDownIcon className="h-4 w-4" />
-                                ))}
+                              <span>Key</span>
+                              {sortIcon("name")}
                             </div>
                           </th>
                           <th
-                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-20 cursor-pointer hover:bg-gray-100 select-none"
+                            className="px-6 py-3 text-left text-[10px] font-semibold text-faint uppercase tracking-wider w-20 cursor-pointer hover:bg-surface-3 select-none"
                             onClick={() => handleSort("size")}
                           >
                             <div className="flex items-center space-x-1">
                               <span>Size</span>
-                              {sortConfig?.key === "size" &&
-                                (sortConfig.direction === "asc" ? (
-                                  <ChevronUpIcon className="h-4 w-4" />
-                                ) : (
-                                  <ChevronDownIcon className="h-4 w-4" />
-                                ))}
+                              {sortIcon("size")}
                             </div>
                           </th>
                           <th
-                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-44 cursor-pointer hover:bg-gray-100 select-none"
+                            className="px-6 py-3 text-left text-[10px] font-semibold text-faint uppercase tracking-wider w-44 cursor-pointer hover:bg-surface-3 select-none"
                             onClick={() => handleSort("modified")}
                           >
                             <div className="flex items-center space-x-1">
                               <span>Last Modified</span>
-                              {sortConfig?.key === "modified" &&
-                                (sortConfig.direction === "asc" ? (
-                                  <ChevronUpIcon className="h-4 w-4" />
-                                ) : (
-                                  <ChevronDownIcon className="h-4 w-4" />
-                                ))}
+                              {sortIcon("modified")}
                             </div>
                           </th>
                           <th
-                            className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-32 cursor-pointer hover:bg-gray-100 select-none"
+                            className="px-6 py-3 text-left text-[10px] font-semibold text-faint uppercase tracking-wider w-32 cursor-pointer hover:bg-surface-3 select-none"
                             onClick={() => handleSort("storage")}
                           >
                             <div className="flex items-center space-x-1">
                               <span>Storage Class</span>
-                              {sortConfig?.key === "storage" &&
-                                (sortConfig.direction === "asc" ? (
-                                  <ChevronUpIcon className="h-4 w-4" />
-                                ) : (
-                                  <ChevronDownIcon className="h-4 w-4" />
-                                ))}
+                              {sortIcon("storage")}
                             </div>
                           </th>
-                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-24">
+                          <th className="px-6 py-3 text-left text-[10px] font-semibold text-faint uppercase tracking-wider w-24">
                             Actions
                           </th>
                         </tr>
                       </thead>
-                      <tbody className="bg-white divide-y divide-gray-200">
-                        {getSortedContents().map((item, index) => (
-                          <tr key={item.Key ?? `obj-${index}`} className="hover:bg-gray-50">
+                      <tbody className="bg-surface divide-y divide-divider">
+                        {getSortedContents().map((item, index) => {
+                          const folder = isFolder(item.Key || "");
+                          const typeInfo = getFileTypeInfo(item.Key || "");
+                          return (
+                          <tr key={item.Key ?? `obj-${index}`} className="hover:bg-surface-2 transition-colors">
                             <td className="px-6 py-4">
                               <div className="flex items-center">
-                                {isFolder(item.Key || "") ? (
-                                  <FolderIcon className="h-5 w-5 text-blue-500 mr-2 shrink-0" />
-                                ) : (
-                                  <DocumentIcon className="h-5 w-5 text-gray-400 mr-2 shrink-0" />
-                                )}
+                                <Icon
+                                  icon={folder ? "lucide:folder" : typeInfo.icon}
+                                  width={16}
+                                  className={`mr-2 shrink-0 ${folder ? "text-muted" : "text-faint"}`}
+                                />
                                 <div className="flex flex-col min-w-0 flex-1">
-                                  {isFolder(item.Key || "") ? (
+                                  {folder ? (
                                     <button
                                       onClick={() =>
                                         handleFolderClick(item.Key || "")
                                       }
-                                      className="text-left text-sm text-blue-600 hover:text-blue-800 font-medium cursor-pointer truncate"
+                                      className="text-left text-sm text-primary hover:text-primary-hover font-mono font-medium cursor-pointer truncate"
                                       title={getDisplayName(item.Key || "")}
                                     >
                                       {getDisplayName(item.Key || "")}
                                     </button>
                                   ) : (
                                     <span
-                                      className="text-sm text-gray-900 font-medium truncate"
+                                      className="text-sm text-ink font-mono font-medium truncate"
                                       title={getDisplayName(item.Key || "")}
                                     >
                                       {getDisplayName(item.Key || "")}
@@ -651,7 +647,7 @@ export default function BucketViewer({
                                   )}
                                   {item.Key && item.Key.includes("/") && (
                                     <span
-                                      className="text-xs text-gray-500 truncate max-w-xs"
+                                      className="text-xs text-faint truncate max-w-xs"
                                       title={item.Key}
                                     >
                                       {item.Key}
@@ -660,44 +656,42 @@ export default function BucketViewer({
                                 </div>
                               </div>
                             </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                              {isFolder(item.Key || "")
-                                ? "-"
-                                : formatFileSize(item.Size)}
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
+                              {folder ? "-" : formatFileSize(item.Size)}
                             </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
                               {formatDate(item.LastModified)}
                             </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                            <td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
                               {item.StorageClass || "STANDARD"}
                             </td>
-                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                              {!isFolder(item.Key || "") && (
-                                <div className="flex items-center space-x-2">
+                            <td className="px-6 py-4 whitespace-nowrap text-sm">
+                              {!folder && (
+                                <div className="flex items-center space-x-1">
                                   <button
                                     onClick={() =>
                                       handleViewFile(item.Key || "")
                                     }
-                                    className="p-1 text-blue-600 hover:text-blue-800"
+                                    className="p-1 rounded text-muted hover:text-primary hover:bg-primary-soft transition-colors"
                                     title="View file"
                                   >
-                                    <EyeIcon className="h-4 w-4" />
+                                    <Icon icon="lucide:eye" width={15} />
                                   </button>
                                   <button
                                     onClick={() =>
                                       handleDeleteFile(item.Key || "")
                                     }
                                     disabled={deletingFile === item.Key}
-                                    className="p-1 text-red-600 hover:text-red-800 disabled:opacity-50"
+                                    className="p-1 rounded text-muted hover:text-danger hover:bg-danger-soft transition-colors disabled:opacity-50"
                                     title="Delete file"
                                   >
-                                    <TrashIcon className="h-4 w-4" />
+                                    <Icon icon="lucide:trash-2" width={15} />
                                   </button>
                                 </div>
                               )}
                             </td>
                           </tr>
-                        ))}
+                        );})}
                       </tbody>
                     </table>
                   </div>
@@ -710,15 +704,11 @@ export default function BucketViewer({
               {buckets.length === 0 ? (
                 <div className="flex flex-col items-center justify-center h-full text-center py-16 px-6">
                   <Icon icon="logos:aws-s3" className="w-24 h-24 mb-4 opacity-20" />
-                  <p className="text-sm font-medium text-gray-700">No S3 buckets found</p>
-                  <p className="text-xs text-gray-400 mt-1 mb-5">Create your first bucket to start storing files.</p>
-                  <button
-                    onClick={() => setShowCreateBucket(true)}
-                    className="flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors shadow-sm"
-                  >
-                    <PlusIcon className="h-4 w-4 mr-1.5" />
+                  <p className="text-sm font-medium text-ink-2">No S3 buckets found</p>
+                  <p className="text-xs text-faint mt-1 mb-5">Create your first bucket to start storing files.</p>
+                  <Button variant="primary" icon="lucide:plus" onClick={() => setShowCreateBucket(true)}>
                     Create Bucket
-                  </button>
+                  </Button>
                 </div>
               ) : (
                 <div className="p-6">
@@ -726,23 +716,26 @@ export default function BucketViewer({
                     {buckets.map((bucket, index) => (
                       <div
                         key={bucket.Name ?? `bucket-${index}`}
-                        className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 cursor-pointer"
+                        className="border border-border rounded-lg p-4 hover:bg-surface-2 hover:border-border-strong cursor-pointer transition-colors"
                         onClick={() => loadBucketContents(bucket.Name || "")}
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex items-center">
-                            <FolderIcon className="h-8 w-8 text-blue-500 mr-3" />
+                            <span className="flex items-center justify-center w-11 h-11 rounded-lg bg-primary-soft mr-3 shrink-0">
+                              <Icon icon="logos:aws-s3" width={20} />
+                            </span>
                             <div>
-                              <h3 className="text-lg font-medium text-gray-900">
+                              <h3 className="text-base font-mono font-medium text-ink">
                                 {bucket.Name}
                               </h3>
-                              <p className="text-sm text-gray-500">
+                              <p className="text-sm text-muted">
                                 Created: {formatDate(bucket.CreationDate)}
                               </p>
                             </div>
                           </div>
-                          <div className="text-sm text-gray-500">
-                            Click to view contents
+                          <div className="text-sm text-faint flex items-center gap-1">
+                            View contents
+                            <Icon icon="lucide:chevron-right" width={14} />
                           </div>
                         </div>
                       </div>

--- a/localcloud-gui/src/components/CliPlaybookSection.tsx
+++ b/localcloud-gui/src/components/CliPlaybookSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Icon } from "@iconify/react";
 import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
 import { usePreferences } from "@/context/PreferencesContext";
 import {
@@ -13,14 +14,7 @@ import {
 } from "@/lib/cliPlaybook";
 import { resourceApi } from "@/services/api";
 import type { Resource, SavedConfig } from "@/types";
-import {
-  ArrowDownTrayIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  ClipboardDocumentIcon,
-  CommandLineIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline";
+import { Badge, Button, Card, IconButton, SegmentedControl, type StatusTone } from "@/components/ui";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "react-hot-toast";
 
@@ -33,6 +27,12 @@ const TYPE_LABELS: Record<string, string> = {
   secrets: "Secrets Manager",
   ssm: "SSM",
   iam: "IAM",
+};
+
+const SOURCE_LABELS: Record<string, { label: string; tone: StatusTone }> = {
+  matched: { label: "full recipe", tone: "success" },
+  "saved-config": { label: "saved recipe", tone: "neutral" },
+  "live-only": { label: "minimal CLI", tone: "warn" },
 };
 
 interface CliPlaybookSectionProps {
@@ -120,25 +120,8 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
   };
 
   const sourceBadge = (source: string) => {
-    if (source === "matched") {
-      return (
-        <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-800">
-          full recipe
-        </span>
-      );
-    }
-    if (source === "saved-config") {
-      return (
-        <span className="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-800">
-          saved recipe
-        </span>
-      );
-    }
-    return (
-      <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-800">
-        minimal CLI
-      </span>
-    );
+    const meta = SOURCE_LABELS[source] || SOURCE_LABELS["live-only"];
+    return <Badge tone={meta.tone}>{meta.label}</Badge>;
   };
 
   const toggleConfigSelection = (id: number) => {
@@ -193,80 +176,76 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+    <Card className="p-6">
       <div className="flex items-start justify-between gap-4 mb-4 flex-wrap">
         <div>
-          <h2 className="text-lg font-semibold text-gray-900">CLI Playbook</h2>
-          <p className="text-sm text-gray-500 mt-1">
-            Project: <span className="font-medium text-gray-700">{projectLabel}</span>
+          <h2 className="text-lg font-semibold text-ink">CLI Playbook</h2>
+          <p className="text-sm text-muted mt-1">
+            Project: <span className="font-medium text-ink-2">{projectLabel}</span>
           </p>
         </div>
         <div className="flex shrink-0 gap-2">
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="lucide:copy"
             onClick={() => copyText(fullScript, "Full playbook copied")}
-            className="flex items-center px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
           >
-            <ClipboardDocumentIcon className="h-4 w-4 mr-1" />
             Copy all
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            icon="lucide:download"
             onClick={downloadScript}
             disabled={entries.length === 0}
-            className="flex items-center px-3 py-1.5 text-xs font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
           >
-            <ArrowDownTrayIcon className="h-4 w-4 mr-1" />
             Download .sh
-          </button>
+          </Button>
         </div>
       </div>
 
-      <p className="text-sm text-gray-500 mb-4">
-        Portable <code className="text-xs bg-gray-100 px-1 rounded">aws</code> commands with no
-        endpoint in each line. Use <strong>LCK AWS CLI</strong> for MiniStack or{" "}
-        <strong>AWS CLI</strong> for real AWS — see the environment block for each.
+      <p className="text-sm text-muted mb-4">
+        Portable <code className="text-xs font-mono bg-surface-3 px-1 rounded">aws</code> commands
+        with no endpoint in each line. Use <strong className="text-ink-2">LCK AWS CLI</strong> for
+        MiniStack or <strong className="text-ink-2">AWS CLI</strong> for real AWS — see the
+        environment block for each.
       </p>
 
       <div className="flex flex-wrap items-center gap-2 mb-4 w-full">
-        <span className="text-sm font-medium text-gray-700">Environment:</span>
-        {(["local", "aws"] as const).map((mode) => (
-          <button
-            key={mode}
-            type="button"
-            onClick={() => setPreambleMode(mode)}
-            className={`px-3 py-1.5 text-sm font-medium rounded-md border transition-colors ${
-              preambleMode === mode
-                ? "bg-blue-600 text-white border-blue-600"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
-            }`}
-          >
-            {mode === "local" ? "LCK AWS CLI" : "AWS CLI"}
-          </button>
-        ))}
+        <span className="text-sm font-medium text-ink-2">Environment:</span>
+        <SegmentedControl
+          options={[
+            { value: "local", label: "LCK AWS CLI" },
+            { value: "aws", label: "AWS CLI" },
+          ]}
+          value={preambleMode}
+          onChange={setPreambleMode}
+        />
         <button
           type="button"
           onClick={loadResources}
           disabled={loadingResources}
-          className="ml-auto text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
+          className="ml-auto flex items-center gap-1.5 text-xs font-medium text-primary hover:text-primary-hover disabled:opacity-50 cursor-pointer"
         >
+          <Icon
+            icon="lucide:refresh-cw"
+            width={13}
+            className={loadingResources ? "animate-spin" : undefined}
+          />
           {loadingResources ? "Refreshing…" : "Refresh inventory"}
         </button>
       </div>
 
       <div className="mb-6 mt-4">
-        <h3 className="text-sm font-medium text-gray-700 mb-2">Environment setup</h3>
-        <ThemeableCodeBlock
-          code={preamble}
-          language="bash"
-          showThemeSelector={false}
-        />
+        <h3 className="text-sm font-medium text-ink-2 mb-2">Environment setup</h3>
+        <ThemeableCodeBlock code={preamble} language="bash" showThemeSelector={false} />
       </div>
 
       <div className="mb-6">
-        <h3 className="text-sm font-medium text-gray-700 mb-2">Live inventory</h3>
+        <h3 className="text-sm font-medium text-ink-2 mb-2">Live inventory</h3>
         {summary.length === 0 ? (
-          <p className="text-sm text-gray-400 italic">
+          <p className="text-sm text-faint italic">
             {loadingResources
               ? "Loading resources…"
               : "No resources in the emulator for this project."}
@@ -276,7 +255,7 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
             {summary.map(({ type, count }) => (
               <span
                 key={type}
-                className="text-xs px-2.5 py-1 rounded-md bg-gray-100 text-gray-700 border border-gray-200"
+                className="text-xs px-2.5 py-1 rounded-md bg-surface-3 text-ink-2 border border-border"
               >
                 {TYPE_LABELS[type] || type}: <strong>{count}</strong>
               </span>
@@ -285,13 +264,13 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
         )}
       </div>
 
-      <h3 className="text-sm font-medium text-gray-700 mb-1">Rebuild commands</h3>
-      <p className="text-xs text-gray-500 mb-3">
+      <h3 className="text-sm font-medium text-ink-2 mb-1">Rebuild commands</h3>
+      <p className="text-xs text-muted mb-3">
         Copy portable CLI for each resource. Manage stored recipes in Saved configurations below.
       </p>
 
       {entries.length === 0 ? (
-        <p className="text-sm text-gray-400 italic">
+        <p className="text-sm text-faint italic">
           No saved configs or live resources yet. Create resources on the dashboard and save
           configs from the creation forms for full CLI recipes.
         </p>
@@ -302,59 +281,50 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
             return (
               <div
                 key={entry.id}
-                className="border border-gray-200 rounded-lg overflow-hidden bg-gray-50"
+                className="border border-border rounded-lg overflow-hidden bg-surface-2"
               >
                 <div className="flex items-center gap-1 px-2 py-2 sm:px-3">
                   <button
                     type="button"
                     onClick={() => setExpandedId(isOpen ? null : entry.id)}
-                    className="flex-1 flex items-center gap-3 min-w-0 px-2 py-1 text-left rounded-md hover:bg-gray-100 transition-colors"
+                    className="flex-1 flex items-center gap-3 min-w-0 px-2 py-1 text-left rounded-md cursor-pointer hover:bg-surface-3 transition-colors"
                   >
-                    <CommandLineIcon className="h-4 w-4 text-gray-500 shrink-0" />
+                    <Icon icon="lucide:terminal" width={16} className="text-muted shrink-0" />
                     <div className="min-w-0">
-                      <p className="text-sm font-medium text-gray-900 truncate">
+                      <p className="text-sm font-medium text-ink truncate">
                         {entry.resourceName}
                         {entry.savedConfigName && entry.label !== entry.resourceName && (
-                          <span className="text-gray-500 font-normal">
-                            {" "}
-                            ({entry.savedConfigName})
-                          </span>
+                          <span className="text-muted font-normal"> ({entry.savedConfigName})</span>
                         )}
                       </p>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-xs text-muted">
                         {TYPE_LABELS[entry.resourceType] || entry.resourceType}
                       </p>
                     </div>
                   </button>
                   <div className="flex items-center gap-1 shrink-0">
                     {sourceBadge(entry.source)}
-                    <button
-                      type="button"
+                    <IconButton
+                      icon="lucide:copy"
+                      label="Copy command"
+                      variant="ghost"
+                      size="sm"
                       onClick={() => copyText(entry.command, "Command copied")}
-                      className="p-2 rounded-md text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
-                      title="Copy command"
-                    >
-                      <ClipboardDocumentIcon className="h-4 w-4" />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setExpandedId(isOpen ? null : entry.id)}
-                      className="p-2 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
-                      title={isOpen ? "Collapse" : "Expand"}
+                    />
+                    <IconButton
+                      icon={isOpen ? "lucide:chevron-up" : "lucide:chevron-down"}
+                      label={isOpen ? "Collapse" : "Expand"}
+                      variant="ghost"
+                      size="sm"
                       aria-expanded={isOpen}
-                    >
-                      {isOpen ? (
-                        <ChevronUpIcon className="h-4 w-4" />
-                      ) : (
-                        <ChevronDownIcon className="h-4 w-4" />
-                      )}
-                    </button>
+                      onClick={() => setExpandedId(isOpen ? null : entry.id)}
+                    />
                   </div>
                 </div>
                 {isOpen && (
-                  <div className="px-4 pb-4 border-t border-gray-200 bg-white">
+                  <div className="px-4 pb-4 border-t border-divider bg-surface">
                     {entry.note && (
-                      <p className="text-xs text-amber-700 bg-amber-50 border border-amber-100 rounded-md px-3 py-2 mt-3 mb-2">
+                      <p className="text-xs text-warn-ink bg-warn-soft rounded-md px-3 py-2 mt-3 mb-2">
                         {entry.note}
                       </p>
                     )}
@@ -374,59 +344,59 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
         </div>
       )}
 
-      <div className="border-t border-gray-200 mt-8 pt-6">
+      <div className="border-t border-divider mt-8 pt-6">
         <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
           <div>
-            <h3 className="text-sm font-medium text-gray-700">Saved configurations</h3>
-            <p className="text-xs text-gray-500 mt-0.5">
+            <h3 className="text-sm font-medium text-ink-2">Saved configurations</h3>
+            <p className="text-xs text-muted mt-0.5">
               Form recipes saved from creation modals. Deleting does not remove emulator resources.
             </p>
           </div>
           {projectSavedConfigs.length > 0 && selectedConfigIds.size > 0 && (
-            <button
-              type="button"
-              onClick={handleDeleteSelectedConfigs}
+            <Button
+              variant="danger"
+              size="sm"
+              icon="lucide:trash-2"
               disabled={deletingConfigs}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-md hover:bg-red-100 disabled:opacity-50"
+              onClick={handleDeleteSelectedConfigs}
             >
-              <TrashIcon className="h-4 w-4" />
               Delete selected ({selectedConfigIds.size})
-            </button>
+            </Button>
           )}
         </div>
 
         {projectSavedConfigs.length === 0 ? (
-          <p className="text-sm text-gray-400 italic">
+          <p className="text-sm text-faint italic">
             No saved configurations for this project. Use &quot;Save config&quot; in a resource
             creation form to store a recipe for the CLI playbook.
           </p>
         ) : (
-          <div className="border border-gray-200 rounded-lg overflow-hidden">
-            <label className="flex items-center gap-3 px-4 py-2.5 bg-gray-50 border-b border-gray-200 cursor-pointer hover:bg-gray-100 transition-colors">
+          <div className="border border-border rounded-lg overflow-hidden">
+            <label className="flex items-center gap-3 px-4 py-2.5 bg-surface-2 border-b border-divider cursor-pointer hover:bg-surface-3 transition-colors">
               <input
                 type="checkbox"
                 checked={allConfigsSelected}
                 onChange={toggleSelectAllConfigs}
-                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                className="h-4 w-4 rounded border-border-strong accent-primary"
               />
-              <span className="text-xs font-medium text-gray-600">Select all</span>
+              <span className="text-xs font-medium text-ink-2">Select all</span>
             </label>
-            <ul className="divide-y divide-gray-200">
+            <ul className="divide-y divide-divider">
               {projectSavedConfigs.map((cfg) => (
                 <li key={cfg.id}>
-                  <label className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors">
+                  <label className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-surface-2 transition-colors">
                     <input
                       type="checkbox"
                       checked={selectedConfigIds.has(cfg.id)}
                       onChange={() => toggleConfigSelection(cfg.id)}
-                      className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                      className="h-4 w-4 rounded border-border-strong accent-primary shrink-0"
                     />
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm font-medium text-gray-900 truncate">{cfg.name}</p>
-                      <p className="text-xs text-gray-500">
+                      <p className="text-sm font-medium text-ink truncate">{cfg.name}</p>
+                      <p className="text-xs text-muted">
                         {TYPE_LABELS[cfg.resource_type] || cfg.resource_type}
                         {configResourceLabel(cfg) !== cfg.name && (
-                          <span className="text-gray-400"> · {configResourceLabel(cfg)}</span>
+                          <span className="text-faint"> · {configResourceLabel(cfg)}</span>
                         )}
                       </p>
                     </div>
@@ -437,6 +407,6 @@ export default function CliPlaybookSection({ onDeleteSavedConfig }: CliPlaybookS
           </div>
         )}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/localcloud-gui/src/components/ConnectionGuide.tsx
+++ b/localcloud-gui/src/components/ConnectionGuide.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { CodeBracketIcon, CommandLineIcon } from "@heroicons/react/24/outline";
-import { usePreferences } from "@/context/PreferencesContext";
-import hljs from "highlight.js";
-
-// Import language support
-import "highlight.js/lib/languages/javascript";
-import "highlight.js/lib/languages/python";
-import "highlight.js/lib/languages/go";
-import "highlight.js/lib/languages/java";
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@iconify/react";
+import { toast } from "react-hot-toast";
+import ThemeableCodeBlock from "@/components/ThemeableCodeBlock";
+import { Button, IconButton } from "@/components/ui";
 
 interface CodeExample {
   language: string;
@@ -17,110 +12,6 @@ interface CodeExample {
   code: string;
   description: string;
 }
-
-const themeMap: Record<string, string> = {
-  hljs: "github.css",
-  "hljs-tomorrow": "base16/tomorrow.css",
-  "hljs-atom-dark": "atom-one-dark.css",
-  "hljs-atom-light": "atom-one-light.css",
-  "hljs-github-dark": "github-dark.css",
-  "hljs-github-dark-dimmed": "github-dark-dimmed.css",
-  "hljs-solarized": "base16/solarized-light.css",
-  "hljs-dark": "dark.css",
-};
-
-// Map profile highlight_theme (from PreferencesContext) to ConnectionGuide themeMap keys
-const profileThemeToConnectionTheme: Record<string, string> = {
-  github: "hljs",
-  "github-light": "hljs",
-  "github-dark": "hljs-github-dark",
-  "github-dark-dimmed": "hljs-github-dark-dimmed",
-  "atom-one-dark": "hljs-atom-dark",
-  "atom-one-light": "hljs-atom-light",
-};
-
-const CodeBlock = ({
-  code,
-  language,
-  theme = "hljs",
-}: {
-  code: string;
-  language: string;
-  theme?: string;
-}) => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
-
-  // Don't render anything until client-side
-  if (!isClient) {
-    return (
-      <pre
-        className={`p-4 rounded-lg overflow-x-auto ${
-          theme === "hljs" ? "" : theme
-        }`}
-      >
-        <code>{code}</code>
-      </pre>
-    );
-  }
-
-  // Client-side only rendering with highlight.js
-  const ClientCodeBlock = () => {
-    const [highlightedCode, setHighlightedCode] = useState("");
-
-    useEffect(() => {
-      // Dynamically inject theme CSS from public/hljs-themes
-      const themeFile = themeMap[theme] || themeMap.hljs;
-      const id = "hljs-theme-style";
-      let link = document.getElementById(id) as HTMLLinkElement | null;
-      if (link) {
-        link.href = `/hljs-themes/${themeFile}`;
-      } else {
-        link = document.createElement("link");
-        link.id = id;
-        link.rel = "stylesheet";
-        link.href = `/hljs-themes/${themeFile}`;
-        document.head.appendChild(link);
-      }
-      return () => {
-        // Optionally remove the theme link on unmount
-        // if (link) link.remove();
-      };
-    }, []); // ClientCodeBlock remounts when theme changes, so effect always runs fresh
-
-    useEffect(() => {
-      // Use highlight.js to generate highlighted HTML safely
-      const highlighted = hljs.highlight(code, {
-        language:
-          language.toLowerCase() === "javascript"
-            ? "javascript"
-            : language.toLowerCase() === "python"
-            ? "python"
-            : language.toLowerCase() === "go"
-            ? "go"
-            : language.toLowerCase() === "java"
-            ? "java"
-            : "text",
-      }).value;
-
-      setHighlightedCode(highlighted);
-    }, []); // ClientCodeBlock remounts when code/language change, so effect always runs fresh
-
-    return (
-      <pre className="p-4 rounded-lg overflow-x-auto">
-        <code
-          className="hljs"
-          dangerouslySetInnerHTML={{ __html: highlightedCode }}
-        />
-      </pre>
-    );
-  };
-
-  return <ClientCodeBlock />;
-};
 
 const codeExamples: CodeExample[] = [
   {
@@ -367,8 +258,8 @@ const dynamoExamples: CodeExample[] = [
   {
     language: "JavaScript",
     title: "DynamoDB - List and Create Tables",
-    code: `import { 
-  ListTablesCommand, 
+    code: `import {
+  ListTablesCommand,
   CreateTableCommand,
   PutItemCommand
 } from '@aws-sdk/client-dynamodb';
@@ -553,225 +444,247 @@ func main() {
   },
 ];
 
-const languageOptions = [
-  { value: "JavaScript", label: "JavaScript" },
-  { value: "Python", label: "Python" },
-  { value: "Go", label: "Go" },
-  { value: "Java", label: "Java" },
+type ResourceTabId = "setup" | "s3" | "dynamodb";
+
+const resourceTabs: { id: ResourceTabId; name: string; icon: string; examples: CodeExample[] }[] = [
+  { id: "setup", name: "Basic Setup", icon: "lucide:zap", examples: codeExamples },
+  { id: "s3", name: "S3", icon: "logos:aws-s3", examples: s3Examples },
+  { id: "dynamodb", name: "DynamoDB", icon: "logos:aws-dynamodb", examples: dynamoExamples },
 ];
 
+const languageOptions = ["JavaScript", "Python", "Go", "Java"] as const;
+type Language = (typeof languageOptions)[number];
+
+function InfoField({
+  label,
+  value,
+  badge,
+  masked,
+  onToggleMask,
+  onCopy,
+}: {
+  label: string;
+  value: string;
+  badge?: string;
+  masked?: boolean;
+  onToggleMask?: () => void;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5 bg-surface border border-border rounded-xl shadow-e1 p-3.5">
+      <span className="text-[11px] font-semibold tracking-wider uppercase text-faint">
+        {label}
+      </span>
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[13px] text-ink truncate">
+          {masked ? "••••" : value}
+        </span>
+        {badge && (
+          <span className="px-1.5 py-0.5 rounded-full bg-surface-3 text-muted text-[10px] font-semibold whitespace-nowrap">
+            {badge}
+          </span>
+        )}
+        {onToggleMask && (
+          <IconButton
+            icon={masked ? "lucide:eye" : "lucide:eye-off"}
+            label={masked ? `Show ${label.toLowerCase()}` : `Hide ${label.toLowerCase()}`}
+            variant="outline"
+            size="sm"
+            onClick={onToggleMask}
+            className="shrink-0"
+          />
+        )}
+        <IconButton
+          icon="lucide:copy"
+          label={`Copy ${label.toLowerCase()}`}
+          variant="outline"
+          size="sm"
+          onClick={onCopy}
+          className="ml-auto shrink-0"
+        />
+      </div>
+    </div>
+  );
+}
+
 export default function ConnectionGuide() {
-  const { profile } = usePreferences();
-  const [activeTab, setActiveTab] = useState("setup");
-  const [selectedLanguage, setSelectedLanguage] = useState("JavaScript");
-  const profileTheme =
-    profile?.highlight_theme && profileThemeToConnectionTheme[profile.highlight_theme]
-      ? profileThemeToConnectionTheme[profile.highlight_theme]
-      : "hljs";
-  const [selectedTheme, setSelectedTheme] = useState(profileTheme);
+  const [activeTab, setActiveTab] = useState<ResourceTabId>("setup");
+  const [selectedLanguage, setSelectedLanguage] = useState<Language>("JavaScript");
+  const [secretVisible, setSecretVisible] = useState(false);
+  const [resourceMenuOpen, setResourceMenuOpen] = useState(false);
+  const resourceMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setSelectedTheme(profileTheme);
-  }, [profileTheme]);
+    function handleClickOutside(e: MouseEvent) {
+      if (resourceMenuRef.current && !resourceMenuRef.current.contains(e.target as Node)) {
+        setResourceMenuOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
-  const tabs = [
-    { id: "setup", name: "Basic Setup", icon: CodeBracketIcon },
-    { id: "s3", name: "S3 Examples", icon: CommandLineIcon },
-    { id: "dynamodb", name: "DynamoDB Examples", icon: CommandLineIcon },
-  ];
+  const activeResourceTab = resourceTabs.find((tab) => tab.id === activeTab) ?? resourceTabs[0];
+  const activeExample = activeResourceTab.examples.find(
+    (example) => example.language === selectedLanguage
+  );
 
-  const getExamples = () => {
-    switch (activeTab) {
-      case "setup":
-        return codeExamples;
-      case "s3":
-        return s3Examples;
-      case "dynamodb":
-        return dynamoExamples;
-      default:
-        return codeExamples;
+  const copyToClipboard = async (text: string, message: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      toast.success(message);
+    } catch {
+      toast.error("Copy failed");
     }
   };
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
-
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-lg font-semibold tracking-tight text-ink">
           Connecting to the AWS Emulator
         </h1>
-        <p className="text-lg text-gray-600">
-          Learn how to connect to your AWS Emulator (MiniStack) instance using various AWS
-          SDKs.
+        <p className="text-xs text-muted mt-1">
+          Point any AWS SDK at the emulator — credentials are dummies
         </p>
       </div>
 
-      {/* Connection Info */}
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-8">
-        <h2 className="text-xl font-semibold text-blue-900 mb-4">
-          🌐 AWS Emulator Endpoint
-        </h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <p className="text-sm font-medium text-blue-700">Endpoint:</p>
-            <code className="text-blue-900 bg-blue-100 px-2 py-1 rounded">
-              http://localhost:4566
-            </code>
-          </div>
-          <div>
-            <p className="text-sm font-medium text-blue-700">Region:</p>
-            <code className="text-blue-900 bg-blue-100 px-2 py-1 rounded">
-              us-east-1
-            </code>
-          </div>
-        </div>
-        <div className="mt-4">
-          <p className="text-sm font-medium text-blue-700">AWS Credentials:</p>
-          <div className="bg-blue-100 p-3 rounded mt-2">
-            <code className="text-blue-900 text-sm">
-              AWS_ACCESS_KEY_ID=test
-              <br />
-              AWS_SECRET_ACCESS_KEY=test
-              <br />
-              AWS_DEFAULT_REGION=us-east-1
-            </code>
-          </div>
-        </div>
+      {/* Connection info cards */}
+      <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
+        <InfoField
+          label="Endpoint"
+          value="http://localhost:4566"
+          onCopy={() => copyToClipboard("http://localhost:4566", "Endpoint copied")}
+        />
+        <InfoField
+          label="Region"
+          value="us-east-1"
+          onCopy={() => copyToClipboard("us-east-1", "Region copied")}
+        />
+        <InfoField
+          label="Access key"
+          value="test"
+          badge="dummy"
+          onCopy={() => copyToClipboard("test", "Access key copied")}
+        />
+        <InfoField
+          label="Secret key"
+          value="test"
+          masked={!secretVisible}
+          onToggleMask={() => setSecretVisible((v) => !v)}
+          onCopy={() => copyToClipboard("test", "Secret key copied")}
+        />
       </div>
 
-      {/* Tabs */}
-      <div className="border-b border-gray-200 mb-8">
-        <nav className="-mb-px flex space-x-8">
-          {tabs.map((tab) => {
-            const Icon = tab.icon;
-            return (
+      {/* Code sample card */}
+      <div className="bg-surface border border-border rounded-xl shadow-e1 overflow-hidden">
+        <div className="flex items-center gap-3 px-3 border-b border-divider flex-wrap">
+          <div className="flex gap-1">
+            {languageOptions.map((lang) => (
               <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`py-2 px-1 border-b-2 font-medium text-sm flex items-center space-x-2 ${
-                  activeTab === tab.id
-                    ? "border-blue-500 text-blue-600"
-                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                key={lang}
+                type="button"
+                onClick={() => setSelectedLanguage(lang)}
+                className={`px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors cursor-pointer ${
+                  selectedLanguage === lang
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted hover:text-ink"
                 }`}
               >
-                <Icon className="h-5 w-5" />
-                <span>{tab.name}</span>
+                {lang}
               </button>
-            );
-          })}
-        </nav>
-      </div>
-
-      {/* Language and Theme Selectors */}
-      <div className="mb-6 flex flex-wrap gap-4 items-center">
-        <div>
-          <label
-            htmlFor="language-selector"
-            className="text-sm font-medium text-gray-700 mr-4"
-          >
-            Select Language:
-          </label>
-          <select
-            id="language-selector"
-            name="language-selector"
-            value={selectedLanguage}
-            onChange={(e) => setSelectedLanguage(e.target.value)}
-            className="bg-white text-gray-900 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          >
-            {languageOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
             ))}
-          </select>
-        </div>
-        <div>
-          <label
-            htmlFor="theme-selector"
-            className="text-sm font-medium text-gray-700 mr-4"
-          >
-            Select Theme:
-          </label>
-          <select
-            id="theme-selector"
-            name="theme-selector"
-            value={selectedTheme}
-            onChange={(e) => setSelectedTheme(e.target.value)}
-            className="bg-white text-gray-900 border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          >
-            <option value="hljs">GitHub (Light)</option>
-            <option value="hljs-tomorrow">Tomorrow (Light)</option>
-            <option value="hljs-atom-dark">Atom One Dark</option>
-            <option value="hljs-atom-light">Atom One Light</option>
-            <option value="hljs-github-dark">GitHub Dark</option>
-            <option value="hljs-github-dark-dimmed">GitHub Dark Dimmed</option>
-            <option value="hljs-solarized">Solarized Light</option>
-            <option value="hljs-dark">Dark</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Code Examples */}
-      <div className="space-y-6">
-        {getExamples()
-          .filter((example) => example.language === selectedLanguage)
-          .map((example, index) => (
-            <div key={index} className="bg-white rounded-lg shadow border">
-              <div className="px-6 py-4 border-b border-gray-200">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <h3 className="text-lg font-medium text-gray-900">
-                      {example.title}
-                    </h3>
-                    <p className="text-sm text-gray-600 mt-1">
-                      {example.description}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => copyToClipboard(example.code)}
-                    className="text-blue-600 hover:text-blue-800 text-sm font-medium"
-                  >
-                    Copy Code
-                  </button>
+          </div>
+          <div className="flex items-center gap-2 ml-auto py-2">
+            <div className="relative" ref={resourceMenuRef}>
+              <button
+                type="button"
+                onClick={() => setResourceMenuOpen((v) => !v)}
+                aria-expanded={resourceMenuOpen}
+                className="flex items-center justify-between gap-2 h-7 min-w-[150px] px-2.5 border border-border-strong rounded-md bg-surface-2 text-xs cursor-pointer whitespace-nowrap transition-colors hover:bg-surface hover:border-ink-2"
+              >
+                <span className="flex items-center gap-1.5">
+                  <Icon icon={activeResourceTab.icon} width={13} />
+                  {activeResourceTab.name}
+                </span>
+                <Icon icon="lucide:chevron-down" width={13} className="text-faint" />
+              </button>
+              {resourceMenuOpen && (
+                <div className="absolute right-0 z-10 mt-1 w-40 bg-surface border border-border rounded-md shadow-e2 py-1">
+                  {resourceTabs.map((tab) => (
+                    <button
+                      key={tab.id}
+                      type="button"
+                      onClick={() => {
+                        setActiveTab(tab.id);
+                        setResourceMenuOpen(false);
+                      }}
+                      className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs text-left cursor-pointer hover:bg-surface-2 ${
+                        activeTab === tab.id ? "text-primary font-medium" : "text-ink-2"
+                      }`}
+                    >
+                      <Icon icon={tab.icon} width={13} />
+                      {tab.name}
+                    </button>
+                  ))}
                 </div>
-              </div>
-              <div className="px-6 py-4">
-                <CodeBlock
-                  code={example.code}
-                  language={example.language}
-                  theme={selectedTheme}
-                />
-              </div>
+              )}
             </div>
-          ))}
+            <Button
+              variant="secondary"
+              size="sm"
+              icon="lucide:copy"
+              disabled={!activeExample}
+              onClick={() => activeExample && copyToClipboard(activeExample.code, "Code copied")}
+            >
+              Copy
+            </Button>
+          </div>
+        </div>
+
+        {activeExample ? (
+          <>
+            <div className="px-4 pt-3">
+              <ThemeableCodeBlock
+                code={activeExample.code}
+                language={activeExample.language.toLowerCase()}
+                showCopyButton={false}
+              />
+            </div>
+            <div className="flex items-center gap-2 px-3.5 py-2.5 border-t border-divider">
+              <Icon icon="lucide:info" width={14} className="text-muted shrink-0" />
+              <span className="text-xs text-muted">{activeExample.description}</span>
+            </div>
+          </>
+        ) : (
+          <p className="px-4 py-10 text-sm text-faint italic text-center">
+            No {selectedLanguage} example available for {activeResourceTab.name}.
+          </p>
+        )}
       </div>
 
       {/* Additional Resources */}
-      <div className="mt-12 bg-gray-50 rounded-lg p-6">
-        <h2 className="text-xl font-semibold text-gray-900 mb-4">
-          📚 Additional Resources
-        </h2>
+      <div className="bg-surface-2 border border-border rounded-xl p-5">
+        <div className="flex items-center gap-2 mb-4">
+          <Icon icon="lucide:book-open" width={16} className="text-muted" />
+          <h2 className="text-sm font-semibold text-ink">Additional Resources</h2>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <h3 className="font-medium text-gray-900 mb-2">Documentation</h3>
-            <ul className="space-y-1 text-sm text-gray-600">
+            <h3 className="text-xs font-semibold text-ink-2 mb-2">Documentation</h3>
+            <ul className="space-y-1.5 text-sm text-muted">
               <li>
-                •{" "}
                 <a
                   href="https://github.com/nahuelnucera/ministack"
-                  className="text-blue-600 hover:text-blue-800"
+                  className="text-primary hover:text-primary-hover"
                 >
                   MiniStack Documentation
                 </a>
               </li>
               <li>
-                •{" "}
                 <a
                   href="https://aws.amazon.com/tools/"
-                  className="text-blue-600 hover:text-blue-800"
+                  className="text-primary hover:text-primary-hover"
                 >
                   AWS SDK Documentation
                 </a>
@@ -779,13 +692,11 @@ export default function ConnectionGuide() {
             </ul>
           </div>
           <div>
-            <h3 className="font-medium text-gray-900 mb-2">Troubleshooting</h3>
-            <ul className="space-y-1 text-sm text-gray-600">
-              <li>• Connection refused: Check if AWS Emulator is running</li>
-              <li>
-                • Invalid credentials: Use test credentials for AWS Emulator
-              </li>
-              <li>• S3 path style: Enable forcePathStyle for S3 operations</li>
+            <h3 className="text-xs font-semibold text-ink-2 mb-2">Troubleshooting</h3>
+            <ul className="space-y-1.5 text-sm text-muted">
+              <li>Connection refused: Check if AWS Emulator is running</li>
+              <li>Invalid credentials: Use test credentials for AWS Emulator</li>
+              <li>S3 path style: Enable forcePathStyle for S3 operations</li>
             </ul>
           </div>
         </div>

--- a/localcloud-gui/src/components/Dashboard.tsx
+++ b/localcloud-gui/src/components/Dashboard.tsx
@@ -8,6 +8,8 @@ import { DynamoDBTableConfig, S3BucketConfig, LambdaFunctionConfig, APIGatewayCo
 import { Icon } from "@iconify/react";
 import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
+import { Button, StatusDot } from "@/components/ui";
+import type { StatusTone } from "@/components/ui";
 import ResourceList from "./ResourceList";
 
 import Link from "next/link";
@@ -572,17 +574,17 @@ export default function Dashboard() {
     onAfterProjectSwitch: loadInitialData,
   };
 
-  const serviceStatusClass = (status: string) => {
-    if (status === "running") return "bg-green-100 text-green-800";
-    if (status === "starting") return "bg-yellow-100 text-yellow-700";
-    if (status === "failed") return "bg-red-100 text-red-800";
-    return "bg-gray-100 text-gray-600";
+  const serviceTone = (status: string): StatusTone => {
+    if (status === "running") return "success";
+    if (status === "starting") return "warn";
+    if (status === "failed") return "danger";
+    return "neutral";
   };
-  const serviceDotClass = (status: string) => {
-    if (status === "running") return "bg-green-500";
-    if (status === "starting") return "bg-yellow-400 animate-pulse";
-    if (status === "failed") return "bg-red-500";
-    return "bg-gray-400";
+  const serviceTextTone: Record<StatusTone, string> = {
+    success: "text-ink-2",
+    warn: "text-warn-ink",
+    danger: "text-danger-ink",
+    neutral: "text-muted",
   };
   const serviceLabel = (status: string) => {
     if (status === "running") return "Running";
@@ -791,18 +793,15 @@ export default function Dashboard() {
           key="error"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          className="flex items-center justify-center min-h-screen bg-linear-to-br from-red-50 to-pink-100"
+          className="flex items-center justify-center min-h-screen bg-bg"
         >
           <div className="text-center">
-            <div className="text-red-600 text-6xl mb-4">⚠️</div>
-            <h2 className="text-xl font-bold text-gray-900 mb-2">Failed to Load Data</h2>
-            <p className="text-gray-600 mb-4">{error.message}</p>
-            <button
-              onClick={loadInitialData}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-            >
+            <Icon icon="lucide:alert-triangle" width={48} className="text-danger mx-auto mb-4" />
+            <h2 className="text-xl font-bold text-ink mb-2">Failed to Load Data</h2>
+            <p className="text-muted mb-4">{error.message}</p>
+            <Button variant="primary" onClick={loadInitialData}>
               Retry
-            </button>
+            </Button>
           </div>
         </motion.div>
       </AnimatePresence>
@@ -811,7 +810,7 @@ export default function Dashboard() {
 
   return (
     <DashboardNavProvider actions={dashboardNavActions}>
-      <div className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100">
+      <div className="min-h-screen bg-bg">
         <DashboardNavBar activePage="dashboard" />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -820,75 +819,87 @@ export default function Dashboard() {
         {loading ? (
           <ServicesBarSkeleton />
         ) : (
-        <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 flex items-center flex-wrap gap-y-2 gap-x-0">
+        <div className="mb-6 bg-surface rounded-lg shadow-e1 border border-border px-2 py-2 flex items-center flex-wrap gap-y-1">
 
           {/* Keycloak */}
-          <Link href="/keycloak" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Keycloak">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(keycloak.status)}`} />
-            <span className="text-sm font-medium text-gray-700">Keycloak</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(keycloak.status)}`}>
+          <Link href="/keycloak" className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-surface-3 transition-colors" title="Keycloak">
+            <StatusDot tone={serviceTone(keycloak.status)} pulse={keycloak.status === "starting"} />
+            <span className="text-xs font-medium text-ink-2">Keycloak</span>
+            <span className={`text-[11px] font-medium ${serviceTextTone[serviceTone(keycloak.status)]}`}>
               {serviceLabel(keycloak.status)}
             </span>
           </Link>
 
-          <div className="h-4 w-px bg-gray-200" />
+          <div className="h-4 w-px bg-border" />
 
           {/* AWS Emulator */}
-          <div className="flex items-center space-x-2 px-3">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${
-              emulatorStatus.health === "healthy" ? "bg-green-500" :
-              emulatorStatus.health === "unhealthy" ? "bg-red-500" : "bg-gray-400"
-            }`} />
-            <span className="text-sm font-medium text-gray-700">AWS Emulator</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-              emulatorStatus.running && emulatorStatus.health === "healthy"
-                ? "bg-green-100 text-green-800"
-                : emulatorStatus.running ? "bg-yellow-100 text-yellow-800"
-                : "bg-gray-100 text-gray-600"
-            }`}>
-              {emulatorStatus.running
-                ? emulatorStatus.health === "healthy" ? "Running" : "Unhealthy"
-                : "Stopped"}
+          <div className="flex items-center gap-1.5 px-3 py-1.5" title="AWS Emulator">
+            <StatusDot
+              tone={
+                emulatorStatus.health === "healthy" ? "success" : emulatorStatus.health === "unhealthy" ? "danger" : "neutral"
+              }
+            />
+            <span className="text-xs font-medium text-ink-2">AWS Emulator</span>
+            <span
+              className={`text-[11px] font-medium ${
+                emulatorStatus.running && emulatorStatus.health === "healthy"
+                  ? "text-ink-2"
+                  : emulatorStatus.running
+                    ? "text-warn-ink"
+                    : "text-muted"
+              }`}
+            >
+              {emulatorStatus.running ? (emulatorStatus.health === "healthy" ? "Running" : "Unhealthy") : "Stopped"}
             </span>
           </div>
 
-          <div className="h-4 w-px bg-gray-200" />
+          <div className="h-4 w-px bg-border" />
 
           {/* Mailpit */}
-          <button onClick={() => setShowMailpit(true)} className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Open Mailpit Inbox">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${mailpit.status === "healthy" ? "bg-green-500" : "bg-gray-400"}`} />
-            <span className="text-sm font-medium text-gray-700">Mailpit</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${mailpit.status === "healthy" ? "bg-green-100 text-green-800" : "bg-gray-100 text-gray-600"}`}>
+          <button onClick={() => setShowMailpit(true)} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-surface-3 transition-colors cursor-pointer" title="Open Mailpit Inbox">
+            <StatusDot tone={mailpit.status === "healthy" ? "success" : "neutral"} />
+            <span className="text-xs font-medium text-ink-2">Mailpit</span>
+            <span className={`text-[11px] font-medium ${mailpit.status === "healthy" ? "text-ink-2" : "text-muted"}`}>
               {mailpit.status === "healthy" ? "Running" : "Unavailable"}
             </span>
             {mailpit.unread > 0 && (
-              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
+              <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-danger-soft text-danger-ink">
                 {mailpit.unread} unread
               </span>
             )}
           </button>
 
-          <div className="h-4 w-px bg-gray-200" />
+          <div className="h-4 w-px bg-border" />
 
           {/* PostgreSQL */}
-          <Link href="/postgres" className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="PostgreSQL">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(postgres.status)}`} />
-            <span className="text-sm font-medium text-gray-700">PostgreSQL</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(postgres.status)}`}>
+          <Link href="/postgres" className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-surface-3 transition-colors" title="PostgreSQL">
+            <StatusDot tone={serviceTone(postgres.status)} />
+            <span className="text-xs font-medium text-ink-2">PostgreSQL</span>
+            <span className={`text-[11px] font-medium ${serviceTextTone[serviceTone(postgres.status)]}`}>
               {serviceLabel(postgres.status)}
             </span>
           </Link>
 
-          <div className="h-4 w-px bg-gray-200" />
+          <div className="h-4 w-px bg-border" />
 
           {/* Redis */}
-          <button onClick={() => setShowRedis(true)} className="flex items-center space-x-2 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors" title="Open Redis Cache">
-            <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${serviceDotClass(redis.status)}`} />
-            <span className="text-sm font-medium text-gray-700">Redis</span>
-            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${serviceStatusClass(redis.status)}`}>
+          <button onClick={() => setShowRedis(true)} className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg hover:bg-surface-3 transition-colors cursor-pointer" title="Open Redis Cache">
+            <StatusDot tone={serviceTone(redis.status)} />
+            <span className="text-xs font-medium text-ink-2">Redis</span>
+            <span className={`text-[11px] font-medium ${serviceTextTone[serviceTone(redis.status)]}`}>
               {serviceLabel(redis.status)}
             </span>
           </button>
+
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="lucide:scroll-text"
+            onClick={() => setShowLogs(true)}
+            className="ml-auto"
+          >
+            System logs
+          </Button>
 
         </div>
         )}
@@ -936,20 +947,20 @@ export default function Dashboard() {
               firstResourceLoading={firstResourceLoading}
             />
           ) : (
-            <div className="bg-white rounded-lg shadow border border-gray-200">
+            <div className="bg-surface rounded-xl shadow-e1 border border-border overflow-hidden">
               {/* Same header structure as ResourceList */}
-              <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+              <div className="px-4 py-3.5 border-b border-divider flex items-center justify-between">
                 <div>
-                  <h3 className="text-lg font-medium text-gray-900">AWS Resources</h3>
-                  <p className="text-xs text-gray-500 mt-0.5">AWS Emulator is not running</p>
+                  <h3 className="text-[15px] font-semibold text-ink">AWS resources</h3>
+                  <p className="text-[11px] text-muted mt-0.5">AWS Emulator is not running</p>
                 </div>
               </div>
               {/* Stopped state */}
               <div className="px-6 py-14 text-center">
                 <Icon icon="logos:aws" className="w-14 h-14 opacity-10 mx-auto mb-4" />
-                <h4 className="text-sm font-semibold text-gray-700 mb-1">AWS Emulator is stopped</h4>
-                <p className="text-sm text-gray-500 mb-4">Start the stack to manage your AWS resources.</p>
-                <code className="inline-block bg-gray-100 text-gray-700 text-xs font-mono px-3 py-1.5 rounded-md">
+                <h4 className="text-sm font-semibold text-ink-2 mb-1">AWS Emulator is stopped</h4>
+                <p className="text-sm text-muted mb-4">Start the stack to manage your AWS resources.</p>
+                <code className="inline-block bg-surface-2 text-ink-2 text-xs font-mono px-3 py-1.5 rounded-md border border-border">
                   docker compose up -d
                 </code>
               </div>
@@ -960,7 +971,7 @@ export default function Dashboard() {
 
         {/* Footer */}
         <div className="mt-8 text-center">
-          <p className="text-xs text-gray-400">
+          <p className="text-xs text-faint">
             LocalCloud Kit v{packageJson.version} • Local Cloud Development Environment
           </p>
         </div>

--- a/localcloud-gui/src/components/DashboardNavBar.tsx
+++ b/localcloud-gui/src/components/DashboardNavBar.tsx
@@ -7,21 +7,9 @@ import {
 } from "@/context/DashboardNavContext";
 import { PLATFORM_SERVICES, PLATFORM_SERVICE_KINDS, SERVICE_KIND_LABEL } from "@/constants/platformServices";
 import { useServicesData } from "@/hooks/useServicesData";
-import {
-  ArrowTopRightOnSquareIcon,
-  Bars3Icon,
-  BookOpenIcon,
-  ChevronDownIcon,
-  ClipboardDocumentCheckIcon,
-  DocumentTextIcon,
-  EyeIcon,
-  ServerIcon,
-  Squares2X2Icon,
-  UserCircleIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { cn, SegmentedControl, type SegmentedOption } from "@/components/ui";
+import type { PreferredLanguage, ThemePreference } from "@/types";
 import { Icon } from "@iconify/react";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -30,12 +18,35 @@ import packageJson from "../../package.json";
 import LogViewer from "./LogViewer";
 import MailpitModal from "./MailpitModal";
 import RedisModal from "./RedisModal";
+import ManageHeaderBrand from "./ManageHeaderBrand";
 
 const DOC_ROUTES = [
   "/docs", "/aws-emulator", "/s3", "/dynamodb", "/lambda",
   "/apigateway", "/secrets", "/ssm", "/iam",
   "/redis", "/mailpit", "/postgres", "/keycloak",
 ];
+
+const LANGUAGE_LABEL: Record<PreferredLanguage, string> = {
+  typescript: "TypeScript",
+  node: "Node.js",
+  python: "Python",
+  go: "Go",
+  java: "Java",
+  cli: "CLI",
+};
+
+const THEME_OPTIONS: SegmentedOption<ThemePreference>[] = [
+  { value: "auto", label: "Auto" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
+function getInitials(name?: string | null): string {
+  const parts = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "U";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
 
 type DashboardNavBarProps = {
   activePage?: "dashboard" | "profile";
@@ -50,6 +61,23 @@ type ResourceActionOptions = {
 
 const INSPECT_FALLBACK_HREF = "/";
 const DASHBOARD_FALLBACK_HREF = "/";
+
+const navPillClass = (active: boolean) =>
+  cn(
+    "flex items-center gap-1.5 h-8 px-3 rounded-lg text-[13px] font-medium transition-colors",
+    active ? "bg-primary-soft text-primary-ink" : "text-muted hover:bg-surface-3 hover:text-ink"
+  );
+
+const dropdownPanelClass = (widthClass: string) =>
+  cn(
+    "absolute right-0 mt-1.5 bg-surface border border-border rounded-xl shadow-e2 z-50 py-1.5",
+    widthClass
+  );
+
+const sectionLabelClass = "px-3 pt-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-faint";
+const dividerClass = "h-px bg-divider mx-1.5 my-1";
+const menuItemClass =
+  "flex items-center flex-1 px-2.5 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink rounded-lg transition-colors";
 
 export default function DashboardNavBar({
   activePage = "dashboard",
@@ -198,12 +226,16 @@ export default function DashboardNavBar({
     }
   };
 
+  const handleThemeChange = (theme: ThemePreference) => {
+    updateProfile({ theme }).catch(() => toast.error("Failed to update theme"));
+  };
+
   const previewActionClass =
-    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
+    "inline-flex items-center justify-center p-1.5 text-primary hover:text-primary-hover hover:bg-primary-soft rounded-md transition-colors";
   const inspectActionClass =
-    "inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-800 hover:bg-gray-100 rounded-md transition-colors";
+    "inline-flex items-center justify-center p-1.5 text-muted hover:text-ink hover:bg-surface-3 rounded-md transition-colors";
   const manageActionClass =
-    "inline-flex items-center justify-center p-1.5 text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors";
+    "inline-flex items-center justify-center p-1.5 text-primary hover:text-primary-hover hover:bg-primary-soft rounded-md transition-colors";
 
   const renderResourceActions = ({
     label,
@@ -219,7 +251,7 @@ export default function DashboardNavBar({
           title={`Open ${label} viewer`}
           aria-label={`Open ${label} viewer`}
         >
-          <EyeIcon className="h-4 w-4" />
+          <Icon icon="lucide:eye" width={15} />
         </button>
       )}
       <button
@@ -228,7 +260,7 @@ export default function DashboardNavBar({
         title={`Inspect ${label} checks`}
         aria-label={`Inspect ${label} checks`}
       >
-        <ClipboardDocumentCheckIcon className="h-4 w-4" />
+        <Icon icon="lucide:clipboard-check" width={15} />
       </button>
       <Link
         href={manageHref}
@@ -237,7 +269,7 @@ export default function DashboardNavBar({
         title={`Open ${label} page`}
         aria-label={`Open ${label} page`}
       >
-        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+        <Icon icon="lucide:external-link" width={15} />
       </Link>
     </div>
   );
@@ -249,49 +281,49 @@ export default function DashboardNavBar({
       title={`Inspect ${label} checks`}
       aria-label={`Inspect ${label} checks`}
     >
-      <ClipboardDocumentCheckIcon className="h-4 w-4" />
+      <Icon icon="lucide:clipboard-check" width={15} />
     </button>
   );
 
+  const displayName = profile?.display_name;
+  const initials = getInitials(displayName);
+  const profileSubtitle = profile
+    ? `${LANGUAGE_LABEL[profile.preferred_language] ?? profile.preferred_language} · ${profile.highlight_theme}`
+    : undefined;
+
   return (
     <>
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header className="bg-surface border-b border-border shadow-e1">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center py-4">
-            <div className="flex items-center space-x-3">
-              <Link href="/" onClick={closeAllMenus} aria-label="Go to dashboard">
-                <Image src="/logo.svg" alt="LocalCloud Kit" width={90} height={36} />
-              </Link>
-              <div>
-                <h1 className="text-2xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">
-                  Local Cloud Development Environment
-                  {" "}
-                  •
-                  {" "}
-                  v
+          <div className="flex justify-between items-center py-3 gap-3">
+            <Link href="/" onClick={closeAllMenus} aria-label="Go to dashboard" className="flex items-center gap-3 min-w-0">
+              <ManageHeaderBrand size="sm" />
+              <div className="hidden sm:flex flex-col min-w-0">
+                <span className="text-[15px] font-semibold tracking-tight text-ink truncate">LocalCloud Kit</span>
+                <span className="text-[11px] text-muted truncate">
+                  Local cloud development environment · v
                   {packageJson.version}
-                </p>
+                </span>
               </div>
-            </div>
+            </Link>
 
             <div className="hidden md:flex items-center gap-0.5">
               <div className="relative" ref={resourcesMenuRef}>
                 <button
                   onClick={() => toggleMenu(setShowResourcesMenu, showResourcesMenu)}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className={navPillClass(showResourcesMenu)}
                 >
-                  <Squares2X2Icon className="h-4 w-4 mr-2" />
+                  <Icon icon="lucide:layers" width={14} />
                   Resources
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showResourcesMenu ? "rotate-180" : ""}`} />
+                  <Icon icon="lucide:chevron-down" width={14} className={cn("transition-transform", showResourcesMenu && "rotate-180")} />
                 </button>
                 {showResourcesMenu && (
-                  <div className="absolute right-0 mt-1 w-80 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1.5">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                  <div className={dropdownPanelClass("w-80")}>
+                    <p className={sectionLabelClass}>Storage</p>
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openS3Buckets, "/manage/s3")}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                         S3 Buckets
@@ -304,12 +336,12 @@ export default function DashboardNavBar({
                       })}
                     </div>
 
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Database</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className={dividerClass} />
+                    <p className={sectionLabelClass}>Database</p>
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb")}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                         DynamoDB
@@ -322,12 +354,12 @@ export default function DashboardNavBar({
                       })}
                     </div>
 
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compute</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className={dividerClass} />
+                    <p className={sectionLabelClass}>Compute</p>
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openLambdaConfig, DASHBOARD_FALLBACK_HREF)}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                         Lambda
@@ -340,12 +372,12 @@ export default function DashboardNavBar({
                       })}
                     </div>
 
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Networking</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className={dividerClass} />
+                    <p className={sectionLabelClass}>Networking</p>
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openAPIGatewayConfig, DASHBOARD_FALLBACK_HREF)}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                         API Gateway
@@ -358,12 +390,12 @@ export default function DashboardNavBar({
                       })}
                     </div>
 
-                    <div className="border-t border-gray-100 mt-1" />
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Security & Identity</p>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className={dividerClass} />
+                    <p className={sectionLabelClass}>Security &amp; Identity</p>
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openSecretsConfig, DASHBOARD_FALLBACK_HREF)}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                         Secrets Manager
@@ -375,10 +407,10 @@ export default function DashboardNavBar({
                         onPreview: () => openActionOrFallback(actions?.openSecretsViewer, "/manage/secrets"),
                       })}
                     </div>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openSSMConfig, DASHBOARD_FALLBACK_HREF)}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                         Parameter Store
@@ -390,10 +422,10 @@ export default function DashboardNavBar({
                         onPreview: () => openActionOrFallback(actions?.openSSMViewer, "/manage/ssm"),
                       })}
                     </div>
-                    <div className="flex items-center justify-between gap-2 px-2.5 py-0.5">
+                    <div className="flex items-center justify-between gap-2 px-1.5 py-0.5">
                       <button
                         onClick={() => openActionOrFallback(actions?.openIAMConfig, DASHBOARD_FALLBACK_HREF)}
-                        className="flex items-center flex-1 px-2.5 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                        className={menuItemClass}
                       >
                         <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                         IAM Roles
@@ -412,35 +444,35 @@ export default function DashboardNavBar({
               <div className="relative" ref={servicesMenuRef}>
                 <button
                   onClick={() => toggleMenu(setShowServicesMenu, showServicesMenu)}
-                  className="relative flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className={cn("relative", navPillClass(showServicesMenu))}
                 >
-                  <ServerIcon className="h-4 w-4 mr-2" />
+                  <Icon icon="lucide:server" width={14} />
                   Services
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showServicesMenu ? "rotate-180" : ""}`} />
+                  <Icon icon="lucide:chevron-down" width={14} className={cn("transition-transform", showServicesMenu && "rotate-180")} />
                   {mailpit.unread > 0 && (
-                    <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
+                    <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[10px] font-bold bg-danger text-white leading-none">
                       {mailpit.unread > 99 ? "99+" : mailpit.unread}
                     </span>
                   )}
                 </button>
                 {showServicesMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                  <div className={dropdownPanelClass("w-56")}>
                     {PLATFORM_SERVICE_KINDS.map((kind, i) => {
                       const items = PLATFORM_SERVICES.filter((service) => service.kind === kind);
                       return (
                         <div key={kind}>
-                          {i > 0 && <div className="border-t border-gray-100 mt-1" />}
-                          <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                          {i > 0 && <div className={dividerClass} />}
+                          <p className={sectionLabelClass}>
                             {SERVICE_KIND_LABEL[kind]}
                           </p>
                           {items.map((service) => {
                             const ServiceIcon = service.icon;
                             const itemContent = (
                               <>
-                                <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                                <ServiceIcon className="h-4 w-4 mr-3 text-faint shrink-0" />
                                 {service.label}
                                 {service.id === "mailpit" && mailpit.unread > 0 && (
-                                  <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white leading-none">
+                                  <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[10px] font-bold bg-danger text-white leading-none">
                                     {mailpit.unread > 99 ? "99+" : mailpit.unread}
                                   </span>
                                 )}
@@ -448,19 +480,19 @@ export default function DashboardNavBar({
                             );
                             const action = service.action;
                             return (
-                              <div key={service.id} className="flex items-center justify-between px-2">
+                              <div key={service.id} className="flex items-center justify-between px-1.5">
                                 {action.type === "link" ? (
                                   <Link
                                     href={action.href}
                                     onClick={closeAllMenus}
-                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                    className={menuItemClass}
                                   >
                                     {itemContent}
                                   </Link>
                                 ) : (
                                   <button
                                     onClick={() => openModal(action.modalKey)}
-                                    className="flex items-center flex-1 px-2 py-2 text-sm text-gray-700 hover:bg-gray-50 rounded transition-colors"
+                                    className={menuItemClass}
                                   >
                                     {itemContent}
                                   </button>
@@ -481,70 +513,70 @@ export default function DashboardNavBar({
                   onClick={() => toggleMenu(setShowDocsMenu, showDocsMenu)}
                   onMouseEnter={prefetchDocRoutes}
                   onFocus={prefetchDocRoutes}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className={navPillClass(showDocsMenu)}
                 >
-                  <BookOpenIcon className="h-4 w-4 mr-2" />
+                  <Icon icon="lucide:book-open" width={14} />
                   Docs
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDocsMenu ? "rotate-180" : ""}`} />
+                  <Icon icon="lucide:chevron-down" width={14} className={cn("transition-transform", showDocsMenu && "rotate-180")} />
                 </button>
                 {showDocsMenu && (
-                  <div className="absolute right-0 mt-1 w-176 max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-md shadow-lg z-50 p-3">
+                  <div className="absolute right-0 mt-1.5 w-176 max-w-[calc(100vw-2rem)] bg-surface border border-border rounded-xl shadow-e2 z-50 p-3">
                     <Link
                       href="/docs"
                       onClick={() => setShowDocsMenu(false)}
-                      className="flex items-center rounded-md px-3 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 transition-colors"
+                      className="flex items-center rounded-lg px-3 py-2 text-sm font-medium text-primary-ink hover:bg-primary-soft transition-colors"
                     >
-                      <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+                      <Icon icon="lucide:book-open" width={16} className="mr-3 text-primary" />
                       Docs Hub
                     </Link>
 
                     <div className="mt-3 grid grid-cols-3 gap-3 max-h-[65vh] overflow-y-auto">
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Infrastructure</p>
+                      <div className="rounded-lg border border-border py-1">
+                        <p className={sectionLabelClass}>Infrastructure</p>
                         <Link
                           href="/aws-emulator"
                           onClick={() => setShowDocsMenu(false)}
-                          className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors"
                         >
-                          <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                          <Icon icon="lucide:cloud" width={16} className="mr-3 text-faint" />
                           AWS Emulator
                         </Link>
                       </div>
 
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
-                        <Link href="/dynamodb" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                      <div className="rounded-lg border border-border py-1">
+                        <p className={sectionLabelClass}>AWS Resources</p>
+                        <Link href="/dynamodb" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                           DynamoDB
                         </Link>
-                        <Link href="/s3" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/s3" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                           S3 Buckets
                         </Link>
-                        <Link href="/lambda" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/lambda" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                           Lambda
                         </Link>
-                        <Link href="/apigateway" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/apigateway" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                           API Gateway
                         </Link>
-                        <Link href="/secrets" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/secrets" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                           Secrets Manager
                         </Link>
-                        <Link href="/ssm" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/ssm" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                           Parameter Store
                         </Link>
-                        <Link href="/iam" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors">
+                        <Link href="/iam" onClick={() => setShowDocsMenu(false)} className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors">
                           <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                           IAM &amp; STS
                         </Link>
                       </div>
 
-                      <div className="rounded-md border border-gray-100 py-1">
-                        <p className="px-3 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Platform Services</p>
+                      <div className="rounded-lg border border-border py-1">
+                        <p className={sectionLabelClass}>Platform Services</p>
                         {PLATFORM_SERVICES.map((service) => {
                           const ServiceIcon = service.icon;
                           const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
@@ -553,9 +585,9 @@ export default function DashboardNavBar({
                               key={service.id}
                               href={href}
                               onClick={() => setShowDocsMenu(false)}
-                              className="flex items-center px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                              className="flex items-center px-3 py-2 text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors"
                             >
-                              <ServiceIcon className="h-4 w-4 mr-3 text-gray-400" />
+                              <ServiceIcon className="h-4 w-4 mr-3 text-faint" />
                               {service.label}
                             </Link>
                           );
@@ -569,74 +601,90 @@ export default function DashboardNavBar({
               <div className="relative" ref={devToolsMenuRef}>
                 <button
                   onClick={() => toggleMenu(setShowDevToolsMenu, showDevToolsMenu)}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className={navPillClass(showDevToolsMenu)}
                 >
-                  <ServerIcon className="h-4 w-4 mr-2" />
+                  <Icon icon="lucide:wrench" width={14} />
                   Dev Tools
-                  <ChevronDownIcon className={`h-4 w-4 ml-2 transition-transform ${showDevToolsMenu ? "rotate-180" : ""}`} />
+                  <Icon icon="lucide:chevron-down" width={14} className={cn("transition-transform", showDevToolsMenu && "rotate-180")} />
                 </button>
                 {showDevToolsMenu && (
-                  <div className="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Logs</p>
-                    <button
-                      onClick={() => openModal("logs")}
-                      className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                    >
-                      <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
-                      System Logs
-                    </button>
+                  <div className={dropdownPanelClass("w-48")}>
+                    <p className={sectionLabelClass}>Logs</p>
+                    <div className="px-1.5">
+                      <button
+                        onClick={() => openModal("logs")}
+                        className={cn(menuItemClass, "w-full")}
+                      >
+                        <Icon icon="lucide:scroll-text" width={16} className="mr-3 text-faint" />
+                        System Logs
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>
 
-              <div className="h-5 w-px bg-gray-200 mx-1.5" />
+              <div className="w-px h-[18px] bg-border mx-1.5" />
 
               <div className="relative" ref={projectMenuRef}>
                 <button
                   onClick={() => toggleMenu(setShowProjectMenu, showProjectMenu)}
-                  className="flex items-center gap-1.5 px-2 py-1.5 text-sm font-medium text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+                  className={cn(
+                    "flex items-center gap-1.5 h-8 px-2.5 rounded-lg border text-xs font-medium whitespace-nowrap transition-colors",
+                    showProjectMenu
+                      ? "border-primary bg-surface text-ink-2 ring-2 ring-focus"
+                      : "border-border-strong bg-surface text-ink-2 hover:bg-surface-2"
+                  )}
                 >
-                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
-                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500 shrink-0" />
-                    {profile?.active_project_label || "Default"}
-                  </span>
-                  <ChevronDownIcon className={`h-3.5 w-3.5 text-gray-400 transition-transform ${showProjectMenu ? "rotate-180" : ""}`} />
+                  <Icon icon="lucide:box" width={13} className={showProjectMenu ? "text-primary" : "text-muted"} />
+                  {profile?.active_project_label || "Default"}
+                  <Icon icon="lucide:chevron-down" width={13} className={cn("text-faint transition-transform", showProjectMenu && "rotate-180")} />
                 </button>
                 {showProjectMenu && (
-                  <div className="absolute right-0 mt-1 w-56 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
-                    <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Projects</p>
-                    {projects.map((project) => (
+                  <div className={dropdownPanelClass("w-56")}>
+                    <p className={sectionLabelClass}>Projects</p>
+                    <div className="px-1.5">
+                      {projects.map((project) => {
+                        const isActive = project.id === profile?.active_project_id;
+                        return (
+                          <button
+                            key={project.id}
+                            onClick={() => handleSwitchProject(project.id)}
+                            className={cn(
+                              "flex items-center w-full gap-2.5 px-2.5 py-2 rounded-lg text-sm transition-colors",
+                              isActive
+                                ? "bg-primary-soft text-primary-ink font-medium"
+                                : "text-ink-2 hover:bg-surface-3 hover:text-ink"
+                            )}
+                          >
+                            <Icon icon="lucide:box" width={15} className={isActive ? "text-primary shrink-0" : "text-muted shrink-0"} />
+                            <span className="flex-1 text-left truncate">{project.label}</span>
+                            {isActive && <Icon icon="lucide:check" width={15} className="text-primary shrink-0" />}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <div className={dividerClass} />
+                    <div className="px-1.5">
                       <button
-                        key={project.id}
-                        onClick={() => handleSwitchProject(project.id)}
-                        className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
-                          project.id === profile?.active_project_id
-                            ? "text-blue-700 bg-blue-50 font-medium"
-                            : "text-gray-700 hover:bg-gray-50"
-                        }`}
+                        onClick={handleCreateProject}
+                        className="flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-sm font-medium text-primary hover:bg-primary-soft transition-colors"
                       >
-                        <span className={`h-2 w-2 rounded-full mr-3 shrink-0 ${project.id === profile?.active_project_id ? "bg-blue-500" : "bg-gray-300"}`} />
-                        {project.label}
+                        <Icon icon="lucide:plus" width={15} />
+                        New project
                       </button>
-                    ))}
-                    <div className="border-t border-gray-100 mt-1" />
-                    <button
-                      onClick={handleCreateProject}
-                      className="flex items-center w-full px-4 py-2 text-sm text-blue-600 hover:bg-blue-50 transition-colors"
-                    >
-                      + New project
-                    </button>
-                    <Link
-                      href="/profile"
-                      onClick={() => setShowProjectMenu(false)}
-                      className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
-                        activePage === "profile"
-                          ? "text-blue-700 bg-blue-50 font-medium"
-                          : "text-gray-700 hover:bg-gray-50"
-                      }`}
-                    >
-                      Manage projects...
-                    </Link>
+                      <Link
+                        href="/profile"
+                        onClick={() => setShowProjectMenu(false)}
+                        className={cn(
+                          "flex items-center w-full px-2.5 py-2 rounded-lg text-sm transition-colors",
+                          activePage === "profile"
+                            ? "text-primary-ink bg-primary-soft font-medium"
+                            : "text-ink-2 hover:bg-surface-3 hover:text-ink"
+                        )}
+                      >
+                        Manage projects...
+                      </Link>
+                    </div>
                   </div>
                 )}
               </div>
@@ -647,34 +695,76 @@ export default function DashboardNavBar({
                     toggleMenu(setShowProfileMenu, showProfileMenu);
                     dismissVersionDot();
                   }}
-                  className="relative p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                  className={cn(
+                    "relative flex items-center justify-center w-8 h-8 rounded-lg text-xs font-semibold transition-colors",
+                    activePage === "profile"
+                      ? "bg-primary-soft text-primary-ink"
+                      : "bg-surface-3 text-ink-2 hover:bg-surface-2"
+                  )}
                   title="Profile & Settings"
                 >
-                  <UserCircleIcon className={`h-6 w-6 ${activePage === "profile" ? "text-blue-600" : ""}`} />
+                  {initials}
                   {hasNewVersion && (
-                    <span className="absolute top-0.5 right-0.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white" />
+                    <span className="absolute -top-1 -right-1 w-2 h-2 rounded-full bg-danger ring-2 ring-surface" />
                   )}
                 </button>
                 {showProfileMenu && (
-                  <div className="absolute right-0 mt-1 w-52 bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1">
+                  <div className={dropdownPanelClass("w-56")}>
                     {hasNewVersion && (
-                      <div className="mx-2 mb-1 px-3 py-2 bg-blue-50 rounded-md border border-blue-100">
-                        <p className="text-xs font-semibold text-blue-700">v{packageJson.version} — What&apos;s new</p>
-                        <Link href="https://github.com/localcloud-kit/localcloud-kit/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">View changelog →</Link>
+                      <div className="mx-1.5 mb-1.5 px-3 py-2 bg-primary-soft rounded-lg border border-primary/20">
+                        <p className="text-xs font-semibold text-primary-ink">
+                          v
+                          {packageJson.version}
+                          {" "}
+                          — What&apos;s new
+                        </p>
+                        <Link href="https://github.com/localcloud-kit/localcloud-kit/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" className="text-xs text-primary hover:underline">View changelog →</Link>
                       </div>
                     )}
-                    <Link
-                      href="/profile"
-                      onClick={() => setShowProfileMenu(false)}
-                      className={`flex items-center w-full px-4 py-2 text-sm transition-colors ${
-                        activePage === "profile"
-                          ? "text-blue-700 bg-blue-50 font-medium"
-                          : "text-gray-700 hover:bg-gray-50"
-                      }`}
-                    >
-                      <UserCircleIcon className={`h-4 w-4 mr-3 ${activePage === "profile" ? "text-blue-500" : "text-gray-400"}`} />
-                      Profile & Preferences
-                    </Link>
+                    <div className="flex items-center gap-2.5 px-3 py-2">
+                      <span className="flex items-center justify-center w-[30px] h-[30px] rounded-lg bg-surface-3 text-ink-2 text-xs font-semibold shrink-0">
+                        {initials}
+                      </span>
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium text-ink truncate">{displayName || "Local user"}</span>
+                        {profileSubtitle && <span className="text-[11px] text-muted truncate">{profileSubtitle}</span>}
+                      </div>
+                    </div>
+                    <div className={dividerClass} />
+                    <div className="px-1.5">
+                      <Link
+                        href="/profile"
+                        onClick={() => setShowProfileMenu(false)}
+                        className={cn(
+                          "flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-sm transition-colors",
+                          activePage === "profile"
+                            ? "text-primary-ink bg-primary-soft font-medium"
+                            : "text-ink-2 hover:bg-surface-3 hover:text-ink"
+                        )}
+                      >
+                        <Icon icon="lucide:user-cog" width={15} className={activePage === "profile" ? "text-primary" : "text-faint"} />
+                        Preferences
+                      </Link>
+                      <div className="flex items-center justify-between gap-2 px-2.5 py-2 rounded-lg text-sm text-ink-2">
+                        <span className="flex items-center gap-2.5">
+                          <Icon icon="lucide:sun-moon" width={15} className="text-faint" />
+                          Theme
+                        </span>
+                        <SegmentedControl
+                          options={THEME_OPTIONS}
+                          value={profile?.theme ?? "auto"}
+                          onChange={handleThemeChange}
+                        />
+                      </div>
+                      <Link
+                        href="/docs"
+                        onClick={() => setShowProfileMenu(false)}
+                        className="flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-sm text-ink-2 hover:bg-surface-3 hover:text-ink transition-colors"
+                      >
+                        <Icon icon="lucide:external-link" width={15} className="text-faint" />
+                        Docs hub
+                      </Link>
+                    </div>
                   </div>
                 )}
               </div>
@@ -682,108 +772,108 @@ export default function DashboardNavBar({
 
             <div className="flex md:hidden items-center gap-2">
               {hasNewVersion && (
-                <span className="h-2 w-2 rounded-full bg-red-500" />
+                <span className="h-2 w-2 rounded-full bg-danger" />
               )}
               {mailpit.unread > 0 && (
-                <span className="flex items-center justify-center h-5 min-w-5 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
+                <span className="flex items-center justify-center h-5 min-w-5 px-1 rounded-full text-xs font-bold bg-danger text-white">
                   {mailpit.unread > 99 ? "99+" : mailpit.unread}
                 </span>
               )}
               <button
                 onClick={() => setShowMobileMenu((value) => !value)}
-                className="p-1.5 rounded-lg text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+                className="p-1.5 rounded-lg text-muted hover:text-ink hover:bg-surface-3 transition-colors"
                 aria-label="Open menu"
               >
-                {showMobileMenu ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+                <Icon icon={showMobileMenu ? "lucide:x" : "lucide:menu"} width={22} />
               </button>
             </div>
           </div>
 
           {showMobileMenu && (
-            <div className="md:hidden border-t border-gray-100 pb-3">
+            <div className="md:hidden border-t border-divider pb-3">
               <div className="pt-3 px-2">
-                <p className="px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">AWS Resources</p>
+                <p className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-faint">AWS Resources</p>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openS3Buckets, "/manage/s3")} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openS3Buckets, "/manage/s3")} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                     S3 Buckets
                   </button>
-                  <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("s3")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb")} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openDynamoDBViewer, "/manage/dynamodb")} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                     DynamoDB Tables
                   </button>
-                  <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("dynamodb")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openLambdaConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openLambdaConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                     Lambda Functions
                   </button>
-                  <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("lambda")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openAPIGatewayConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openAPIGatewayConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                     API Gateway
                   </button>
-                  <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("apigateway")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openSecretsConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openSecretsConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                     Secrets Manager
                   </button>
-                  <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("secretsmanager")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openSSMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openSSMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                     Parameter Store
                   </button>
-                  <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("ssm")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
                 <div className="flex items-center gap-1">
-                  <button onClick={() => openActionOrFallback(actions?.openIAMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                  <button onClick={() => openActionOrFallback(actions?.openIAMConfig, DASHBOARD_FALLBACK_HREF)} className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                     <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                     IAM Roles
                   </button>
-                  <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap">
+                  <button onClick={() => openInspectTarget("iam")} className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap">
                     Inspect
                   </button>
                 </div>
               </div>
 
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
+              <div className="pt-2 px-2 border-t border-divider mt-2">
                 {PLATFORM_SERVICE_KINDS.map((kind, i) => {
                   const items = PLATFORM_SERVICES.filter((service) => service.kind === kind);
                   return (
                     <div key={kind}>
-                      <p className={`px-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider ${i > 0 ? "pt-2" : "py-1"}`}>
+                      <p className={`px-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-faint ${i > 0 ? "pt-2" : "py-1"}`}>
                         {SERVICE_KIND_LABEL[kind]}
                       </p>
                       {items.map((service) => {
                         const ServiceIcon = service.icon;
                         const itemContent = (
                           <>
-                            <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                            <ServiceIcon className="h-4 w-4 mr-3 text-faint shrink-0" />
                             {service.label}
                             {service.id === "mailpit" && mailpit.unread > 0 && (
-                              <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-xs font-bold bg-red-500 text-white">
+                              <span className="ml-auto flex items-center justify-center h-4 min-w-4 px-1 rounded-full text-[10px] font-bold bg-danger text-white">
                                 {mailpit.unread > 99 ? "99+" : mailpit.unread}
                               </span>
                             )}
@@ -796,21 +886,21 @@ export default function DashboardNavBar({
                               <Link
                                 href={action.href}
                                 onClick={closeAllMenus}
-                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors"
                               >
                                 {itemContent}
                               </Link>
                             ) : (
                               <button
                                 onClick={() => openModal(action.modalKey)}
-                                className="flex items-center flex-1 px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                                className="flex items-center flex-1 px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors"
                               >
                                 {itemContent}
                               </button>
                             )}
                             <button
                               onClick={() => openInspectTarget(service.id)}
-                              className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded whitespace-nowrap"
+                              className="px-2 py-1 text-xs text-muted hover:text-ink hover:bg-surface-3 rounded-md whitespace-nowrap"
                             >
                               Inspect
                             </button>
@@ -822,41 +912,41 @@ export default function DashboardNavBar({
                 })}
               </div>
 
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Docs</p>
-                <Link href="/docs" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm font-medium text-indigo-700 rounded-lg hover:bg-indigo-50 transition-colors">
-                  <BookOpenIcon className="h-4 w-4 mr-3 text-indigo-500" />
+              <div className="pt-2 px-2 border-t border-divider mt-2">
+                <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-faint">Docs</p>
+                <Link href="/docs" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm font-medium text-primary-ink rounded-lg hover:bg-primary-soft transition-colors">
+                  <Icon icon="lucide:book-open" width={16} className="mr-3 text-primary" />
                   Docs Hub
                 </Link>
-                <Link href="/aws-emulator" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <Squares2X2Icon className="h-4 w-4 mr-3 text-gray-400" />
+                <Link href="/aws-emulator" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
+                  <Icon icon="lucide:cloud" width={16} className="mr-3 text-faint" />
                   AWS Emulator
                 </Link>
-                <Link href="/s3" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/s3" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-s3" className="w-4 h-4 mr-3 shrink-0" />
                   S3 Buckets
                 </Link>
-                <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/dynamodb" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-dynamodb" className="w-4 h-4 mr-3 shrink-0" />
                   DynamoDB
                 </Link>
-                <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/lambda" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-lambda" className="w-4 h-4 mr-3 shrink-0" />
                   Lambda
                 </Link>
-                <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/apigateway" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-api-gateway" className="w-4 h-4 mr-3 shrink-0" />
                   API Gateway
                 </Link>
-                <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/secrets" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-secrets-manager" className="w-4 h-4 mr-3 shrink-0" />
                   Secrets Manager
                 </Link>
-                <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/ssm" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-systems-manager" className="w-4 h-4 mr-3 shrink-0" />
                   Parameter Store
                 </Link>
-                <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
+                <Link href="/iam" onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
                   <Icon icon="logos:aws-iam" className="w-4 h-4 mr-3 shrink-0" />
                   IAM &amp; STS
                 </Link>
@@ -864,36 +954,54 @@ export default function DashboardNavBar({
                   const ServiceIcon = service.icon;
                   const href = service.action.type === "link" ? service.action.href : `/${service.id}`;
                   return (
-                    <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                      <ServiceIcon className="h-4 w-4 mr-3 text-gray-400 shrink-0" />
+                    <Link key={service.id} href={href} onClick={closeAllMenus} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
+                      <ServiceIcon className="h-4 w-4 mr-3 text-faint shrink-0" />
                       {service.label}
                     </Link>
                   );
                 })}
               </div>
 
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Dev Tools</p>
-                <button onClick={() => openModal("logs")} className="flex items-center w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 transition-colors">
-                  <DocumentTextIcon className="h-4 w-4 mr-3 text-gray-400" />
+              <div className="pt-2 px-2 border-t border-divider mt-2">
+                <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-faint">Dev Tools</p>
+                <button onClick={() => openModal("logs")} className="flex items-center w-full px-3 py-2 text-sm text-ink-2 rounded-lg hover:bg-surface-3 transition-colors">
+                  <Icon icon="lucide:scroll-text" width={16} className="mr-3 text-faint" />
                   System Logs
                 </button>
               </div>
 
-              <div className="pt-2 px-2 border-t border-gray-100 mt-2">
-                <p className="px-2 py-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Account</p>
-                <div className="px-3 py-2">
-                  <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-blue-50 text-blue-700 text-xs font-semibold">
-                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
-                    {profile?.active_project_label || "Default"}
+              <div className="pt-2 px-2 border-t border-divider mt-2">
+                <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-faint">Account</p>
+                <div className="flex items-center gap-2.5 px-3 py-2">
+                  <span className="flex items-center justify-center w-7 h-7 rounded-lg bg-surface-3 text-ink-2 text-xs font-semibold shrink-0">
+                    {initials}
                   </span>
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium text-ink truncate">{displayName || "Local user"}</span>
+                    <span className="text-[11px] text-muted truncate flex items-center gap-1">
+                      <Icon icon="lucide:box" width={11} className="text-primary" />
+                      {profile?.active_project_label || "Default"}
+                    </span>
+                  </div>
                 </div>
-                <Link href="/profile" onClick={closeAllMenus} className={`flex items-center w-full px-3 py-2 text-sm rounded-lg transition-colors ${
+                <div className="px-3 py-1.5 flex items-center justify-between gap-2">
+                  <span className="flex items-center gap-2 text-sm text-ink-2">
+                    <Icon icon="lucide:sun-moon" width={15} className="text-faint" />
+                    Theme
+                  </span>
+                  <SegmentedControl
+                    options={THEME_OPTIONS}
+                    value={profile?.theme ?? "auto"}
+                    onChange={handleThemeChange}
+                  />
+                </div>
+                <Link href="/profile" onClick={closeAllMenus} className={cn(
+                  "flex items-center w-full px-3 py-2 text-sm rounded-lg transition-colors",
                   activePage === "profile"
-                    ? "text-blue-700 bg-blue-50"
-                    : "text-gray-700 hover:bg-gray-50"
-                }`}>
-                  <UserCircleIcon className={`h-4 w-4 mr-3 ${activePage === "profile" ? "text-blue-500" : "text-gray-400"}`} />
+                    ? "text-primary-ink bg-primary-soft"
+                    : "text-ink-2 hover:bg-surface-3"
+                )}>
+                  <Icon icon="lucide:user-cog" width={16} className={cn("mr-3", activePage === "profile" ? "text-primary" : "text-faint")} />
                   Profile & Preferences
                 </Link>
               </div>

--- a/localcloud-gui/src/components/DashboardSkeleton.tsx
+++ b/localcloud-gui/src/components/DashboardSkeleton.tsx
@@ -7,20 +7,19 @@ import packageJson from "../../package.json";
 /** Skeleton row matching the exact grid used by ResourceList */
 function ResourceRowSkeleton({ opacity = 1 }: { opacity?: number }) {
   return (
-    <div className="px-6 py-3.5 border-b border-gray-100" style={{ opacity }}>
+    <div className="px-4 py-3 border-b border-divider" style={{ opacity }}>
       <div
-        className="grid items-center gap-x-4"
-        style={{ gridTemplateColumns: "1.25rem 2.5rem 1fr 9rem 6rem 1.75rem" }}
+        className="grid items-center gap-x-3"
+        style={{ gridTemplateColumns: "1.25rem minmax(0,1fr) 8rem 6rem 6.5rem 5rem" }}
       >
-        <div className="h-4 w-4 rounded bg-gray-200" />
-        <div className="h-6 w-6 rounded bg-gray-200 mx-auto" />
+        <div className="h-3.5 w-3.5 rounded bg-skeleton" />
         <div className="space-y-1.5">
-          <div className="h-3.5 w-40 bg-gray-200 rounded" />
-          <div className="h-3 w-24 bg-gray-100 rounded" />
+          <div className="h-3.5 w-40 bg-skeleton rounded" />
         </div>
-        <div className="h-5 w-20 bg-gray-100 rounded-full" />
-        <div className="h-6 w-16 bg-gray-100 rounded-md mx-auto" />
-        <div className="h-4 w-4 bg-gray-100 rounded" />
+        <div className="h-3 w-16 bg-skeleton rounded" />
+        <div className="h-3 w-14 bg-skeleton rounded" />
+        <div className="h-5 w-16 bg-skeleton rounded-full mx-auto" />
+        <div className="h-6 w-12 bg-skeleton rounded-md mx-auto" />
       </div>
     </div>
   );
@@ -29,10 +28,10 @@ function ResourceRowSkeleton({ opacity = 1 }: { opacity?: number }) {
 /** Service pill: real name + pulsing status badge */
 export function ServicePillSkeleton({ name }: { name: string }) {
   return (
-    <div className="flex items-center space-x-2 px-3">
-      <div className="h-2.5 w-2.5 rounded-full bg-gray-300 shrink-0 animate-pulse" />
-      <span className="text-sm font-medium text-gray-700">{name}</span>
-      <div className="h-5 w-16 rounded-full bg-gray-100 animate-pulse" />
+    <div className="flex items-center gap-1.5 px-3 py-1.5">
+      <div className="h-1.5 w-1.5 rounded-full bg-faint shrink-0 animate-pulse" />
+      <span className="text-xs font-medium text-ink-2">{name}</span>
+      <div className="h-3.5 w-12 rounded bg-skeleton animate-pulse" />
     </div>
   );
 }
@@ -40,17 +39,15 @@ export function ServicePillSkeleton({ name }: { name: string }) {
 /** Single-row services bar skeleton — matches Dashboard flat layout */
 export function ServicesBarSkeleton() {
   return (
-    <div className="mb-6 bg-white rounded-lg shadow-sm border border-gray-200 px-4 py-3 flex items-center flex-wrap gap-y-2 gap-x-0">
+    <div className="mb-6 bg-surface rounded-lg shadow-e1 border border-border px-2 py-2 flex items-center flex-wrap gap-y-1">
       <ServicePillSkeleton name="Keycloak" />
-      <div className="h-4 w-px bg-gray-200" />
+      <div className="h-4 w-px bg-border" />
       <ServicePillSkeleton name="AWS Emulator" />
-      <div className="h-4 w-px bg-gray-200" />
+      <div className="h-4 w-px bg-border" />
       <ServicePillSkeleton name="Mailpit" />
-      <div className="h-4 w-px bg-gray-200" />
+      <div className="h-4 w-px bg-border" />
       <ServicePillSkeleton name="PostgreSQL" />
-      <div className="h-4 w-px bg-gray-200" />
-      <ServicePillSkeleton name="PostHog (Beta)" />
-      <div className="h-4 w-px bg-gray-200" />
+      <div className="h-4 w-px bg-border" />
       <ServicePillSkeleton name="Redis" />
     </div>
   );
@@ -59,38 +56,46 @@ export function ServicesBarSkeleton() {
 /** Resources panel skeleton */
 export function ResourcesPanelSkeleton() {
   return (
-    <div className="mb-8 bg-white rounded-lg shadow animate-pulse">
-      <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+    <div className="mb-8 bg-surface rounded-xl shadow-e1 border border-border overflow-hidden animate-pulse">
+      <div className="px-4 py-3.5 border-b border-divider flex items-center justify-between">
         <div className="space-y-1.5">
-          <div className="h-4 w-28 bg-gray-200 rounded" />
-          <div className="h-3 w-36 bg-gray-100 rounded" />
+          <div className="h-4 w-28 bg-skeleton rounded" />
+          <div className="h-3 w-36 bg-skeleton rounded" />
         </div>
-        <div className="flex items-center space-x-2">
-          <div className="h-8 w-8 bg-gray-100 rounded-md" />
-          <div className="h-8 w-20 bg-gray-200 rounded-md" />
+        <div className="flex items-center gap-1.5">
+          <div className="h-8 w-36 bg-skeleton rounded-lg" />
+          <div className="h-8 w-8 bg-skeleton rounded-lg" />
+          <div className="h-8 w-32 bg-skeleton rounded-lg" />
         </div>
       </div>
-      <div className="px-6 py-2 bg-gray-50 border-b border-gray-200 flex items-center space-x-2">
-        <div className="h-3 w-14 bg-gray-200 rounded" />
-        <div className="h-3 w-5 bg-gray-100 rounded" />
-      </div>
-      <div className="grid items-center gap-x-4 px-6 py-2 bg-white border-b border-gray-100" style={{ gridTemplateColumns: "1.25rem 2.5rem 1fr 9rem 6rem 1.75rem" }}>
-        <div /><div />
-        <div className="h-2.5 w-16 bg-gray-100 rounded" />
-        <div className="h-2.5 w-12 bg-gray-100 rounded" />
-        <div className="h-2.5 w-12 bg-gray-100 rounded mx-auto" />
+      <div
+        className="grid items-center gap-x-3 px-4 py-2 bg-surface-2 border-b border-divider"
+        style={{ gridTemplateColumns: "1.25rem minmax(0,1fr) 8rem 6rem 6.5rem 5rem" }}
+      >
         <div />
+        <div className="h-2.5 w-12 bg-skeleton rounded" />
+        <div className="h-2.5 w-12 bg-skeleton rounded" />
+        <div className="h-2.5 w-12 bg-skeleton rounded" />
+        <div className="h-2.5 w-12 bg-skeleton rounded mx-auto" />
+        <div />
+      </div>
+      <div className="px-4 py-1.5 bg-surface-2 border-b border-divider flex items-center gap-2">
+        <div className="h-3 w-3.5 bg-skeleton rounded" />
+        <div className="h-3 w-20 bg-skeleton rounded" />
+        <div className="h-3 w-4 bg-skeleton rounded" />
       </div>
       <ResourceRowSkeleton opacity={1} />
       <ResourceRowSkeleton opacity={0.85} />
-      <div className="px-6 py-2 bg-gray-50 border-b border-gray-200 border-t border-t-gray-200 flex items-center space-x-2">
-        <div className="h-3 w-16 bg-gray-200 rounded" />
-        <div className="h-3 w-5 bg-gray-100 rounded" />
+      <div className="px-4 py-1.5 bg-surface-2 border-b border-t border-divider flex items-center gap-2">
+        <div className="h-3 w-3.5 bg-skeleton rounded" />
+        <div className="h-3 w-24 bg-skeleton rounded" />
+        <div className="h-3 w-4 bg-skeleton rounded" />
       </div>
       <ResourceRowSkeleton opacity={0.7} />
-      <div className="px-6 py-2 bg-gray-50 border-b border-gray-200 border-t border-t-gray-200 flex items-center space-x-2">
-        <div className="h-3 w-32 bg-gray-200 rounded" />
-        <div className="h-3 w-5 bg-gray-100 rounded" />
+      <div className="px-4 py-1.5 bg-surface-2 border-b border-t border-divider flex items-center gap-2">
+        <div className="h-3 w-3.5 bg-skeleton rounded" />
+        <div className="h-3 w-16 bg-skeleton rounded" />
+        <div className="h-3 w-4 bg-skeleton rounded" />
       </div>
       <ResourceRowSkeleton opacity={0.5} />
     </div>
@@ -105,30 +110,30 @@ export default function DashboardSkeleton() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0, transition: { duration: 0.15 } }}
       transition={{ duration: 0.2 }}
-      className="min-h-screen bg-linear-to-br from-blue-50 to-indigo-100"
+      className="min-h-screen bg-bg"
     >
       {/* ── Header ─────────────────────────────────────────── */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header className="bg-surface shadow-e1 border-b border-border">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
 
             {/* Logo + title + subtitle — fully static, no shimmer */}
-            <div className="flex items-center space-x-3">
+            <div className="flex items-center gap-3">
               <Image src="/logo.svg" alt="LocalCloud Kit" width={40} height={40} />
               <div>
-                <h1 className="text-2xl font-bold text-gray-900">LocalCloud Kit</h1>
-                <p className="text-xs text-gray-500">Local Cloud Development Environment • v{packageJson.version}</p>
+                <h1 className="text-2xl font-bold text-ink">LocalCloud Kit</h1>
+                <p className="text-xs text-muted">Local Cloud Development Environment • v{packageJson.version}</p>
               </div>
             </div>
 
             {/* Nav: Resources | Services | Docs | ─ | Project | Profile */}
             <div className="flex items-center gap-0.5 animate-pulse">
-              <div className="h-7 w-24 bg-gray-100 rounded-lg" />
-              <div className="h-7 w-20 bg-gray-100 rounded-lg" />
-              <div className="h-7 w-16 bg-gray-100 rounded-lg" />
-              <div className="h-5 w-px bg-gray-200 mx-1.5" />
-              <div className="h-7 w-24 bg-gray-100 rounded-lg" />
-              <div className="h-7 w-7 bg-gray-100 rounded-lg" />
+              <div className="h-7 w-24 bg-skeleton rounded-lg" />
+              <div className="h-7 w-20 bg-skeleton rounded-lg" />
+              <div className="h-7 w-16 bg-skeleton rounded-lg" />
+              <div className="h-5 w-px bg-border mx-1.5" />
+              <div className="h-7 w-24 bg-skeleton rounded-lg" />
+              <div className="h-7 w-7 bg-skeleton rounded-lg" />
             </div>
           </div>
         </div>
@@ -144,7 +149,7 @@ export default function DashboardSkeleton() {
 
         {/* ── Footer ──────────────────────────────────────── */}
         <div className="mt-8 text-center">
-          <div className="h-3 w-72 bg-gray-100 rounded mx-auto animate-pulse" />
+          <div className="h-3 w-72 bg-skeleton rounded mx-auto animate-pulse" />
         </div>
       </div>
     </motion.div>

--- a/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBAddItemModal.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { ChevronDownIcon, XMarkIcon, PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { getDynamoDBTableSchema } from "@/services/api";
+import { Button, IconButton, Input } from "./ui";
 
 type AttributeType = "S" | "N" | "BOOL" | "M" | "L";
 
@@ -100,6 +101,40 @@ function buildDynamoDBAttribute(attr: NestedAttribute): unknown {
   return undefined;
 }
 
+const selectClass =
+  "h-8 appearance-none rounded-lg border border-border-strong bg-surface-2 pl-2.5 pr-7 text-[13px] text-ink outline-none transition-colors focus:border-primary focus:bg-surface focus:ring-3 focus:ring-focus";
+
+function TypeSelect({
+  value,
+  onChange,
+  className,
+}: {
+  value: AttributeType;
+  onChange: (value: AttributeType) => void;
+  className?: string;
+}) {
+  return (
+    <div className={`relative ${className ?? ""}`}>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as AttributeType)}
+        className={`${selectClass} w-full cursor-pointer`}
+      >
+        <option value="S">String</option>
+        <option value="N">Number</option>
+        <option value="BOOL">Boolean</option>
+        <option value="M">Map</option>
+        <option value="L">List</option>
+      </select>
+      <Icon
+        icon="lucide:chevron-down"
+        width={13}
+        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+      />
+    </div>
+  );
+}
+
 // Recursive attribute editor
 function AttributeEditor({
   attr,
@@ -135,51 +170,35 @@ function AttributeEditor({
   };
 
   return (
-    <div
-      className={`border border-gray-200 rounded-md p-3 mb-3 ${
-        parentType === "L" ? "ml-6" : ""
-      }`}
-    >
-      <div className="flex items-center space-x-2 mb-2">
+    <div className={`mb-2.5 rounded-lg border border-border bg-surface-2 p-3 ${parentType === "L" ? "ml-5" : ""}`}>
+      <div className="flex items-center gap-2">
         {parentType !== "L" && (
-          <input
-            type="text"
+          <Input
+            mono
             value={attr.key}
             onChange={(e) => handleFieldChange("key", e.target.value)}
-            className="w-32 px-2.5 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-            placeholder="Attribute Name"
+            className="w-32"
+            placeholder="attribute name"
           />
         )}
-        <div className="relative">
-          <select
-            value={attr.type}
-            onChange={(e) => handleFieldChange("type", e.target.value)}
-            className="appearance-none pl-2.5 pr-7 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 bg-white cursor-pointer"
-          >
-            <option value="S">String</option>
-            <option value="N">Number</option>
-            <option value="BOOL">Boolean</option>
-            <option value="M">Map</option>
-            <option value="L">List</option>
-          </select>
-          <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
-        </div>
+        <TypeSelect value={attr.type} onChange={(value) => handleFieldChange("type", value)} className="w-[118px]" />
         {attr.type === "S" && (
-          <input
-            type="text"
+          <Input
+            mono
             value={attr.value ?? ""}
             onChange={(e) => handleFieldChange("value", e.target.value)}
-            className="w-32 px-2.5 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-            placeholder="Value"
+            className="w-32"
+            placeholder="value"
           />
         )}
         {attr.type === "N" && (
-          <input
+          <Input
+            mono
             type="number"
             step="any"
             value={attr.value ?? ""}
             onChange={(e) => handleFieldChange("value", e.target.value)}
-            className="w-32 px-2.5 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
+            className="w-32"
             placeholder="0"
           />
         )}
@@ -188,39 +207,36 @@ function AttributeEditor({
             <select
               value={attr.value ?? "true"}
               onChange={(e) => handleFieldChange("value", e.target.value)}
-              className="appearance-none w-24 pl-2.5 pr-7 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 bg-white cursor-pointer"
+              className={`${selectClass} w-24 cursor-pointer font-mono`}
             >
               <option value="true">true</option>
               <option value="false">false</option>
             </select>
-            <ChevronDownIcon className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+            <Icon
+              icon="lucide:chevron-down"
+              width={13}
+              className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+            />
           </div>
         )}
         {onRemove && (
-          <button
-            type="button"
+          <IconButton
+            icon="lucide:trash-2"
+            variant="ghost"
+            size="sm"
+            label="Remove attribute"
+            className="ml-auto !text-danger hover:!bg-danger-soft hover:!text-danger"
             onClick={onRemove}
-            className="text-red-600 hover:text-red-800"
-            aria-label="Remove"
-          >
-            <TrashIcon className="h-5 w-5" />
-          </button>
+          />
         )}
       </div>
       {(attr.type === "M" || attr.type === "L") && (
-        <div className="ml-4 border-l-2 border-blue-200 pl-3">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-sm font-medium text-gray-700">
-              {attr.type === "M" ? "Map Items" : "List Items"}
-            </span>
-            <button
-              type="button"
-              onClick={handleAddChild}
-              className="flex items-center px-2 py-1 text-xs bg-blue-600 text-white rounded hover:bg-blue-700"
-            >
-              <PlusIcon className="h-3 w-3 mr-1" />
-              Add Item
-            </button>
+        <div className="mt-2.5 border-l-2 border-primary-soft pl-3">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="text-xs font-medium text-ink-2">{attr.type === "M" ? "Map items" : "List items"}</span>
+            <Button type="button" variant="secondary" size="sm" icon="lucide:plus" onClick={handleAddChild}>
+              Add item
+            </Button>
           </div>
           {attr.children?.map((child, idx) => (
             <AttributeEditor
@@ -234,9 +250,7 @@ function AttributeEditor({
         </div>
       )}
       {isAttributeEmpty(attr) && (
-        <p className="mt-1 text-xs text-amber-600">
-          This attribute is empty and will not be saved.
-        </p>
+        <p className="mt-1.5 text-[11px] text-warn-ink">This attribute is empty and will not be saved.</p>
       )}
     </div>
   );
@@ -371,67 +385,60 @@ export default function DynamoDBAddItemModal({
 
   return (
     <div
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-scrim p-4"
       onMouseDown={handleBackdropMouseDown}
     >
-      <div
-        className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[90vh] flex flex-col"
-      >
+      <div className="flex w-full max-w-lg max-h-[90vh] flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-e3">
         {/* Header — always visible */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Add Item</h2>
-            <p className="text-xs text-gray-500">{tableName}</p>
+        <div className="flex items-start gap-2.5 border-b border-divider px-4.5 py-3.5 shrink-0">
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-primary-soft text-primary">
+            <Icon icon="lucide:plus" width={16} />
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[15px] font-semibold text-ink">Add item</span>
+            <span className="font-mono text-[11px] text-muted">{tableName}</span>
           </div>
-          <button
+          <IconButton
+            icon="lucide:x"
+            variant="ghost"
+            size="sm"
+            label="Close"
+            className="ml-auto"
             onClick={onClose}
-            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-            aria-label="Close"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
+          />
         </div>
 
         {/* Scrollable body */}
-        <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="flex-1 overflow-y-auto px-4.5 py-4">
           {schemaLoading ? (
-            <div className="text-center py-8">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-              <p className="mt-2 text-gray-600">Loading table schema...</p>
+            <div className="flex flex-col items-center gap-2 py-8 text-center">
+              <Icon icon="lucide:loader-2" width={22} className="animate-spin text-primary" />
+              <p className="text-sm text-muted">Loading table schema…</p>
             </div>
           ) : schema ? (
-            <form id="add-item-form" onSubmit={handleSubmit} className="space-y-6">
+            <form id="add-item-form" onSubmit={handleSubmit} className="flex flex-col gap-5">
               {/* Key Fields */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Required Keys
-                </label>
+              <div className="flex flex-col gap-2.5">
+                <span className="text-xs font-medium text-ink-2">Required keys</span>
                 {schema.Table.KeySchema.map((key) => (
-                  <div key={key.AttributeName} className="mb-3">
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                  <label key={key.AttributeName} className="flex flex-col gap-1.5">
+                    <span className="text-xs text-muted">
                       {key.AttributeName}{" "}
-                      <span className="text-xs text-gray-500 font-normal">
-                        ({key.KeyType === "HASH" ? "Partition Key" : "Sort Key"})
-                      </span>
-                    </label>
-                    <input
-                      type="text"
+                      <span className="text-faint">({key.KeyType === "HASH" ? "Partition key" : "Sort key"})</span>
+                    </span>
+                    <Input
+                      mono
                       value={keyValues[key.AttributeName] || ""}
-                      onChange={(e) =>
-                        handleKeyValueChange(key.AttributeName, e.target.value)
-                      }
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
+                      onChange={(e) => handleKeyValueChange(key.AttributeName, e.target.value)}
                       required
                     />
-                  </div>
+                  </label>
                 ))}
               </div>
 
               {/* Custom Attributes */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Custom Attributes
-                </label>
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-medium text-ink-2">Custom attributes</span>
                 {attributes.map((attr, idx) => (
                   <AttributeEditor
                     key={idx}
@@ -446,50 +453,39 @@ export default function DynamoDBAddItemModal({
                     }
                   />
                 ))}
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
+                  size="sm"
+                  icon="lucide:plus"
                   onClick={handleAddAttribute}
-                  className="flex items-center px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 mt-2"
+                  className="w-fit"
                 >
-                  <PlusIcon className="h-4 w-4 mr-1" />
-                  Add Attribute
-                </button>
+                  Add attribute
+                </Button>
               </div>
 
-              {error && <div className="text-red-600 text-sm">{error}</div>}
+              {error && <div className="text-sm text-danger">{error}</div>}
             </form>
           ) : (
-            <div className="text-center py-8">
-              <p className="text-red-600">Failed to load table schema</p>
-              <button
-                onClick={loadTableSchema}
-                className="mt-2 px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700"
-              >
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <p className="text-sm text-danger">Failed to load table schema</p>
+              <Button type="button" variant="primary" size="sm" onClick={loadTableSchema}>
                 Retry
-              </button>
+              </Button>
             </div>
           )}
         </div>
 
         {/* Footer — always visible, pinned to bottom */}
         {schema && !schemaLoading && (
-          <div className="flex justify-end space-x-3 px-6 py-4 border-t border-gray-200 shrink-0">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-              disabled={loading}
-            >
+          <div className="flex items-center justify-end gap-2.5 border-t border-divider bg-surface-2 px-4.5 py-3.5 shrink-0">
+            <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
               Cancel
-            </button>
-            <button
-              type="submit"
-              form="add-item-form"
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
-              disabled={loading}
-            >
-              {loading ? "Adding..." : "Add Item"}
-            </button>
+            </Button>
+            <Button type="submit" form="add-item-form" variant="primary" icon="lucide:plus" loading={loading}>
+              {loading ? "Adding…" : "Add item"}
+            </Button>
           </div>
         )}
       </div>

--- a/localcloud-gui/src/components/DynamoDBCompoundKeyCell.tsx
+++ b/localcloud-gui/src/components/DynamoDBCompoundKeyCell.tsx
@@ -12,11 +12,11 @@ export default function DynamoDBCompoundKeyCell({ value }: DynamoDBCompoundKeyCe
   return (
     <div className="min-w-0 max-w-[220px]">
       {line1 ? (
-        <span className="mb-1 inline-block rounded border border-blue-200 bg-blue-100 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-700">
+        <span className="mb-1 inline-block rounded bg-primary-soft px-1.5 py-0.5 font-mono text-[10px] font-semibold text-primary-ink">
           {line1}
         </span>
       ) : null}
-      <span className="block break-all font-mono text-xs leading-snug text-blue-900">
+      <span className="block break-all font-mono text-xs leading-snug text-ink">
         {line2 || value}
       </span>
     </div>

--- a/localcloud-gui/src/components/DynamoDBConfigModal.tsx
+++ b/localcloud-gui/src/components/DynamoDBConfigModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { XMarkIcon, PlusIcon, TrashIcon, CircleStackIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { DynamoDBTableConfig, DynamoDBGSI } from "@/types";
 import { usePreferences } from "@/context/PreferencesContext";
 import { toast } from "react-hot-toast";
+import { Button, IconButton, Input, SegmentedControl } from "./ui";
 
 interface DynamoDBConfigModalProps {
   isOpen: boolean;
@@ -138,37 +139,35 @@ export default function DynamoDBConfigModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-scrim p-4 py-10"
       onMouseDown={handleBackdropMouseDown}
     >
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-xl max-h-[90vh] overflow-y-auto">
+      <div className="w-full max-w-xl shrink-0 rounded-xl border border-border bg-surface shadow-e3">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <div className="flex items-center space-x-3">
-            <div className="p-2 bg-indigo-50 rounded-lg">
-              <CircleStackIcon className="h-5 w-5 text-indigo-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900">Create DynamoDB Table</h2>
-              <p className="text-xs text-gray-500">Primary key, billing mode &amp; GSIs</p>
-            </div>
+        <div className="flex items-start gap-2.5 border-b border-divider px-4.5 py-4">
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary-soft">
+            <Icon icon="logos:aws-dynamodb" width={18} />
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[15px] font-semibold text-ink">Create DynamoDB table</span>
+            <span className="text-[11px] text-muted">
+              Primary key, billing mode &amp; GSIs · runs{" "}
+              <span className="font-mono">awslocal dynamodb create-table</span>
+            </span>
           </div>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-            aria-label="Close"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
+          <IconButton icon="lucide:x" variant="ghost" size="sm" label="Close" className="ml-auto" onClick={onClose} />
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-
+        <form id="dynamodb-config-form" onSubmit={handleSubmit} className="flex flex-col gap-5 px-4.5 py-4">
           {/* Saved config pills — only shown if configs exist */}
           {profile?.active_project_id && projectConfigs.length > 0 && (
-            <div>
-              <p className="text-xs font-medium text-gray-500 mb-2 uppercase tracking-wide">Load saved config</p>
-              <div className="flex flex-wrap gap-2">
+            <div className="flex flex-col gap-2 rounded-lg border border-border bg-surface-2 p-3">
+              <div className="flex items-center gap-1.5">
+                <Icon icon="lucide:bookmark" width={13} className="text-muted" />
+                <span className="text-xs font-medium text-ink-2">Saved configs</span>
+                <span className="text-[11px] text-faint">{profile.active_project_label}</span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
                 {projectConfigs.map((cfg) => (
                   <button
                     key={cfg.id}
@@ -177,7 +176,7 @@ export default function DynamoDBConfigModal({
                       loadSavedConfig(cfg.config as DynamoDBTableConfig);
                       toast.success(`Loaded "${cfg.name}"`);
                     }}
-                    className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-200 rounded-full hover:border-blue-400 hover:text-blue-700 hover:bg-blue-50 transition-colors"
+                    className="h-[26px] cursor-pointer rounded-full border border-border bg-surface px-2.5 text-xs font-medium text-ink-2 transition-colors hover:border-primary hover:bg-primary-soft hover:text-primary"
                   >
                     {cfg.name}
                   </button>
@@ -186,185 +185,167 @@ export default function DynamoDBConfigModal({
             </div>
           )}
 
-          {/* Basic Configuration */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Table Name
-              </label>
-              <input
-                type="text"
-                value={tableName}
-                onChange={(e) => setTableName(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Billing Mode
-              </label>
-              <select
-                value={billingMode}
-                onChange={(e) => setBillingMode(e.target.value as "PAY_PER_REQUEST" | "PROVISIONED")}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-              >
-                <option value="PAY_PER_REQUEST">Pay Per Request</option>
-                <option value="PROVISIONED">Provisioned</option>
-              </select>
-            </div>
+          {/* Table name + billing mode */}
+          <div className="grid grid-cols-2 gap-3">
+            <label className="col-span-2 flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink-2">
+                Table name <span className="text-danger">*</span>
+              </span>
+              <Input mono value={tableName} onChange={(e) => setTableName(e.target.value)} required />
+              <span className="text-[11px] text-muted">Lowercase, hyphens, 3–255 chars</span>
+            </label>
           </div>
 
           {/* Primary Key */}
-          <div className="border-t pt-5">
-            <h3 className="text-sm font-semibold text-gray-700 mb-3">Primary Key</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Partition Key (PK)
-                </label>
-                <input
-                  type="text"
-                  value={partitionKey}
-                  onChange={(e) => setPartitionKey(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Sort Key (SK) <span className="text-gray-400 font-normal">(optional)</span>
-                </label>
-                <input
-                  type="text"
-                  value={sortKey}
-                  onChange={(e) => setSortKey(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-                  placeholder="Leave empty for simple primary key"
-                />
-              </div>
-            </div>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink-2">
+                Partition key <span className="text-danger">*</span>
+              </span>
+              <Input mono value={partitionKey} onChange={(e) => setPartitionKey(e.target.value)} required />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink-2">Sort key</span>
+              <Input
+                mono
+                value={sortKey}
+                onChange={(e) => setSortKey(e.target.value)}
+                placeholder="Leave empty for simple primary key"
+              />
+            </label>
+          </div>
+
+          {/* Billing mode */}
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-ink-2">Billing mode</span>
+            <SegmentedControl
+              value={billingMode}
+              onChange={setBillingMode}
+              options={[
+                { value: "PAY_PER_REQUEST", label: "On-demand" },
+                { value: "PROVISIONED", label: "Provisioned" },
+              ]}
+            />
           </div>
 
           {/* Provisioned Capacity */}
           {billingMode === "PROVISIONED" && (
-            <div className="border-t pt-5">
-              <h3 className="text-sm font-semibold text-gray-700 mb-3">Provisioned Capacity</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Read Capacity Units
-                  </label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={readCapacity}
-                    onChange={(e) => setReadCapacity(parseInt(e.target.value))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-                    required
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Write Capacity Units
-                  </label>
-                  <input
-                    type="number"
-                    min="1"
-                    value={writeCapacity}
-                    onChange={(e) => setWriteCapacity(parseInt(e.target.value))}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-                    required
-                  />
-                </div>
-              </div>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-ink-2">Read capacity units</span>
+                <Input
+                  type="number"
+                  min="1"
+                  value={readCapacity}
+                  onChange={(e) => setReadCapacity(parseInt(e.target.value))}
+                  required
+                />
+              </label>
+              <label className="flex flex-col gap-1.5">
+                <span className="text-xs font-medium text-ink-2">Write capacity units</span>
+                <Input
+                  type="number"
+                  min="1"
+                  value={writeCapacity}
+                  onChange={(e) => setWriteCapacity(parseInt(e.target.value))}
+                  required
+                />
+              </label>
             </div>
           )}
 
           {/* Global Secondary Indexes */}
-          <div className="border-t pt-5">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-gray-700">Global Secondary Indexes</h3>
-              <button
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-2 rounded-lg border border-dashed border-border-strong px-3 py-2.5">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-medium text-ink-2">Global secondary indexes</span>
+                <span className="text-[11px] text-muted">
+                  {gsis.length === 0
+                    ? "None yet — add one if you query by another attribute"
+                    : `${gsis.length} configured`}
+                </span>
+              </div>
+              <Button
                 type="button"
+                variant="secondary"
+                size="sm"
+                icon="lucide:plus"
                 onClick={addGSI}
                 disabled={gsis.length >= 5}
-                className="flex items-center px-3 py-1 text-xs font-medium bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                <PlusIcon className="h-3.5 w-3.5 mr-1" />
                 Add GSI ({gsis.length}/5)
-              </button>
+              </Button>
             </div>
 
-            {gsis.length === 0 && (
-              <p className="text-xs text-gray-400 italic">
-                No GSIs configured. Click &quot;Add GSI&quot; to create up to 5 Global Secondary Indexes.
-              </p>
-            )}
-
             {gsis.map((gsi, index) => (
-              <div key={index} className="border border-gray-200 rounded-lg p-4 mb-3">
-                <div className="flex justify-between items-center mb-3">
-                  <h4 className="text-sm font-medium text-gray-900">GSI {index + 1}</h4>
-                  <button
-                    type="button"
+              <div key={index} className="flex flex-col gap-3 rounded-lg border border-border bg-surface-2 p-3.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-semibold text-ink-2">GSI {index + 1}</span>
+                  <IconButton
+                    icon="lucide:trash-2"
+                    variant="ghost"
+                    size="sm"
+                    label="Remove GSI"
+                    className="!text-danger hover:!bg-danger-soft hover:!text-danger"
                     onClick={() => removeGSI(index)}
-                    className="text-red-500 hover:text-red-700"
-                  >
-                    <TrashIcon className="h-4 w-4" />
-                  </button>
+                  />
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Index Name</label>
-                    <input
-                      type="text"
+                <div className="grid grid-cols-2 gap-3">
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium text-muted">Index name</span>
+                    <Input
+                      mono
                       value={gsi.indexName}
                       onChange={(e) => updateGSI(index, "indexName", e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 text-sm"
                       required
                     />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Partition Key</label>
-                    <input
-                      type="text"
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium text-muted">Partition key</span>
+                    <Input
+                      mono
                       value={gsi.partitionKey}
                       onChange={(e) => updateGSI(index, "partitionKey", e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 text-sm"
                       required
                     />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Sort Key <span className="text-gray-400">(optional)</span></label>
-                    <input
-                      type="text"
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium text-muted">Sort key <span className="text-faint">(optional)</span></span>
+                    <Input
+                      mono
                       value={gsi.sortKey || ""}
                       onChange={(e) => updateGSI(index, "sortKey", e.target.value || undefined)}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 text-sm"
                     />
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Projection Type</label>
-                    <select
-                      value={gsi.projectionType}
-                      onChange={(e) => updateGSI(index, "projectionType", e.target.value as "ALL" | "KEYS_ONLY" | "INCLUDE")}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900 text-sm"
-                    >
-                      <option value="ALL">All</option>
-                      <option value="KEYS_ONLY">Keys Only</option>
-                      <option value="INCLUDE">Include</option>
-                    </select>
-                  </div>
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-medium text-muted">Projection type</span>
+                    <div className="relative">
+                      <select
+                        value={gsi.projectionType}
+                        onChange={(e) =>
+                          updateGSI(index, "projectionType", e.target.value as "ALL" | "KEYS_ONLY" | "INCLUDE")
+                        }
+                        className="h-8 w-full cursor-pointer appearance-none rounded-lg border border-border-strong bg-surface pl-2.5 pr-7 text-[13px] text-ink outline-none transition-colors focus:border-primary focus:ring-3 focus:ring-focus"
+                      >
+                        <option value="ALL">All</option>
+                        <option value="KEYS_ONLY">Keys only</option>
+                        <option value="INCLUDE">Include</option>
+                      </select>
+                      <Icon
+                        icon="lucide:chevron-down"
+                        width={13}
+                        className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+                      />
+                    </div>
+                  </label>
                 </div>
               </div>
             ))}
           </div>
 
           {/* Save as config */}
-          <div className="border-t pt-4">
-            <label className="flex items-center space-x-3 cursor-pointer">
+          <div className="flex flex-col gap-2.5 border-t border-divider pt-4">
+            <label className="flex cursor-pointer items-center gap-2.5">
               <input
                 type="checkbox"
                 checked={saveConfig_}
@@ -372,51 +353,49 @@ export default function DynamoDBConfigModal({
                   setSaveConfig_(e.target.checked);
                   if (!e.target.checked) setConfigName("");
                 }}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+                className="h-4 w-4 cursor-pointer rounded border-border-strong text-primary focus:ring-focus"
               />
-              <span className="text-sm text-gray-700">Save as config</span>
+              <span className="text-sm text-ink-2">Save as config for future use</span>
             </label>
             {saveConfig_ && (
-              <div className="mt-3">
-                <input
-                  type="text"
+              <div>
+                <Input
                   value={configName}
                   onChange={(e) => setConfigName(e.target.value)}
                   onBlur={() => setConfigNameTouched(true)}
                   placeholder="e.g. my-app-table"
-                  className={`w-full px-3 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 text-gray-900 ${
-                    configNameError
-                      ? "border-red-400 focus:ring-red-400 focus:border-red-400 bg-red-50"
-                      : "border-gray-300 focus:ring-blue-500 focus:border-blue-500"
-                  }`}
+                  invalid={!!configNameError}
+                  className="w-full"
                   autoFocus
                 />
-                {configNameError && (
-                  <p className="text-xs text-red-600 mt-1">{configNameError}</p>
-                )}
+                {configNameError && <p className="mt-1 text-[11px] text-danger">{configNameError}</p>}
               </div>
             )}
           </div>
+        </form>
 
-          {/* Actions */}
-          <div className="flex justify-end space-x-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-              disabled={loading}
-            >
+        {/* Actions */}
+        <div className="flex items-center gap-2.5 border-t border-divider bg-surface-2 px-4.5 py-3.5">
+          <span className="hidden items-center gap-1.5 text-[11px] text-muted sm:flex">
+            <Icon icon="lucide:terminal" width={13} />
+            Runs <span className="font-mono">awslocal dynamodb create-table</span>
+          </span>
+          <div className="ml-auto flex items-center gap-2.5">
+            <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               type="submit"
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+              form="dynamodb-config-form"
+              variant="primary"
+              icon="lucide:plus"
+              loading={loading}
               disabled={loading || (saveConfig_ && !configName.trim())}
             >
-              {loading ? "Creating..." : "Create Table"}
-            </button>
+              {loading ? "Creating…" : "Create table"}
+            </Button>
           </div>
-        </form>
+        </div>
       </div>
     </div>
   );

--- a/localcloud-gui/src/components/DynamoDBItemDetailPanel.tsx
+++ b/localcloud-gui/src/components/DynamoDBItemDetailPanel.tsx
@@ -1,13 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import {
-  ArrowsPointingOutIcon,
-  CheckIcon,
-  ClipboardDocumentIcon,
-  TrashIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { IconButton } from "./ui";
 
 type DynamoDBItem = Record<string, unknown>;
 
@@ -28,14 +23,23 @@ function formatScalar(value: unknown): string {
   return String(value);
 }
 
+function typeLetter(value: unknown): string {
+  if (value === null || value === undefined) return "S";
+  if (typeof value === "number") return "N";
+  if (typeof value === "boolean") return "BOOL";
+  if (Array.isArray(value)) return "L";
+  if (typeof value === "object") return "M";
+  return "S";
+}
+
 function CopyableField({
   label,
+  type,
   value,
-  emphasize = false,
 }: {
   label: string;
+  type: string;
   value: string;
-  emphasize?: boolean;
 }) {
   const [copied, setCopied] = useState(false);
 
@@ -48,36 +52,25 @@ function CopyableField({
   };
 
   return (
-    <div>
-      <div className="mb-1.5 flex items-center justify-between gap-2">
-        <p className="text-[10px] font-semibold uppercase tracking-wide text-gray-500">{label}</p>
-        {value ? (
+    <div className="grid grid-cols-[100px_1fr] items-start gap-2.5 border-b border-divider px-3.5 py-2.5 last:border-b-0">
+      <span className="flex items-center gap-1.5 text-[11px] text-muted">
+        {label}
+        <span className="text-faint">{type}</span>
+      </span>
+      {value ? (
+        <div className="flex min-w-0 items-start justify-between gap-2">
+          <span className="min-w-0 break-all font-mono text-xs leading-relaxed text-ink">{value}</span>
           <button
             type="button"
             onClick={handleCopy}
-            className="shrink-0 rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+            className="shrink-0 cursor-pointer rounded p-0.5 text-faint transition-colors hover:bg-surface-3 hover:text-ink"
             title={copied ? "Copied" : `Copy ${label}`}
           >
-            {copied ? (
-              <CheckIcon className="h-3.5 w-3.5 text-green-500" />
-            ) : (
-              <ClipboardDocumentIcon className="h-3.5 w-3.5" />
-            )}
+            <Icon icon={copied ? "lucide:check" : "lucide:copy"} width={12} className={copied ? "text-success" : ""} />
           </button>
-        ) : null}
-      </div>
-      {value ? (
-        <div
-          className={`break-all font-mono text-xs leading-relaxed ${
-            emphasize
-              ? "rounded-md border border-blue-200 bg-blue-50 px-2.5 py-2 text-blue-900"
-              : "text-gray-700"
-          }`}
-        >
-          {value}
         </div>
       ) : (
-        <p className="text-xs italic text-gray-400">empty</p>
+        <span className="text-xs italic text-faint">empty</span>
       )}
     </div>
   );
@@ -93,111 +86,107 @@ export default function DynamoDBItemDetailPanel({
   onJsonClick,
   accent = "blue",
 }: DynamoDBItemDetailPanelProps) {
+  void accent;
+
   const keySet = new Set(keyColumnNames);
   const attributeNames = Object.keys(item)
     .filter((name) => !keySet.has(name))
     .sort();
 
-  const headerAccent =
-    accent === "indigo"
-      ? "border-indigo-100 bg-indigo-50 text-indigo-900"
-      : "border-blue-100 bg-blue-50 text-blue-900";
+  const summary = keyColumnNames
+    .map((name) => formatScalar(item[name]))
+    .filter(Boolean)
+    .join(" / ");
 
   return (
-    <aside className="flex w-80 shrink-0 flex-col overflow-hidden rounded-lg border border-gray-200 bg-white">
-      <div className={`flex items-start justify-between gap-2 border-b px-4 py-3 ${headerAccent}`}>
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-wide opacity-70">Item detail</p>
-          <p className="truncate text-sm font-medium">{tableName}</p>
-        </div>
-        {onClose ? (
-          <button
-            type="button"
-            onClick={onClose}
-            className="shrink-0 rounded p-1 text-gray-400 transition-colors hover:bg-white/60 hover:text-gray-600"
-            aria-label="Close item detail"
-          >
-            <XMarkIcon className="h-4 w-4" />
-          </button>
+    <aside className="flex w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-e1">
+      <div className="flex items-center gap-2.5 border-b border-divider px-3.5 py-3">
+        <span className="text-sm font-semibold text-ink">Item</span>
+        {summary ? (
+          <span className="truncate font-mono text-[11px] text-muted">{summary}</span>
         ) : null}
-      </div>
-
-      <div className="flex-1 space-y-4 overflow-y-auto p-4">
-        {keyColumnNames.map((name) => {
-          const keyType = getKeyType?.(name);
-          const label = keyType ? `${name} (${keyType})` : name;
-          return (
-            <CopyableField
-              key={name}
-              label={label}
-              value={formatScalar(item[name])}
-              emphasize
+        <div className="ml-auto flex shrink-0 items-center gap-1">
+          <IconButton
+            icon="lucide:copy"
+            variant="ghost"
+            size="sm"
+            label="Copy item JSON"
+            onClick={() => {
+              void navigator.clipboard.writeText(JSON.stringify(item, null, 2));
+            }}
+          />
+          {onDelete ? (
+            <IconButton
+              icon="lucide:trash-2"
+              variant="ghost"
+              size="sm"
+              label="Delete item"
+              className="!text-danger hover:!bg-danger-soft hover:!text-danger"
+              onClick={onDelete}
             />
-          );
-        })}
-
-        {attributeNames.length > 0 ? (
-          <div className="border-t border-gray-100 pt-4">
-            <p className="mb-3 text-[10px] font-semibold uppercase tracking-wide text-gray-500">
-              Attributes
-            </p>
-            <div className="space-y-4">
-              {attributeNames.map((name) => {
-                const value = item[name];
-                const isComplex = value !== null && typeof value === "object";
-
-                if (isComplex && onJsonClick) {
-                  return (
-                    <div key={name}>
-                      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-gray-500">
-                        {name}
-                      </p>
-                      <button
-                        type="button"
-                        onClick={() => onJsonClick(value, `${name} - ${tableName}`)}
-                        className={`flex max-w-full items-center gap-1.5 rounded border px-2 py-1 text-left font-mono text-xs transition-colors ${
-                          accent === "indigo"
-                            ? "border-indigo-200 bg-indigo-50 text-gray-800 hover:bg-indigo-100"
-                            : "border-blue-200 bg-blue-50 text-gray-800 hover:bg-blue-100"
-                        }`}
-                        title="Click to view full JSON"
-                      >
-                        <ArrowsPointingOutIcon
-                          className={`h-3.5 w-3.5 shrink-0 ${
-                            accent === "indigo" ? "text-indigo-600" : "text-blue-600"
-                          }`}
-                        />
-                        <span className="truncate">{formatScalar(value)}</span>
-                      </button>
-                    </div>
-                  );
-                }
-
-                return (
-                  <CopyableField
-                    key={name}
-                    label={name}
-                    value={formatScalar(value)}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        ) : null}
+          ) : null}
+          {onClose ? (
+            <IconButton icon="lucide:x" variant="ghost" size="sm" label="Close item detail" onClick={onClose} />
+          ) : null}
+        </div>
       </div>
 
-      {onDelete ? (
-        <div className="border-t border-gray-100 p-4">
-          <button
-            type="button"
-            onClick={onDelete}
-            className="flex w-full items-center justify-center gap-1.5 rounded-md border border-red-200 px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-50"
-          >
-            <TrashIcon className="h-4 w-4" />
-            Delete item
-          </button>
+      <div className="flex-1 overflow-y-auto">
+        <div className="flex flex-col">
+          {keyColumnNames.map((name) => {
+            const keyType = getKeyType?.(name);
+            const value = item[name];
+            return (
+              <div
+                key={name}
+                className="grid grid-cols-[100px_1fr] items-start gap-2.5 border-b border-divider px-3.5 py-2.5"
+              >
+                <span className="flex items-center gap-1.5 text-[11px] text-muted" title={keyType}>
+                  {name}
+                  <span className="text-faint">{typeLetter(value)}</span>
+                </span>
+                <span className="break-all font-mono text-xs text-ink">{formatScalar(value)}</span>
+              </div>
+            );
+          })}
+
+          {attributeNames.map((name) => {
+            const value = item[name];
+            const isComplex = value !== null && typeof value === "object";
+
+            if (isComplex && onJsonClick) {
+              return (
+                <div
+                  key={name}
+                  className="grid grid-cols-[100px_1fr] items-center gap-2.5 border-b border-divider px-3.5 py-2.5"
+                >
+                  <span className="flex items-center gap-1.5 text-[11px] text-muted">
+                    {name}
+                    <span className="text-faint">{typeLetter(value)}</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => onJsonClick(value, `${name} - ${tableName}`)}
+                    className="flex max-w-full cursor-pointer items-center gap-1.5 justify-self-start rounded border border-primary bg-primary-soft px-2 py-1 text-left font-mono text-xs text-primary-ink transition-colors hover:bg-primary/10"
+                    title="Click to view full JSON"
+                  >
+                    <Icon icon="lucide:maximize-2" width={12} className="shrink-0 text-primary" />
+                    <span className="truncate">{formatScalar(value)}</span>
+                  </button>
+                </div>
+              );
+            }
+
+            return (
+              <CopyableField key={name} label={name} type={typeLetter(value)} value={formatScalar(value)} />
+            );
+          })}
         </div>
-      ) : null}
+
+        <pre className="m-0 max-h-[220px] overflow-auto border-t border-divider bg-surface-2 px-3.5 py-3 font-mono text-[11px] leading-relaxed text-ink-2">
+          {JSON.stringify(item, null, 2)}
+        </pre>
+      </div>
     </aside>
   );
 }

--- a/localcloud-gui/src/components/DynamoDBViewer.tsx
+++ b/localcloud-gui/src/components/DynamoDBViewer.tsx
@@ -7,15 +7,6 @@ import {
   resourceApi,
 } from "@/services/api";
 import { DynamoDBTableConfig } from "@/types";
-import {
-  ArrowsPointingOutIcon,
-  ChevronDownIcon,
-  MagnifyingGlassIcon,
-  PlusIcon,
-  TrashIcon,
-  XMarkIcon,
-  ArrowTopRightOnSquareIcon,
-} from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useEffect, useState, useCallback } from "react";
 import DynamoDBAddItemModal from "./DynamoDBAddItemModal";
@@ -27,6 +18,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { toast } from "react-hot-toast";
 import ThemeableCodeBlock from "./ThemeableCodeBlock";
 import { parseDynamoDBItem } from "@/lib/dynamodbValue";
+import { Button, IconButton, Input, SegmentedControl } from "./ui";
 
 interface DynamoDBViewerProps {
   isOpen: boolean;
@@ -376,17 +368,17 @@ export default function DynamoDBViewer({
             e.stopPropagation();
             handleJsonClick(value, `${header} - ${selectedTable}`);
           }}
-          className="mx-auto flex max-w-[200px] items-center justify-center gap-1.5 rounded border border-blue-200 bg-blue-50 px-2 py-1 text-left font-mono text-xs text-gray-800 transition-colors hover:bg-blue-100"
+          className="mx-auto flex max-w-[200px] cursor-pointer items-center justify-center gap-1.5 rounded border border-primary bg-primary-soft px-2 py-1 text-left font-mono text-xs text-ink transition-colors hover:bg-primary/10"
           title="Click to view full JSON"
         >
-          <ArrowsPointingOutIcon className="h-3.5 w-3.5 shrink-0 text-blue-600" />
+          <Icon icon="lucide:maximize-2" width={13} className="shrink-0 text-primary" />
           <span className="truncate">{formatValue(value)}</span>
         </button>
       );
     }
 
     return (
-      <span className="mx-auto block max-w-[220px] truncate text-center" title={formatValue(value)}>
+      <span className="mx-auto block max-w-[220px] truncate text-center text-ink-2" title={formatValue(value)}>
         {formatValue(value)}
       </span>
     );
@@ -458,7 +450,7 @@ export default function DynamoDBViewer({
   return (
   <>
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4"
       onMouseDown={handleBackdropMouseDown}
     >
       <motion.div
@@ -466,52 +458,43 @@ export default function DynamoDBViewer({
         animate={{ opacity: 1, y: 0, scale: 1 }}
         exit={{ opacity: 0, y: 8, scale: 0.98 }}
         transition={{ duration: 0.22, ease: [0.4, 0, 0.2, 1] as const }}
-        className="bg-white rounded-xl shadow-2xl w-full max-w-7xl h-[88vh] flex flex-col"
+        className="flex h-[88vh] w-full max-w-7xl flex-col rounded-xl border border-border bg-surface shadow-e3"
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">DynamoDB Tables</h2>
-            <p className="text-xs text-gray-500">View and manage table contents</p>
+        <div className="flex items-center justify-between gap-3 border-b border-divider px-5 py-3.5 shrink-0">
+          <div className="flex items-center gap-2.5">
+            <Icon icon="logos:aws-dynamodb" width={18} />
+            <div>
+              <h2 className="text-[15px] font-semibold text-ink">DynamoDB tables</h2>
+              <p className="text-[11px] text-muted">View and manage table contents</p>
+            </div>
           </div>
-          <div className="flex items-center space-x-2">
-            <button
-              onClick={() => setShowCreateTableModal(true)}
-              className="flex items-center px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-            >
-              <PlusIcon className="h-4 w-4 mr-1.5" />
-              Create Table
-            </button>
+          <div className="flex items-center gap-2">
+            <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setShowCreateTableModal(true)}>
+              Create table
+            </Button>
             <Link
               href="/manage/dynamodb"
-              className="flex items-center space-x-1.5 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 rounded-md transition-colors"
+              className="flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary-soft"
             >
-              <span>Open Manager</span>
-              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+              Open manager
+              <Icon icon="lucide:external-link" width={13} />
             </Link>
-            <button
-              onClick={onClose}
-              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-              aria-label="Close"
-            >
-              <XMarkIcon className="h-5 w-5" />
-            </button>
+            <IconButton icon="lucide:x" variant="ghost" label="Close" onClick={onClose} />
           </div>
         </div>
 
         {/* Content */}
-        <div className="flex-1 flex flex-col p-6 gap-4 min-h-0">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 p-5">
           {/* Table Selection */}
-          <div className="flex items-center gap-3 shrink-0">
-            <label className="text-sm font-medium text-gray-600 whitespace-nowrap">
-              Select Table
-            </label>
+          <div className="flex shrink-0 items-center gap-2.5">
+            <label className="whitespace-nowrap text-xs font-medium text-ink-2">Table</label>
             <div className="relative">
               <select
                 value={selectedTable}
                 onChange={(e) => setSelectedTable(e.target.value)}
-                className="appearance-none pl-3 pr-8 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900 bg-white cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                 disabled={loading}
+                className="h-8 min-w-[200px] cursor-pointer appearance-none rounded-lg border border-border-strong bg-surface pl-2.5 pr-8 font-mono text-[13px] text-ink outline-none transition-colors focus:border-primary focus:ring-3 focus:ring-focus disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <option value="">Choose a table…</option>
                 {tables.map((table) => (
@@ -520,15 +503,20 @@ export default function DynamoDBViewer({
                   </option>
                 ))}
               </select>
-              <ChevronDownIcon className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400" />
+              <Icon
+                icon="lucide:chevron-down"
+                width={14}
+                className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-faint"
+              />
             </div>
-            <button
+            <IconButton
+              icon="lucide:refresh-cw"
+              variant="outline"
+              label="Refresh"
               onClick={refreshData}
               disabled={loading}
-              className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors disabled:opacity-50"
-            >
-              Refresh
-            </button>
+              className={loading ? "[&_svg]:animate-spin" : ""}
+            />
           </div>
 
           {/* Below-selector area — switches between initial loading / empty / table content */}
@@ -542,23 +530,23 @@ export default function DynamoDBViewer({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{ duration: 0.15 }}
-              className="flex-1 min-h-0 overflow-hidden border border-gray-200 rounded-lg animate-pulse"
+              className="min-h-0 flex-1 animate-pulse overflow-hidden rounded-xl border border-border"
             >
               {/* Fake table header */}
-              <div className="flex bg-gray-50 border-b border-gray-200 px-3 py-2 gap-6">
+              <div className="flex gap-6 border-b border-divider bg-surface-2 px-3 py-2">
                 {[40, 28, 20, 12].map((w, i) => (
-                  <div key={i} className={`h-3 bg-gray-200 rounded`} style={{ width: `${w}%` }} />
+                  <div key={i} className="h-3 rounded bg-skeleton" style={{ width: `${w}%` }} />
                 ))}
               </div>
               {/* Fake rows */}
               {Array.from({ length: 8 }).map((_, i) => (
                 <div
                   key={i}
-                  className="flex items-center border-b border-gray-100 px-3 py-3 gap-6"
+                  className="flex items-center gap-6 border-b border-divider px-3 py-3"
                   style={{ opacity: 1 - i * 0.09 }}
                 >
                   {[40, 28, 20, 12].map((w, j) => (
-                    <div key={j} className="h-3 bg-gray-100 rounded" style={{ width: `${w}%` }} />
+                    <div key={j} className="h-3 rounded bg-skeleton" style={{ width: `${w}%` }} />
                   ))}
                 </div>
               ))}
@@ -572,18 +560,14 @@ export default function DynamoDBViewer({
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -4 }}
               transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] as const }}
-              className="flex-1 flex flex-col items-center justify-center text-center"
+              className="flex flex-1 flex-col items-center justify-center text-center"
             >
-              <Icon icon="logos:aws-dynamodb" className="w-20 h-20 mb-4 opacity-20" />
-              <p className="text-sm font-medium text-gray-700 mb-1">No DynamoDB tables found</p>
-              <p className="text-xs text-gray-400 mb-5">Create your first table to start storing data.</p>
-              <button
-                onClick={() => setShowCreateTableModal(true)}
-                className="flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors shadow-sm"
-              >
-                <PlusIcon className="h-4 w-4 mr-1.5" />
-                Create Table
-              </button>
+              <Icon icon="logos:aws-dynamodb" className="mb-4 h-20 w-20 opacity-20" />
+              <p className="mb-1 text-sm font-medium text-ink-2">No DynamoDB tables found</p>
+              <p className="mb-5 text-xs text-faint">Create your first table to start storing data.</p>
+              <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setShowCreateTableModal(true)}>
+                Create table
+              </Button>
             </motion.div>
 
           ) : tables.length > 0 && (
@@ -593,184 +577,106 @@ export default function DynamoDBViewer({
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            className="flex-1 flex flex-col gap-4 min-h-0"
+            className="flex min-h-0 flex-1 flex-col gap-4"
           >
 
           {selectedTable && (
             <>
               {/* Query Controls */}
-              <div className="bg-gray-50 rounded-lg px-4 py-3 shrink-0">
-                <div className="flex items-center space-x-4 mb-3">
-                  <div className="flex items-center space-x-2">
-                    <input
-                      type="radio"
-                      id="scan"
-                      name="queryMode"
-                      value="scan"
-                      checked={queryMode === "scan"}
-                      onChange={(e) =>
-                        setQueryMode(e.target.value as "scan" | "query")
-                      }
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
+              <div className="flex shrink-0 flex-col gap-3 rounded-xl border border-border bg-surface p-3.5 shadow-e1">
+                <div className="flex flex-wrap items-end gap-3">
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-medium text-ink-2">Read mode</span>
+                    <SegmentedControl
+                      value={queryMode}
+                      onChange={setQueryMode}
+                      options={[
+                        { value: "scan", label: "Scan" },
+                        { value: "query", label: "Query" },
+                      ]}
                     />
-                    <label
-                      htmlFor="scan"
-                      className="text-sm font-medium text-gray-700"
-                    >
-                      Scan
-                    </label>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <input
-                      type="radio"
-                      id="query"
-                      name="queryMode"
-                      value="query"
-                      checked={queryMode === "query"}
-                      onChange={(e) =>
-                        setQueryMode(e.target.value as "scan" | "query")
-                      }
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300"
-                    />
-                    <label
-                      htmlFor="query"
-                      className="text-sm font-medium text-gray-700"
-                    >
-                      Query
-                    </label>
-                  </div>
-                </div>
 
-                {queryMode === "query" && (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Partition Key
+                  {queryMode === "query" && (
+                    <>
+                      <label className="flex min-w-[110px] flex-1 flex-col gap-1.5">
+                        <span className="text-xs font-medium text-ink-2">Partition key</span>
+                        <Input
+                          mono
+                          value={queryParams.partitionKey}
+                          onChange={(e) => setQueryParams({ ...queryParams, partitionKey: e.target.value })}
+                          placeholder="pk"
+                        />
                       </label>
-                      <input
-                        type="text"
-                        value={queryParams.partitionKey}
-                        onChange={(e) =>
-                          setQueryParams({
-                            ...queryParams,
-                            partitionKey: e.target.value,
-                          })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                        placeholder="pk"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Partition Value
+                      <label className="flex min-w-[130px] flex-1 flex-col gap-1.5">
+                        <span className="text-xs font-medium text-ink-2">Value</span>
+                        <Input
+                          mono
+                          value={queryParams.partitionValue}
+                          onChange={(e) => setQueryParams({ ...queryParams, partitionValue: e.target.value })}
+                          placeholder="value"
+                        />
                       </label>
-                      <input
-                        type="text"
-                        value={queryParams.partitionValue}
-                        onChange={(e) =>
-                          setQueryParams({
-                            ...queryParams,
-                            partitionValue: e.target.value,
-                          })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                        placeholder="value"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Sort Key (optional)
+                      <label className="flex min-w-[100px] flex-1 flex-col gap-1.5">
+                        <span className="text-xs font-medium text-ink-2">Sort key</span>
+                        <Input
+                          mono
+                          value={queryParams.sortKey}
+                          onChange={(e) => setQueryParams({ ...queryParams, sortKey: e.target.value })}
+                          placeholder="sk"
+                        />
                       </label>
-                      <input
-                        type="text"
-                        value={queryParams.sortKey}
-                        onChange={(e) =>
-                          setQueryParams({
-                            ...queryParams,
-                            sortKey: e.target.value,
-                          })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                        placeholder="sk"
-                      />
-                    </div>
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        Sort Value (optional)
+                      <label className="flex min-w-[100px] flex-1 flex-col gap-1.5">
+                        <span className="text-xs font-medium text-ink-2">Sort value</span>
+                        <Input
+                          mono
+                          value={queryParams.sortValue}
+                          onChange={(e) => setQueryParams({ ...queryParams, sortValue: e.target.value })}
+                          placeholder="value"
+                        />
                       </label>
-                      <input
-                        type="text"
-                        value={queryParams.sortValue}
-                        onChange={(e) =>
-                          setQueryParams({
-                            ...queryParams,
-                            sortValue: e.target.value,
-                          })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                        placeholder="value"
-                      />
-                    </div>
-                  </div>
-                )}
+                    </>
+                  )}
 
-                <div className="flex items-center space-x-4 mt-3">
-                  <div className="flex items-center space-x-2">
-                    <label className="text-sm font-medium text-gray-700">
-                      Limit:
-                    </label>
-                    <input
+                  <label className="flex w-[84px] flex-col gap-1.5">
+                    <span className="text-xs font-medium text-ink-2">Limit</span>
+                    <Input
+                      mono
                       type="number"
-                      value={queryParams.limit}
-                      onChange={(e) =>
-                        setQueryParams({
-                          ...queryParams,
-                          limit: e.target.value,
-                        })
-                      }
-                      className="w-20 px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
                       min="1"
                       max="1000"
+                      value={queryParams.limit}
+                      onChange={(e) => setQueryParams({ ...queryParams, limit: e.target.value })}
                     />
-                  </div>
-                  <button
-                    onClick={
-                      queryMode === "scan" ? loadTableContents : executeQuery
-                    }
-                    disabled={loading}
-                    className="flex items-center px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+                  </label>
+
+                  <Button
+                    variant="primary"
+                    icon="lucide:play"
+                    loading={loading}
+                    onClick={queryMode === "scan" ? loadTableContents : executeQuery}
                   >
-                    <MagnifyingGlassIcon className="h-4 w-4 mr-1.5" />
-                    {loading
-                      ? "Loading…"
-                      : queryMode === "scan"
-                      ? "Scan Table"
-                      : "Execute Query"}
-                  </button>
+                    {loading ? "Loading…" : queryMode === "scan" ? "Scan table" : "Execute query"}
+                  </Button>
                 </div>
+
+                {scanResult && (
+                  <div className="flex items-center gap-2 border-t border-divider pt-2.5 text-[11px] text-muted">
+                    <span>
+                      Showing <strong className="text-ink-2">{items.length} items</strong> · scanned{" "}
+                      {scanResult.scannedCount}
+                    </span>
+                    <span className="ml-auto font-mono">{selectedTable}</span>
+                  </div>
+                )}
               </div>
 
-              {/* Results Info */}
-              {scanResult && (
-                <div className="flex items-center justify-between text-sm text-gray-600 shrink-0">
-                  <span>
-                    Showing {items.length} items (scanned:{" "}
-                    {scanResult.scannedCount})
-                  </span>
-                  <span>Table: {selectedTable}</span>
-                </div>
-              )}
-
               {/* Add Item Button */}
-              <div className="flex justify-between items-center shrink-0">
-                <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">Items</h3>
-                <button
-                  onClick={() => setAddModalOpen(true)}
-                  className="flex items-center px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
-                >
-                  <PlusIcon className="h-4 w-4 mr-1.5" />
-                  Add Item
-                </button>
+              <div className="flex shrink-0 items-center justify-between">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-faint">Items</h3>
+                <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setAddModalOpen(true)}>
+                  Add item
+                </Button>
               </div>
 
               {/* Items Table + Detail Panel */}
@@ -783,106 +689,98 @@ export default function DynamoDBViewer({
                 transition={{ duration: 0.18 }}
                 className="flex min-h-0 flex-1 gap-4"
               >
-                <div className="min-h-0 min-w-0 flex-1 overflow-auto rounded-lg border border-gray-200 pb-4">
+                <div className="min-h-0 min-w-0 flex-1 overflow-auto rounded-xl border border-border bg-surface shadow-e1">
                 {loading ? (
                   /* Skeleton rows that match the real table layout */
                   <div className="animate-pulse">
-                    <div className="flex bg-gray-50 border-b border-gray-200 px-3 py-2 gap-4">
+                    <div className="flex gap-4 border-b border-divider bg-surface-2 px-3 py-2">
                       {[35, 25, 20, 15].map((w, i) => (
-                        <div key={i} className="h-3 bg-gray-200 rounded" style={{ width: `${w}%` }} />
+                        <div key={i} className="h-3 rounded bg-skeleton" style={{ width: `${w}%` }} />
                       ))}
-                      <div className="h-3 w-10 bg-gray-100 rounded ml-auto" />
+                      <div className="ml-auto h-3 w-10 rounded bg-skeleton" />
                     </div>
                     {Array.from({ length: 6 }).map((_, i) => (
-                      <div key={i} className="flex items-center border-b border-gray-100 px-3 py-3 gap-4" style={{ opacity: 1 - i * 0.12 }}>
+                      <div key={i} className="flex items-center gap-4 border-b border-divider px-3 py-3" style={{ opacity: 1 - i * 0.12 }}>
                         {[35, 25, 20, 15].map((w, j) => (
-                          <div key={j} className="h-3 bg-gray-100 rounded" style={{ width: `${w}%` }} />
+                          <div key={j} className="h-3 rounded bg-skeleton" style={{ width: `${w}%` }} />
                         ))}
-                        <div className="h-5 w-5 bg-gray-100 rounded ml-auto" />
+                        <div className="ml-auto h-5 w-5 rounded bg-skeleton" />
                       </div>
                     ))}
                   </div>
                 ) : items.length === 0 ? (
-                  <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
-                    <Icon icon="logos:aws-dynamodb" className="w-20 h-20 mb-4 opacity-20" />
-                    <p className="text-sm font-medium text-gray-700 mb-1">No items found</p>
-                    <p className="text-xs text-gray-400 mb-5">Add your first item to this table.</p>
-                    <button
-                      onClick={() => setAddModalOpen(true)}
-                      className="flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors shadow-sm"
-                    >
-                      <PlusIcon className="h-4 w-4 mr-1.5" />
-                      Add Item
-                    </button>
+                  <div className="flex flex-col items-center justify-center px-6 py-16 text-center">
+                    <Icon icon="logos:aws-dynamodb" className="mb-4 h-20 w-20 opacity-20" />
+                    <p className="mb-1 text-sm font-medium text-ink-2">No items found</p>
+                    <p className="mb-5 text-xs text-faint">Add your first item to this table.</p>
+                    <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setAddModalOpen(true)}>
+                      Add item
+                    </Button>
                   </div>
                 ) : (
-                  <>
-                    <table className="w-full divide-y divide-gray-200 table-auto">
-                      <thead className="bg-gray-50 sticky top-0 z-1">
-                        <tr>
-                          {getTableHeaders().map((header, hi) => (
-                            <th
-                              key={`${selectedTable}-header-${header}-${hi}`}
-                              className={`px-3 py-2 text-xs font-medium uppercase tracking-wider whitespace-nowrap ${
-                                isKeyColumn(header)
-                                  ? "min-w-[200px] bg-blue-100 text-left text-blue-800 border-r border-blue-200"
-                                  : "text-center text-gray-500"
-                              }`}
-                            >
-                              <span>{header}</span>
-                              {isKeyColumn(header) && (
-                                <span className="ml-1.5 text-xs font-normal text-blue-500 normal-case">
-                                  ({getKeyType(header)})
-                                </span>
-                              )}
-                            </th>
-                          ))}
-                          <th className="px-3 py-2 text-center text-xs font-medium uppercase tracking-wider text-gray-500 w-14">
-                            Actions
-                          </th>
-                        </tr>
-                      </thead>
-                      <tbody className="bg-white divide-y divide-gray-200">
-                        {items.map((item, index) => (
-                          <tr
-                            key={`${selectedTable}-row-${index}`}
-                            onClick={() => setSelectedItemIndex(index)}
-                            className={`cursor-pointer transition-colors hover:bg-gray-50 ${
-                              selectedItemIndex === index
-                                ? "bg-blue-50 ring-2 ring-inset ring-blue-400"
-                                : ""
+                  <table className="w-full table-auto border-collapse">
+                    <thead className="sticky top-0 z-1 bg-surface-2">
+                      <tr>
+                        {getTableHeaders().map((header, hi) => (
+                          <th
+                            key={`${selectedTable}-header-${header}-${hi}`}
+                            className={`whitespace-nowrap border-b border-divider px-3 py-2 text-[10px] font-semibold uppercase tracking-wide ${
+                              isKeyColumn(header)
+                                ? "min-w-[200px] bg-primary-soft text-left text-primary-ink"
+                                : "text-center text-faint"
                             }`}
                           >
-                            {getTableHeaders().map((header, hj) => (
-                              <td
-                                key={`${header}-${hj}`}
-                                className={`px-3 py-2 text-sm ${
-                                  isKeyColumn(header)
-                                    ? "min-w-[200px] max-w-[240px] align-top bg-blue-50 text-left text-blue-900 border-r border-blue-200 font-medium"
-                                    : "text-center align-middle text-gray-900"
-                                }`}
-                              >
-                                {renderCellValue(header, item[header])}
-                              </td>
-                            ))}
-                            <td className="px-3 py-2 text-center">
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleDeleteClick(item);
-                                }}
-                                className="text-red-600 hover:text-red-800 transition-colors"
-                                title="Delete item"
-                              >
-                                <TrashIcon className="h-4 w-4" />
-                              </button>
-                            </td>
-                          </tr>
+                            <span>{header}</span>
+                            {isKeyColumn(header) && (
+                              <span className="ml-1.5 text-[10px] font-normal normal-case text-primary">
+                                ({getKeyType(header)})
+                              </span>
+                            )}
+                          </th>
                         ))}
-                      </tbody>
-                    </table>
-                  </>
+                        <th className="px-3 py-2 text-center text-[10px] font-semibold uppercase tracking-wide text-faint w-14">
+                          Actions
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {items.map((item, index) => (
+                        <tr
+                          key={`${selectedTable}-row-${index}`}
+                          onClick={() => setSelectedItemIndex(index)}
+                          className={`cursor-pointer border-b border-divider transition-colors last:border-b-0 hover:bg-surface-2 ${
+                            selectedItemIndex === index ? "bg-primary-soft" : ""
+                          }`}
+                        >
+                          {getTableHeaders().map((header, hj) => (
+                            <td
+                              key={`${header}-${hj}`}
+                              className={`px-3 py-2 text-sm ${
+                                isKeyColumn(header)
+                                  ? "min-w-[200px] max-w-[240px] bg-primary-soft/60 text-left align-top font-medium"
+                                  : "text-center align-middle"
+                              }`}
+                            >
+                              {renderCellValue(header, item[header])}
+                            </td>
+                          ))}
+                          <td className="px-3 py-2 text-center">
+                            <IconButton
+                              icon="lucide:trash-2"
+                              variant="ghost"
+                              size="sm"
+                              label="Delete item"
+                              className="!text-danger hover:!bg-danger-soft hover:!text-danger"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDeleteClick(item);
+                              }}
+                            />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
                 )}
                 </div>
 
@@ -895,7 +793,6 @@ export default function DynamoDBViewer({
                     onDelete={() => handleDeleteClick(selectedItem)}
                     onClose={() => setSelectedItemIndex(null)}
                     onJsonClick={handleJsonClick}
-                    accent="blue"
                   />
                 ) : null}
               </motion.div>
@@ -920,51 +817,35 @@ export default function DynamoDBViewer({
 
     {/* Delete Confirmation Modal */}
     {deleteModalOpen && (
-      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-        <div className="bg-white rounded-xl shadow-2xl w-full max-w-md">
+      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-scrim p-4">
+        <div className="w-full max-w-md rounded-xl border border-border bg-surface shadow-e3">
           {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <div className="flex items-center justify-between border-b border-divider px-5 py-4">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Delete Item</h2>
-              <p className="text-xs text-gray-500">This action cannot be undone</p>
+              <h2 className="text-[15px] font-semibold text-ink">Delete item</h2>
+              <p className="text-[11px] text-muted">This action cannot be undone</p>
             </div>
-            <button
-              onClick={() => setDeleteModalOpen(false)}
-              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-              aria-label="Close"
-            >
-              <XMarkIcon className="h-5 w-5" />
-            </button>
+            <IconButton icon="lucide:x" variant="ghost" label="Close" onClick={() => setDeleteModalOpen(false)} />
           </div>
 
           {/* Content */}
-          <div className="p-6">
-            <div className="text-sm text-gray-700 mb-4">
-              <p>The item will be permanently deleted from the table.</p>
-            </div>
+          <div className="p-5">
+            <p className="mb-4 text-sm text-ink-2">The item will be permanently deleted from the table.</p>
 
             {error && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+              <div className="mb-4 rounded-lg border border-danger bg-danger-soft px-3 py-2.5 text-sm text-danger-ink">
                 {error}
               </div>
             )}
 
             {/* Actions */}
-            <div className="flex justify-end space-x-3">
-              <button
-                onClick={() => setDeleteModalOpen(false)}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-                disabled={deleteLoading}
-              >
+            <div className="flex justify-end gap-2.5">
+              <Button variant="secondary" onClick={() => setDeleteModalOpen(false)} disabled={deleteLoading}>
                 Cancel
-              </button>
-              <button
-                onClick={handleDeleteConfirm}
-                disabled={deleteLoading}
-                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
-              >
-                {deleteLoading ? "Deleting..." : "Delete"}
-              </button>
+              </Button>
+              <Button variant="danger" icon="lucide:trash-2" loading={deleteLoading} onClick={handleDeleteConfirm}>
+                {deleteLoading ? "Deleting…" : "Delete"}
+              </Button>
             </div>
           </div>
         </div>
@@ -973,25 +854,19 @@ export default function DynamoDBViewer({
 
     {/* JSON Viewer Modal */}
     {jsonViewerOpen && (
-      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 p-4">
-        <div className="bg-white rounded-xl shadow-2xl w-full max-w-3xl max-h-[80vh] flex flex-col">
+      <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-scrim p-4">
+        <div className="flex max-h-[80vh] w-full max-w-3xl flex-col rounded-xl border border-border bg-surface shadow-e3">
           {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
+          <div className="flex items-center justify-between border-b border-divider px-5 py-4 shrink-0">
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">JSON Viewer</h2>
-              <p className="text-xs text-gray-500">{selectedJsonTitle}</p>
+              <h2 className="text-[15px] font-semibold text-ink">JSON viewer</h2>
+              <p className="text-[11px] text-muted">{selectedJsonTitle}</p>
             </div>
-            <button
-              onClick={() => setJsonViewerOpen(false)}
-              className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-              aria-label="Close"
-            >
-              <XMarkIcon className="h-5 w-5" />
-            </button>
+            <IconButton icon="lucide:x" variant="ghost" label="Close" onClick={() => setJsonViewerOpen(false)} />
           </div>
 
           {/* JSON Content */}
-          <div className="flex-1 p-6 overflow-auto">
+          <div className="flex-1 overflow-auto p-5">
             <ThemeableCodeBlock
               code={JSON.stringify(selectedJsonData, null, 2)}
               language="javascript"

--- a/localcloud-gui/src/components/FileViewerModal.tsx
+++ b/localcloud-gui/src/components/FileViewerModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { XMarkIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import hljs from "highlight.js";
 import { highlightThemes, HighlightTheme } from "./highlightThemes";
 import { marked } from "marked";
 import Papa from "papaparse";
+import { Button, IconButton } from "@/components/ui";
 
 // Register highlight.js languages
 import javascript from "highlight.js/lib/languages/javascript";
@@ -150,11 +151,11 @@ function Tooltip({
       </div>
       {isVisible && (
         <div
-          className="absolute z-50 px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg left-0 bottom-full mb-2 max-w-xs w-max"
+          className="absolute z-50 px-3 py-2 text-sm text-white bg-ink rounded-lg shadow-e2 left-0 bottom-full mb-2 max-w-xs w-max"
           style={{ maxWidth: "300px", wordBreak: "break-all" }}
         >
           <div className="break-all whitespace-normal">{content}</div>
-          <div className="absolute top-full left-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900"></div>
+          <div className="absolute top-full left-4 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-ink"></div>
         </div>
       )}
     </div>
@@ -380,14 +381,15 @@ export default function FileViewerModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-6xl h-5/6 flex flex-col">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4">
+      <div className="bg-surface border border-border rounded-xl shadow-e3 w-full max-w-6xl h-5/6 flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+        <div className="flex items-center justify-between p-6 border-b border-divider shrink-0">
           <div className="flex-1 min-w-0">
-            <div className="mb-2">
-              <Tooltip content={objectKey} className="cursor-help">
-                <h2 className="text-xl font-bold text-gray-900 truncate">
+            <div className="mb-1.5 flex items-center gap-2">
+              <Icon icon="lucide:file" width={17} className="shrink-0 text-muted" />
+              <Tooltip content={objectKey} className="cursor-help min-w-0">
+                <h2 className="text-lg font-semibold text-ink font-mono truncate">
                   {objectKey.split("/").pop() || objectKey}
                 </h2>
               </Tooltip>
@@ -398,9 +400,8 @@ export default function FileViewerModal({
                   content={`Full path: ${objectKey}`}
                   className="cursor-help"
                 >
-                  <div className="text-sm text-gray-600">
+                  <div className="text-xs text-muted font-mono">
                     <div className="truncate">
-                      Path:{" "}
                       {objectKey.length > 75
                         ? `${objectKey.substring(0, 75)}...`
                         : objectKey}
@@ -409,36 +410,46 @@ export default function FileViewerModal({
                 </Tooltip>
               </div>
             )}
-            <div className="mt-1 text-sm text-gray-500">
-              <div>Bucket: {bucketName}</div>
-              {fileContent?.metadata.ContentLength && (
-                <div>
-                  Size: {formatFileSize(fileContent.metadata.ContentLength)}
-                </div>
+            <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-xs text-muted">
+              <span>
+                Bucket: <span className="font-mono text-ink-2">{bucketName}</span>
+              </span>
+              {fileContent?.metadata.ContentLength !== undefined && (
+                <span>
+                  Size:{" "}
+                  <span className="font-mono text-ink-2">
+                    {formatFileSize(fileContent.metadata.ContentLength)}
+                  </span>
+                </span>
               )}
               {fileContent?.metadata.LastModified && (
-                <div>
-                  Modified: {formatDate(fileContent.metadata.LastModified)}
-                </div>
+                <span>
+                  Modified:{" "}
+                  <span className="font-mono text-ink-2">
+                    {formatDate(fileContent.metadata.LastModified)}
+                  </span>
+                </span>
               )}
               {fileContent?.metadata.ContentType && (
-                <div>Type: {fileContent.metadata.ContentType}</div>
+                <span>
+                  Type: <span className="font-mono text-ink-2">{fileContent.metadata.ContentType}</span>
+                </span>
               )}
             </div>
           </div>
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center gap-2.5 shrink-0">
             {/* Theme Selector (only for code/json/markdown) */}
             {showThemeSelector && (
               <>
                 <label
-                  className="text-xs font-semibold text-gray-700 mr-2"
+                  className="text-xs font-medium text-ink-2"
                   htmlFor="hljs-theme-select-modal"
                 >
-                  Theme:
+                  Theme
                 </label>
                 <select
                   id="hljs-theme-select-modal"
-                  className="border-2 border-gray-500 bg-white text-gray-900 font-semibold rounded px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="h-8 px-2.5 rounded-lg border border-border-strong bg-surface-2 text-[13px] text-ink outline-none transition-colors focus:bg-surface focus:border-primary focus:ring-3 focus:ring-focus"
                   value={selectedTheme}
                   onChange={(e) =>
                     setSelectedTheme(e.target.value as HighlightTheme)
@@ -456,21 +467,14 @@ export default function FileViewerModal({
               </>
             )}
             {fileContent && (
-              <button
+              <IconButton
+                icon="lucide:download"
+                label="Download file"
+                variant="outline"
                 onClick={handleDownload}
-                className="p-2 text-gray-400 hover:text-gray-600"
-                title="Download file"
-              >
-                <ArrowDownTrayIcon className="h-5 w-5" />
-              </button>
+              />
             )}
-            <button
-              onClick={onClose}
-              className="text-gray-400 hover:text-gray-600"
-              aria-label="Close"
-            >
-              <XMarkIcon className="h-6 w-6" />
-            </button>
+            <IconButton icon="lucide:x" label="Close" variant="ghost" onClick={onClose} />
           </div>
         </div>
 
@@ -478,18 +482,15 @@ export default function FileViewerModal({
         <div className="flex-1 overflow-hidden">
           {loading ? (
             <div className="flex items-center justify-center h-full">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+              <Icon icon="lucide:loader-2" width={28} className="animate-spin text-primary" />
             </div>
           ) : error ? (
             <div className="flex items-center justify-center h-full">
               <div className="text-center">
-                <p className="text-red-600 mb-4">{error}</p>
-                <button
-                  onClick={loadFileContent}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-                >
+                <p className="text-danger mb-4">{error}</p>
+                <Button variant="primary" onClick={loadFileContent}>
                   Retry
-                </button>
+                </Button>
               </div>
             </div>
           ) : fileContent ? (
@@ -497,11 +498,7 @@ export default function FileViewerModal({
               <div className="p-6">
                 {viewerType === "plain" && (
                   <pre
-                    className="bg-gray-100 text-gray-900 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow"
-                    style={{
-                      fontFamily:
-                        'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-                    }}
+                    className="bg-surface-2 border border-border text-ink-2 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow-e1"
                   >
                     {fileContent.content}
                   </pre>
@@ -512,18 +509,14 @@ export default function FileViewerModal({
                   <div
                     className={
                       isDarkTheme
-                        ? "bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow"
-                        : "bg-gray-100 text-gray-900 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow"
+                        ? "bg-gray-900 text-gray-100 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow-e1"
+                        : "bg-surface-2 border border-border text-ink-2 p-4 rounded-lg overflow-x-auto text-sm leading-relaxed font-mono shadow-e1"
                     }
-                    style={{
-                      fontFamily:
-                        'ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace',
-                    }}
                   >
                     {viewerType === "json" ? (
                       <>
                         {jsonParseError && (
-                          <div className="mb-2 text-red-600 text-sm font-semibold">
+                          <div className="mb-2 text-danger text-sm font-semibold">
                             JSON Parse Error: {jsonParseError}
                           </div>
                         )}
@@ -561,10 +554,10 @@ export default function FileViewerModal({
                     <img
                       src={binaryPreviewUrl}
                       alt={objectKey}
-                      className="max-h-[60vh] max-w-full rounded object-contain mx-auto shadow"
+                      className="max-h-[60vh] max-w-full rounded object-contain mx-auto shadow-e1"
                     />
                   ) : (
-                    <p className="text-center text-sm text-gray-600">
+                    <p className="text-center text-sm text-muted">
                       Could not decode this image for preview. Use Download to open the file locally.
                     </p>
                   ))}
@@ -573,10 +566,10 @@ export default function FileViewerModal({
                     <iframe
                       src={binaryPreviewUrl}
                       title={objectKey}
-                      className="w-full h-[60vh] border rounded"
+                      className="w-full h-[60vh] border border-border rounded"
                     />
                   ) : (
-                    <p className="text-center text-sm text-gray-600">
+                    <p className="text-center text-sm text-muted">
                       Could not decode this PDF for preview. Use Download to open the file locally.
                     </p>
                   ))}
@@ -589,16 +582,16 @@ export default function FileViewerModal({
                   />
                 )}
                 {viewerType === "csv" && (
-                  <div className="overflow-x-auto">
-                    <table className="min-w-full text-xs border border-gray-400">
+                  <div className="overflow-x-auto rounded-lg border border-border">
+                    <table className="min-w-full text-xs">
                       <tbody>
                         {Papa.parse<string[]>(fileContent.content.trim()).data.map(
                           (row, i) => (
-                            <tr key={i}>
+                            <tr key={i} className="even:bg-surface-2">
                               {row.map((cell, j) => (
                                 <td
                                   key={j}
-                                  className="border border-gray-400 px-2 py-1 whitespace-nowrap text-gray-800 font-medium"
+                                  className="border border-divider px-2 py-1 whitespace-nowrap text-ink-2 font-mono"
                                 >
                                   {cell}
                                 </td>
@@ -611,16 +604,16 @@ export default function FileViewerModal({
                   </div>
                 )}
                 {viewerType === "document" && (
-                  <div className="bg-white text-gray-900 p-6 rounded-lg shadow border">
+                  <div className="bg-surface text-ink p-6 rounded-lg shadow-e1 border border-border">
                     <div className="prose max-w-none">
-                      <h1 className="text-2xl font-bold text-gray-900 mb-4">
+                      <h1 className="text-2xl font-bold text-ink mb-4">
                         {objectKey
                           .split("/")
                           .pop()
                           ?.replace(/\.(doc|docx)$/i, "") || "Document"}
                       </h1>
                       <div
-                        className="text-gray-800 leading-relaxed"
+                        className="text-ink-2 leading-relaxed"
                         style={{
                           fontFamily: 'Georgia, "Times New Roman", serif',
                           lineHeight: "1.6",
@@ -642,7 +635,7 @@ export default function FileViewerModal({
                             return (
                               <h3
                                 key={index}
-                                className="text-lg font-semibold text-gray-900 mt-4 mb-2"
+                                className="text-lg font-semibold text-ink mt-4 mb-2"
                               >
                                 {line}
                               </h3>
@@ -666,23 +659,20 @@ export default function FileViewerModal({
                   </div>
                 )}
                 {viewerType === "binary" && (
-                  <div className="text-center text-gray-500">
+                  <div className="text-center text-muted">
                     <p>
                       This file type cannot be previewed. Please download to
                       view.
                     </p>
-                    <button
-                      onClick={handleDownload}
-                      className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
-                    >
+                    <Button variant="primary" className="mt-4" icon="lucide:download" onClick={handleDownload}>
                       Download
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>
             </div>
           ) : (
-            <div className="flex items-center justify-center h-full text-gray-500">
+            <div className="flex items-center justify-center h-full text-muted">
               <p>No content available</p>
             </div>
           )}

--- a/localcloud-gui/src/components/ManageHeaderBrand.tsx
+++ b/localcloud-gui/src/components/ManageHeaderBrand.tsx
@@ -1,17 +1,27 @@
 import Image from "next/image";
 
+const SIZE_CLASSES = {
+  sm: "h-7",
+  md: "h-9",
+} as const;
+
+interface ManageHeaderBrandProps {
+  /** Logo height — "sm" (28px) for compact bars like the dashboard nav, "md" (36px, default) for manage pages. */
+  size?: keyof typeof SIZE_CLASSES;
+}
+
 /**
  * Brand mark for manage / secondary pages — same asset as the dashboard (`/logo.svg`).
  * `unoptimized` keeps SVG rendering reliable across Next/Image + CSP setups.
  */
-export default function ManageHeaderBrand() {
+export default function ManageHeaderBrand({ size = "md" }: ManageHeaderBrandProps) {
   return (
     <Image
       src="/logo.svg"
       alt="LocalCloud Kit"
       width={90}
       height={36}
-      className="h-9 w-auto shrink-0 object-contain object-left"
+      className={`${SIZE_CLASSES[size]} w-auto shrink-0 object-contain object-left`}
       priority
       unoptimized
     />

--- a/localcloud-gui/src/components/RedisModal.tsx
+++ b/localcloud-gui/src/components/RedisModal.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { cacheApi } from "@/services/api";
-import {
-  ArrowRightIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
+import { Badge, IconButton } from "@/components/ui";
 
 interface RedisInfo {
   status: string;
@@ -19,9 +17,9 @@ interface RedisModalProps {
 
 function InfoRow({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-center justify-between py-1.5 border-b border-gray-100 last:border-0">
-      <span className="text-xs text-gray-500">{label}</span>
-      <span className="text-xs font-mono text-gray-900">{value}</span>
+    <div className="flex items-center justify-between py-1.5 border-b border-divider last:border-0">
+      <span className="text-xs text-muted">{label}</span>
+      <span className="text-xs font-mono text-ink-2">{value}</span>
     </div>
   );
 }
@@ -89,63 +87,63 @@ export default function RedisModal({ onClose }: RedisModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-scrim"
       onMouseDown={handleBackdropMouseDown}
     >
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
+      <div className="bg-surface border border-border rounded-xl shadow-e3 w-full max-w-lg max-h-[85vh] flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 shrink-0">
-          <div className="flex items-center space-x-3">
-            <span className="text-2xl">🧊</span>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary-soft text-primary">
+              <Icon icon="logos:redis" width={18} />
+            </span>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Redis Cache</h2>
-              <p className="text-xs text-gray-500">Local cache service</p>
+              <h2 className="text-base font-semibold text-ink">Redis Cache</h2>
+              <p className="text-xs text-muted">Local cache service</p>
             </div>
           </div>
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center gap-2">
             <Link
               href="/cache"
               onClick={onClose}
-              className="flex items-center px-3 py-1.5 text-xs font-medium text-cyan-700 bg-cyan-50 border border-cyan-200 rounded-md hover:bg-cyan-100 transition-colors"
+              className="no-underline inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md border border-border-strong bg-surface text-ink-2 text-xs font-medium transition-colors hover:bg-surface-2"
             >
-              <ArrowRightIcon className="h-3.5 w-3.5 mr-1" />
+              <Icon icon="lucide:arrow-right" width={13} />
               Manage Cache
             </Link>
-            <button
+            <IconButton
+              icon="lucide:x"
+              label="Close"
+              variant="ghost"
+              size="sm"
               onClick={onClose}
-              className="p-1.5 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
-            >
-              <XMarkIcon className="h-5 w-5" />
-            </button>
+            />
           </div>
         </div>
 
         {/* Body */}
-        <div className="overflow-y-auto flex-1 divide-y divide-gray-100">
+        <div className="overflow-y-auto flex-1 divide-y divide-divider">
 
           {/* Status bar */}
-          <div className="px-6 py-4 bg-gray-50 flex items-center justify-between">
-            <div className="flex items-center space-x-6">
+          <div className="px-6 py-4 bg-surface-2 flex items-center justify-between">
+            <div className="flex items-center gap-6">
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wide">Status</p>
-                <span className={`inline-flex items-center text-sm font-medium ${
-                  isRunning ? "text-green-700" : "text-gray-500"
-                }`}>
-                  <span className={`h-2 w-2 rounded-full mr-1.5 ${
-                    isRunning ? "bg-green-500 animate-pulse" : "bg-gray-300"
-                  }`} />
-                  {isRunning ? "Running" : "Unavailable"}
-                </span>
+                <p className="text-[11px] text-faint uppercase tracking-wide">Status</p>
+                <div className="mt-0.5">
+                  <Badge tone={isRunning ? "success" : "neutral"} pulse={isRunning}>
+                    {isRunning ? "Running" : "Unavailable"}
+                  </Badge>
+                </div>
               </div>
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wide">Keys</p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-[11px] text-faint uppercase tracking-wide">Keys</p>
+                <p className="text-2xl font-bold text-ink font-mono">
                   {loading ? "—" : totalKeys}
                 </p>
               </div>
               <div>
-                <p className="text-xs text-gray-500 uppercase tracking-wide">Memory</p>
-                <p className="text-2xl font-bold text-gray-900">
+                <p className="text-[11px] text-faint uppercase tracking-wide">Memory</p>
+                <p className="text-2xl font-bold text-ink font-mono">
                   {loading ? "—" : usedMemory}
                 </p>
               </div>
@@ -155,8 +153,8 @@ export default function RedisModal({ onClose }: RedisModalProps) {
           {/* Server info */}
           {isRunning && !loading && (
             <div className="px-6 py-4">
-              <h3 className="text-sm font-semibold text-gray-900 mb-3">Server Info</h3>
-              <div className="rounded-lg border border-gray-200 px-4 py-2">
+              <h3 className="text-sm font-semibold text-ink mb-3">Server Info</h3>
+              <div className="rounded-lg border border-border px-4 py-2">
                 <InfoRow label="Redis Version" value={redisVersion} />
                 <InfoRow label="Uptime" value={uptime} />
                 <InfoRow label="Connected Clients" value={connectedClients} />
@@ -168,27 +166,27 @@ export default function RedisModal({ onClose }: RedisModalProps) {
           {/* Key sample */}
           <div className="px-6 py-4">
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-sm font-semibold text-gray-900">Keys</h3>
-              <span className="text-xs text-gray-400">
+              <h3 className="text-sm font-semibold text-ink">Keys</h3>
+              <span className="text-xs text-faint">
                 {totalKeys === 0 ? "No keys" : `${totalKeys} total`}
               </span>
             </div>
             {loading ? (
-              <div className="text-center py-4 text-gray-400 text-sm">Loading…</div>
+              <div className="text-center py-4 text-muted text-sm">Loading…</div>
             ) : keys.length === 0 ? (
-              <div className="text-center py-4 text-gray-400 text-sm">
+              <div className="text-center py-4 text-muted text-sm">
                 No keys stored yet.
               </div>
             ) : (
-              <div className="rounded-lg border border-gray-200 overflow-hidden">
-                <div className="divide-y divide-gray-100 max-h-40 overflow-y-auto">
+              <div className="rounded-lg border border-border overflow-hidden">
+                <div className="divide-y divide-divider max-h-40 overflow-y-auto">
                   {keys.slice(0, 20).map((key) => (
-                    <div key={key} className="px-3 py-2 text-xs font-mono text-gray-700 bg-white hover:bg-gray-50">
+                    <div key={key} className="px-3 py-2 text-xs font-mono text-ink-2 bg-surface hover:bg-surface-2">
                       {key}
                     </div>
                   ))}
                   {keys.length > 20 && (
-                    <div className="px-3 py-2 text-xs text-gray-400 bg-gray-50">
+                    <div className="px-3 py-2 text-xs text-faint bg-surface-2">
                       +{keys.length - 20} more — open Redis Management for full view
                     </div>
                   )}
@@ -198,14 +196,14 @@ export default function RedisModal({ onClose }: RedisModalProps) {
           </div>
 
           {/* CTA */}
-          <div className="px-6 py-4 bg-gray-50">
+          <div className="px-6 py-4 bg-surface-2">
             <Link
               href="/cache"
               onClick={onClose}
-              className="flex items-center justify-center w-full px-4 py-2.5 text-sm font-medium text-white bg-cyan-600 rounded-md hover:bg-cyan-700 transition-colors"
+              className="no-underline inline-flex items-center justify-center gap-1.5 w-full h-9 rounded-lg bg-primary text-white text-[13px] font-medium transition-colors hover:bg-primary-hover"
             >
               Go to Redis Management
-              <ArrowRightIcon className="h-4 w-4 ml-2" />
+              <Icon icon="lucide:arrow-right" width={15} />
             </Link>
           </div>
 

--- a/localcloud-gui/src/components/ResourceList.tsx
+++ b/localcloud-gui/src/components/ResourceList.tsx
@@ -1,24 +1,11 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Resource } from "@/types";
 import { Icon } from "@iconify/react";
 import { AnimatePresence, motion } from "framer-motion";
-import {
-  TrashIcon,
-  EyeIcon,
-  PencilSquareIcon,
-  CodeBracketIcon,
-  Cog6ToothIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  ClockIcon,
-  ExclamationTriangleIcon,
-  ClipboardDocumentIcon,
-  ArrowPathIcon,
-  PlusIcon,
-  ChevronDownIcon,
-} from "@heroicons/react/24/outline";
+import { Badge, Button, IconButton, SearchInput } from "@/components/ui";
+import type { StatusTone } from "@/components/ui";
 
 interface ResourceListProps {
   resources: Resource[];
@@ -46,11 +33,11 @@ interface ResourceListProps {
 }
 
 const AWS_CATEGORIES = [
-  { name: "Storage", types: ["s3"] },
-  { name: "Database", types: ["dynamodb"] },
-  { name: "Compute", types: ["lambda"] },
-  { name: "Networking", types: ["apigateway"] },
-  { name: "Security & Identity", types: ["iam", "secretsmanager", "ssm"] },
+  { name: "Storage", types: ["s3"] as Resource["type"][] },
+  { name: "Database", types: ["dynamodb"] as Resource["type"][] },
+  { name: "Compute", types: ["lambda"] as Resource["type"][] },
+  { name: "Networking", types: ["apigateway"] as Resource["type"][] },
+  { name: "Security & Identity", types: ["iam", "secretsmanager", "ssm"] as Resource["type"][] },
 ];
 
 const RESOURCE_ICON: Record<string, string> = {
@@ -69,9 +56,68 @@ const RESOURCE_LABEL: Record<string, string> = {
   lambda: "Lambda Function",
   apigateway: "API Gateway",
   ssm: "Parameter Store",
-  iam: "IAM",
+  iam: "IAM Role",
   secretsmanager: "Secrets Manager",
 };
+
+const RESOURCE_GROUP_LABEL: Record<string, string> = {
+  s3: "S3 buckets",
+  dynamodb: "DynamoDB tables",
+  lambda: "Lambda functions",
+  apigateway: "API Gateway APIs",
+  ssm: "Parameter Store",
+  iam: "IAM roles",
+  secretsmanager: "Secrets",
+};
+
+const RESOURCE_DESCRIPTION: Record<string, string> = {
+  s3: "Object storage",
+  dynamodb: "Key-value store",
+  lambda: "Placeholder zip, upload later",
+  apigateway: "REST API",
+  ssm: "Config parameters",
+  iam: "Trust policy required",
+  secretsmanager: "Encrypted secret values",
+};
+
+const STATUS_LABEL: Record<Resource["status"], string> = {
+  active: "Active",
+  creating: "Creating",
+  deleting: "Deleting",
+  error: "Error",
+  unknown: "Unknown",
+};
+
+const STATUS_TONE: Record<Resource["status"], StatusTone> = {
+  active: "success",
+  creating: "warn",
+  deleting: "warn",
+  error: "danger",
+  unknown: "neutral",
+};
+
+const STATUS_PULSE: Record<Resource["status"], boolean> = {
+  active: false,
+  creating: true,
+  deleting: true,
+  error: false,
+  unknown: false,
+};
+
+function formatRelativeTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  const diffSec = Math.round((Date.now() - date.getTime()) / 1000);
+  if (diffSec < 60) return "just now";
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  if (diffDay === 1) return "yesterday";
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return date.toLocaleDateString();
+}
 
 interface EmptyStateAction {
   key: string;
@@ -108,48 +154,18 @@ export default function ResourceList({
   const [selectedResources, setSelectedResources] = useState<string[]>([]);
   const [showDetails, setShowDetails] = useState<string | null>(null);
   const [copiedArn, setCopiedArn] = useState<string | null>(null);
-  const [showAddMenu, setShowAddMenu] = useState(false);
-  const addMenuRef = useRef<HTMLDivElement>(null);
+  const [showTypePicker, setShowTypePicker] = useState(false);
+  const [filterQuery, setFilterQuery] = useState("");
+  const pickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
-        setShowAddMenu(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case "active":
-        return <CheckCircleIcon className="h-5 w-5 text-green-500" />;
-      case "creating":
-        return <ClockIcon className="h-5 w-5 text-yellow-500" />;
-      case "deleting":
-        return <ClockIcon className="h-5 w-5 text-orange-500" />;
-      case "error":
-        return <ExclamationTriangleIcon className="h-5 w-5 text-red-500" />;
-      default:
-        return <XCircleIcon className="h-5 w-5 text-gray-400" />;
-    }
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "active":
-        return "text-green-600 bg-green-50 border-green-200";
-      case "creating":
-        return "text-yellow-600 bg-yellow-50 border-yellow-200";
-      case "deleting":
-        return "text-orange-600 bg-orange-50 border-orange-200";
-      case "error":
-        return "text-red-600 bg-red-50 border-red-200";
-      default:
-        return "text-gray-600 bg-gray-50 border-gray-200";
-    }
-  };
+    if (!showTypePicker) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setShowTypePicker(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [showTypePicker]);
 
   const handleSelectResource = (resourceId: string) => {
     setSelectedResources((prev) =>
@@ -179,18 +195,34 @@ export default function ResourceList({
   const awsTypes = new Set(AWS_CATEGORIES.flatMap((c) => c.types));
   const awsResources = resources.filter((r) => r.project === projectName && awsTypes.has(r.type));
 
+  const filteredAwsResources = useMemo(() => {
+    const query = filterQuery.trim().toLowerCase();
+    if (!query) return awsResources;
+    return awsResources.filter((r) => r.name.toLowerCase().includes(query));
+  }, [awsResources, filterQuery]);
+
   const handleSelectAll = () => {
-    if (selectedResources.length === awsResources.length) {
+    if (selectedResources.length === filteredAwsResources.length) {
       setSelectedResources([]);
     } else {
-      setSelectedResources(awsResources.map((r) => r.id));
+      setSelectedResources(filteredAwsResources.map((r) => r.id));
     }
   };
 
   const getApiId = (r: Resource) => r.details?.apiId || r.id.replace(/^apigateway-/, "");
 
-  const hasAddActions = onAddS3 || onAddDynamoDB || onAddSecrets || onAddLambda || onAddAPIGateway || onAddSSM || onAddIAM;
-  const rowGridTemplate = "1.25rem 2.5rem minmax(0, 1fr) 10rem 8rem 1.75rem";
+  const addHandlers: Partial<Record<Resource["type"], () => void>> = {
+    s3: onAddS3,
+    dynamodb: onAddDynamoDB,
+    lambda: onAddLambda,
+    apigateway: onAddAPIGateway,
+    secretsmanager: onAddSecrets,
+    ssm: onAddSSM,
+    iam: onAddIAM,
+  };
+
+  const hasAddActions = Object.values(addHandlers).some(Boolean);
+  const rowGridTemplate = "1.25rem minmax(0,1fr) 8rem 6rem 6.5rem 5rem";
   const listTransition = { duration: 0.24, ease: "easeOut" as const };
   const emptyStateActions: EmptyStateAction[] = [
     onAddS3
@@ -230,147 +262,73 @@ export default function ResourceList({
         }
       : null,
   ].filter((action): action is EmptyStateAction => action !== null);
-  const viewState = awsResources.length === 0 ? (firstResourceLoading ? "building" : "empty") : "list";
+
+  const viewState =
+    awsResources.length === 0
+      ? firstResourceLoading
+        ? "building"
+        : "empty"
+      : filteredAwsResources.length === 0
+        ? "no-match"
+        : "list";
 
   return (
-    <motion.div layout className="bg-white rounded-lg shadow">
+    <motion.div layout className="bg-surface border border-border rounded-xl shadow-e1 overflow-hidden">
       {/* Header */}
-      <div className="px-6 py-4 border-b border-gray-200">
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-lg font-medium text-gray-900">AWS Resources</h3>
-            <p className="text-xs text-gray-500 mt-0.5">{awsResources.length} resource{awsResources.length !== 1 ? "s" : ""} in &quot;{projectName}&quot;</p>
-          </div>
-          <div className="flex items-center space-x-2">
-            {/* Destroy Selected */}
-            {selectedResources.length > 0 && (
-              <button
-                onClick={handleDestroySelected}
-                disabled={loading}
-                className="flex items-center px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-50"
-              >
-                {loading ? (
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                ) : (
-                  <TrashIcon className="h-4 w-4 mr-2" />
-                )}
-                {loading ? "Destroying..." : `Destroy Selected (${selectedResources.length})`}
-              </button>
-            )}
+      <div className="flex items-center gap-3 px-4 py-3.5 border-b border-divider flex-wrap">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[15px] font-semibold text-ink">AWS resources</span>
+          <span className="text-[11px] text-muted">
+            {awsResources.length} resource{awsResources.length !== 1 ? "s" : ""} in{" "}
+            <span className="font-mono">{projectName}</span>
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 ml-auto">
+          {selectedResources.length > 0 && (
+            <Button variant="danger" size="sm" icon="lucide:trash-2" onClick={handleDestroySelected} loading={loading}>
+              {loading ? "Destroying…" : `Destroy Selected (${selectedResources.length})`}
+            </Button>
+          )}
 
-            {/* Refresh */}
-            {onRefresh && (
-              <button
-                onClick={onRefresh}
-                disabled={refreshLoading}
-                className="p-2 text-gray-500 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 transition-colors"
-                title="Refresh resources"
-              >
-                <ArrowPathIcon className={`h-4 w-4 ${refreshLoading ? "animate-spin" : ""}`} />
-              </button>
-            )}
+          <SearchInput
+            placeholder="Filter resources…"
+            value={filterQuery}
+            onChange={(e) => setFilterQuery(e.target.value)}
+            containerClassName="w-44"
+          />
 
-            {/* + Add dropdown */}
-            {hasAddActions && (
-              <div className="relative" ref={addMenuRef}>
-                <button
-                  onClick={() => setShowAddMenu((v) => !v)}
-                  disabled={addLoading}
-                  className="flex items-center px-3 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                >
-                  <PlusIcon className="h-4 w-4 mr-1.5" />
-                  Add
-                  <ChevronDownIcon className={`h-3.5 w-3.5 ml-1.5 transition-transform ${showAddMenu ? "rotate-180" : ""}`} />
-                </button>
-                {showAddMenu && (
-                  <div className="absolute right-0 mt-1 w-60 bg-white border border-gray-200 rounded-md shadow-lg z-50">
-                    {(onAddS3) && (
-                      <>
-                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider">Storage</p>
-                        <button
-                          onClick={() => { onAddS3(); setShowAddMenu(false); }}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-s3" className="w-5 h-5 mr-3 shrink-0" />
-                          S3 Bucket
-                        </button>
-                      </>
-                    )}
-                    {(onAddDynamoDB) && (
-                      <>
-                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Database</p>
-                        <button
-                          onClick={() => { onAddDynamoDB(); setShowAddMenu(false); }}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-dynamodb" className="w-5 h-5 mr-3 shrink-0" />
-                          DynamoDB Table
-                        </button>
-                      </>
-                    )}
-                    {(onAddLambda) && (
-                      <>
-                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Compute</p>
-                        <button
-                          onClick={() => { onAddLambda(); setShowAddMenu(false); }}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-lambda" className="w-5 h-5 mr-3 shrink-0" />
-                          Lambda Function
-                        </button>
-                      </>
-                    )}
-                    {(onAddAPIGateway) && (
-                      <>
-                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Networking</p>
-                        <button
-                          onClick={() => { onAddAPIGateway(); setShowAddMenu(false); }}
-                          className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                        >
-                          <Icon icon="logos:aws-api-gateway" className="w-5 h-5 mr-3 shrink-0" />
-                          API Gateway
-                        </button>
-                      </>
-                    )}
-                    {(onAddSecrets || onAddSSM || onAddIAM) && (
-                      <>
-                        <p className="px-4 pt-2 pb-1 text-xs font-semibold text-gray-400 uppercase tracking-wider border-t border-gray-100 mt-1">Security & Identity</p>
-                        {onAddSecrets && (
-                          <button
-                            onClick={() => { onAddSecrets(); setShowAddMenu(false); }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                          >
-                            <Icon icon="logos:aws-secrets-manager" className="w-5 h-5 mr-3 shrink-0" />
-                            Secrets Manager
-                          </button>
-                        )}
-                        {onAddSSM && (
-                          <button
-                            onClick={() => { onAddSSM(); setShowAddMenu(false); }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                          >
-                            <Icon icon="logos:aws-systems-manager" className="w-5 h-5 mr-3 shrink-0" />
-                            Parameter Store
-                          </button>
-                        )}
-                        {onAddIAM && (
-                          <button
-                            onClick={() => { onAddIAM(); setShowAddMenu(false); }}
-                            className="flex items-center w-full px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
-                          >
-                            <Icon icon="logos:aws-iam" className="w-5 h-5 mr-3 shrink-0" />
-                            IAM Role
-                          </button>
-                        )}
-                      </>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+          {onRefresh && (
+            <IconButton
+              icon="lucide:refresh-cw"
+              label="Refresh resources"
+              onClick={onRefresh}
+              disabled={refreshLoading}
+              className={refreshLoading ? "animate-spin" : ""}
+            />
+          )}
+
+          {hasAddActions && (
+            <Button variant="primary" size="sm" icon="lucide:plus" onClick={() => setShowTypePicker(true)} disabled={addLoading}>
+              Create resource
+            </Button>
+          )}
         </div>
       </div>
+
+      {/* Column labels */}
+      {viewState === "list" && (
+        <div
+          className="grid items-center gap-x-3 px-4 py-2 bg-surface-2 border-b border-divider"
+          style={{ gridTemplateColumns: rowGridTemplate }}
+        >
+          <div />
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-faint">Name</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-faint">Detail</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-faint">Created</span>
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-faint text-center">Status</span>
+          <div />
+        </div>
+      )}
 
       <AnimatePresence initial={false} mode="wait">
         {viewState === "empty" && (
@@ -383,33 +341,29 @@ export default function ResourceList({
             transition={listTransition}
             className="px-6 py-12 min-h-[23rem] flex flex-col justify-center"
           >
-            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">No AWS resources yet</h4>
-            <p className="text-sm text-gray-500 text-center">
-              Create resources for your active project.
-            </p>
+            <h4 className="text-sm font-semibold text-ink mb-1 text-center">No AWS resources yet</h4>
+            <p className="text-sm text-muted text-center">Create resources for your active project.</p>
 
             {emptyStateActions.length > 0 && (
-              <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl mx-auto">
+              <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl mx-auto w-full">
                 {emptyStateActions.map((action) => (
                   <button
                     key={action.key}
                     onClick={action.onClick}
                     disabled={addLoading}
-                    className="flex items-center p-3 text-left border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50/40 transition-colors disabled:opacity-50"
+                    className="flex items-center p-3 text-left border border-border rounded-lg hover:border-primary hover:bg-primary-soft/40 transition-colors disabled:opacity-50"
                   >
                     <Icon icon={action.icon} className="w-8 h-8 mr-3 shrink-0" />
                     <span className="min-w-0">
-                      <span className="block text-sm font-medium text-gray-900">{action.title}</span>
-                      <span className="block text-xs text-gray-500">{action.description}</span>
+                      <span className="block text-sm font-medium text-ink">{action.title}</span>
+                      <span className="block text-xs text-muted">{action.description}</span>
                     </span>
                   </button>
                 ))}
               </div>
             )}
 
-            <p className="mt-4 text-xs text-gray-500 text-center">
-              Pick any service; there&apos;s no required order.
-            </p>
+            <p className="mt-4 text-xs text-muted text-center">Pick any service; there&apos;s no required order.</p>
           </motion.div>
         )}
 
@@ -423,27 +377,44 @@ export default function ResourceList({
             transition={listTransition}
             className="px-6 py-12 min-h-[23rem] flex flex-col justify-center"
           >
-            <h4 className="text-sm font-semibold text-gray-900 mb-1 text-center">Resource creation in progress...</h4>
-            <p className="text-sm text-gray-500 text-center">
-              Setting up your resource for the active project.
-            </p>
-            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl mx-auto">
+            <h4 className="text-sm font-semibold text-ink mb-1 text-center">Resource creation in progress…</h4>
+            <p className="text-sm text-muted text-center">Setting up your resource for the active project.</p>
+            <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-3 max-w-2xl mx-auto w-full">
               {[0, 1, 2, 3].map((idx) => (
                 <div
                   key={`building-card-${idx}`}
-                  className="flex items-center p-3 border border-gray-200 rounded-lg bg-gray-50/70 animate-pulse"
+                  className="flex items-center p-3 border border-border rounded-lg bg-surface-2 animate-pulse"
                 >
-                  <div className="w-8 h-8 mr-3 rounded bg-gray-200" />
+                  <div className="w-8 h-8 mr-3 rounded bg-skeleton" />
                   <span className="min-w-0 w-full">
-                    <span className="block h-3.5 w-28 bg-gray-200 rounded mb-1.5" />
-                    <span className="block h-3 w-24 bg-gray-100 rounded" />
+                    <span className="block h-3.5 w-28 bg-skeleton rounded mb-1.5" />
+                    <span className="block h-3 w-24 bg-skeleton rounded" />
                   </span>
                 </div>
               ))}
             </div>
-            <p className="mt-4 text-xs text-gray-500 text-center">
-              It will appear here automatically when ready.
-            </p>
+            <p className="mt-4 text-xs text-muted text-center">It will appear here automatically when ready.</p>
+          </motion.div>
+        )}
+
+        {viewState === "no-match" && (
+          <motion.div
+            key="no-match"
+            layout
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={listTransition}
+            className="px-6 py-12 flex flex-col items-center justify-center gap-2"
+          >
+            <Icon icon="lucide:search-x" width={28} className="text-faint" />
+            <p className="text-sm text-ink font-medium">No resources match &quot;{filterQuery}&quot;</p>
+            <button
+              onClick={() => setFilterQuery("")}
+              className="text-xs font-medium text-primary hover:text-primary-hover cursor-pointer"
+            >
+              Clear filter
+            </button>
           </motion.div>
         )}
 
@@ -459,7 +430,7 @@ export default function ResourceList({
             {/* Category sections */}
             <AnimatePresence initial={false}>
               {AWS_CATEGORIES.map((category, catIndex) => {
-                const categoryResources = awsResources.filter((r) =>
+                const categoryResources = filteredAwsResources.filter((r) =>
                   category.types.includes(r.type)
                 );
                 if (categoryResources.length === 0) return null;
@@ -473,297 +444,281 @@ export default function ResourceList({
                     exit={{ opacity: 0, y: -6 }}
                     transition={listTransition}
                   >
-                    {/* Category header */}
-                    <div className="px-6 py-2 bg-gray-50 border-b border-gray-200 flex items-center space-x-2">
-                      <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                        {category.name}
-                      </span>
-                      <span className="text-xs text-gray-400">({categoryResources.length})</span>
-                    </div>
-
-                    {/* Column labels — only on first category */}
-                    <div
-                      className="grid items-center gap-x-4 px-6 py-2 bg-white border-b border-gray-100"
-                      style={{ gridTemplateColumns: rowGridTemplate }}
-                    >
-                      <div />
-                      <div />
-                      <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">Resource</span>
-                      <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">Status</span>
-                      <span className="text-xs font-medium text-gray-400 uppercase tracking-wide text-center">Action</span>
-                      <div />
-                    </div>
-
-                    <div className="divide-y divide-gray-100">
-                      <AnimatePresence initial={false}>
-                        {categoryResources.map((resource) => (
-                          <motion.div
-                            key={resource.id}
-                            layout
-                            initial={{ opacity: 0, y: 8 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            exit={{ opacity: 0, y: -8 }}
-                            transition={listTransition}
-                            className="px-6 py-4"
-                          >
-                            <div
-                              className="grid items-center gap-x-4"
-                              style={{ gridTemplateColumns: rowGridTemplate }}
-                            >
-                        {/* Checkbox */}
-                        <input
-                          type="checkbox"
-                          checked={selectedResources.includes(resource.id)}
-                          onChange={() => handleSelectResource(resource.id)}
-                          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                        />
-
-                        {/* AWS icon */}
-                        <div className="flex items-center justify-center">
-                          <Icon
-                            icon={RESOURCE_ICON[resource.type] || "logos:aws"}
-                            className="w-6 h-6"
-                          />
-                        </div>
-
-                        {/* Name + type */}
-                        <div className="min-w-0">
-                          <h4 className="text-sm font-medium text-gray-900 break-words leading-5">
-                            {resource.name}
-                          </h4>
-                          <p className="text-xs text-gray-500 break-words">
-                            {RESOURCE_LABEL[resource.type] || resource.type} · {resource.project}
-                          </p>
-                        </div>
-
-                        {/* Status badge */}
-                        <div>
-                          <span
-                            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border ${getStatusColor(resource.status)}`}
-                          >
-                            {getStatusIcon(resource.status)}
-                            <span className="ml-1 capitalize">{resource.status}</span>
-                          </span>
-                        </div>
-
-                        {/* Action button */}
-                        <div className="flex justify-center">
-                          {resource.status === "active" && (
-                            <>
-                              {resource.type === "s3" && onViewS3 && (
-                                <button
-                                  onClick={() => onViewS3(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="Browse S3 Bucket"
-                                >
-                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Open
-                                </button>
-                              )}
-                              {resource.type === "dynamodb" && onViewDynamoDB && (
-                                <button
-                                  onClick={() => onViewDynamoDB(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="Browse DynamoDB Table"
-                                >
-                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Open
-                                </button>
-                              )}
-                              {resource.type === "secretsmanager" && onViewSecretsManager && (
-                                <button
-                                  onClick={() => onViewSecretsManager(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="View secret"
-                                >
-                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  View
-                                </button>
-                              )}
-                              {resource.type === "ssm" && onEditSSM && (
-                                <button
-                                  onClick={() => onEditSSM(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="Edit parameter"
-                                >
-                                  <PencilSquareIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Edit
-                                </button>
-                              )}
-                              {resource.type === "lambda" && onViewLambdaCode && (
-                                <button
-                                  onClick={() => onViewLambdaCode(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="View code"
-                                >
-                                  <CodeBracketIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Code
-                                </button>
-                              )}
-                              {resource.type === "iam" && onViewIAMRole && (
-                                <button
-                                  onClick={() => onViewIAMRole(resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="View role policies"
-                                >
-                                  <EyeIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Policies
-                                </button>
-                              )}
-                              {resource.type === "apigateway" && onConfigureAPIGateway && (
-                                <button
-                                  onClick={() => onConfigureAPIGateway(getApiId(resource), resource.name)}
-                                  className="w-full flex items-center justify-center px-2 py-1 text-xs font-medium text-indigo-600 bg-indigo-50 rounded-md hover:bg-indigo-100 transition-colors"
-                                  title="Configure API"
-                                >
-                                  <Cog6ToothIcon className="h-3 w-3 mr-1 shrink-0" />
-                                  Config
-                                </button>
-                              )}
-                            </>
-                          )}
-                        </div>
-
-                        {/* Details toggle */}
-                        <div className="flex justify-center">
-                          <button
-                            onClick={() =>
-                              setShowDetails(showDetails === resource.id ? null : resource.id)
-                            }
-                            className={`text-gray-400 hover:text-gray-600 transition-colors ${showDetails === resource.id ? "text-gray-600" : ""}`}
-                            title="Show Details"
-                          >
-                            <EyeIcon className="h-4 w-4" />
-                          </button>
-                        </div>
-                            </div>
-
-                            {/* Resource Details */}
-                            <AnimatePresence initial={false}>
-                              {showDetails === resource.id && (
-                                <motion.div
-                                  layout
-                                  initial={{ opacity: 0, height: 0 }}
-                                  animate={{ opacity: 1, height: "auto" }}
-                                  exit={{ opacity: 0, height: 0 }}
-                                  transition={listTransition}
-                                  className="mt-4 pl-8 border-l-2 border-gray-200 overflow-hidden"
-                                >
-                                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                            <div>
-                              <dt className="font-medium text-gray-500">Resource ID</dt>
-                              <dd className="text-gray-900 font-mono">{resource.id}</dd>
-                            </div>
-                            <div>
-                              <dt className="font-medium text-gray-500">Created</dt>
-                              <dd className="text-gray-900">
-                                {new Date(resource.createdAt).toLocaleString()}
-                              </dd>
-                            </div>
-
-                            {resource.type === "secretsmanager" && resource.details && (
-                              <>
-                                <div>
-                                  <dt className="font-medium text-gray-500">ARN</dt>
-                                  <dd className="text-gray-900 font-mono text-sm break-all">
-                                    <div className="flex items-center space-x-2">
-                                      <code className="flex-1 min-w-0">
-                                        {resource.details.arn}
-                                      </code>
-                                      <button
-                                        onClick={() =>
-                                          resource.details?.arn &&
-                                          copyArnToClipboard(resource.details.arn)
-                                        }
-                                        className="shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
-                                        title="Copy ARN"
-                                      >
-                                        <ClipboardDocumentIcon className="h-4 w-4" />
-                                      </button>
-                                    </div>
-                                    {copiedArn === resource.details.arn && (
-                                      <p className="text-xs text-green-600 mt-1">
-                                        ✓ Copied to clipboard
-                                      </p>
-                                    )}
-                                  </dd>
-                                </div>
-                                {resource.details.description && (
-                                  <div>
-                                    <dt className="font-medium text-gray-500">Description</dt>
-                                    <dd className="text-gray-900">{resource.details.description}</dd>
-                                  </div>
-                                )}
-                                <div>
-                                  <dt className="font-medium text-gray-500">Last Changed</dt>
-                                  <dd className="text-gray-900">
-                                    {new Date(resource.details.lastChangedDate).toLocaleString()}
-                                  </dd>
-                                </div>
-                              </>
-                            )}
-
-                            {resource.type === "iam" && resource.details && (
-                              <>
-                                {resource.details.arn && (
-                                  <div>
-                                    <dt className="font-medium text-gray-500">ARN</dt>
-                                    <dd className="text-gray-900 font-mono text-sm break-all">
-                                      <div className="flex items-center space-x-2">
-                                        <code className="flex-1 min-w-0">{resource.details.arn}</code>
-                                        <button
-                                          onClick={() => resource.details?.arn && copyArnToClipboard(resource.details.arn)}
-                                          className="shrink-0 p-1 text-gray-400 hover:text-gray-600 transition-colors"
-                                          title="Copy ARN"
-                                        >
-                                          <ClipboardDocumentIcon className="h-4 w-4" />
-                                        </button>
-                                      </div>
-                                      {copiedArn === resource.details.arn && (
-                                        <p className="text-xs text-green-600 mt-1">✓ Copied to clipboard</p>
-                                      )}
-                                    </dd>
-                                  </div>
-                                )}
-                                {resource.details.trustService && (
-                                  <div>
-                                    <dt className="font-medium text-gray-500">Trusted Service</dt>
-                                    <dd className="text-gray-900 font-mono text-sm">{resource.details.trustService}.amazonaws.com</dd>
-                                  </div>
-                                )}
-                                {resource.details.description && (
-                                  <div>
-                                    <dt className="font-medium text-gray-500">Description</dt>
-                                    <dd className="text-gray-900">{resource.details.description}</dd>
-                                  </div>
-                                )}
-                                {resource.details.path && (
-                                  <div>
-                                    <dt className="font-medium text-gray-500">Path</dt>
-                                    <dd className="text-gray-900 font-mono text-sm">{resource.details.path}</dd>
-                                  </div>
-                                )}
-                              </>
-                            )}
-
-                            {resource.type !== "secretsmanager" && resource.type !== "iam" &&
-                              resource.details &&
-                              Object.entries(resource.details).map(([key, value], detailIdx) => (
-                                <div key={`${resource.id}-detail-${key}-${detailIdx}`}>
-                                  <dt className="font-medium text-gray-500 capitalize">
-                                    {key.replace(/([A-Z])/g, " $1")}
-                                  </dt>
-                                  <dd className="text-gray-900">{String(value)}</dd>
-                                </div>
-                              ))}
+                    {/* Group headers — one per resource type present */}
+                    {category.types.map((type) => {
+                      const typeResources = categoryResources.filter((r) => r.type === type);
+                      if (typeResources.length === 0) return null;
+                      return (
+                        <div key={type}>
+                          <div className="flex items-center gap-2 px-4 py-1.5 bg-surface-2 border-b border-divider border-t border-t-divider first:border-t-0">
+                            <Icon icon={RESOURCE_ICON[type] || "logos:aws"} width={14} />
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-muted">
+                              {RESOURCE_GROUP_LABEL[type] || type}
+                            </span>
+                            <span className="font-mono text-[11px] text-faint">{typeResources.length}</span>
                           </div>
+
+                          <div className="divide-y divide-divider">
+                            <AnimatePresence initial={false}>
+                              {typeResources.map((resource) => (
+                                <motion.div
+                                  key={resource.id}
+                                  layout
+                                  initial={{ opacity: 0, y: 8 }}
+                                  animate={{ opacity: 1, y: 0 }}
+                                  exit={{ opacity: 0, y: -8 }}
+                                  transition={listTransition}
+                                  className="px-4 py-3"
+                                >
+                                  <div
+                                    className="grid items-center gap-x-3"
+                                    style={{ gridTemplateColumns: rowGridTemplate }}
+                                  >
+                                    {/* Checkbox */}
+                                    <input
+                                      type="checkbox"
+                                      checked={selectedResources.includes(resource.id)}
+                                      onChange={() => handleSelectResource(resource.id)}
+                                      className="h-3.5 w-3.5 accent-primary border-border-strong rounded"
+                                    />
+
+                                    {/* Name */}
+                                    <div className="min-w-0">
+                                      <p className="font-mono text-[13px] text-ink truncate">{resource.name}</p>
+                                    </div>
+
+                                    {/* Detail */}
+                                    <span className="text-xs text-muted truncate">
+                                      {RESOURCE_LABEL[resource.type] || resource.type}
+                                    </span>
+
+                                    {/* Created */}
+                                    <span
+                                      className="text-xs text-muted truncate"
+                                      title={new Date(resource.createdAt).toLocaleString()}
+                                    >
+                                      {formatRelativeTime(resource.createdAt)}
+                                    </span>
+
+                                    {/* Status badge */}
+                                    <div className="flex justify-center">
+                                      <Badge tone={STATUS_TONE[resource.status]} pulse={STATUS_PULSE[resource.status]}>
+                                        {STATUS_LABEL[resource.status] || resource.status}
+                                      </Badge>
+                                    </div>
+
+                                    {/* Actions */}
+                                    <div className="flex items-center justify-center gap-1">
+                                      {resource.status === "active" && (
+                                        <>
+                                          {resource.type === "s3" && onViewS3 && (
+                                            <IconButton
+                                              icon="lucide:eye"
+                                              label="Browse S3 bucket"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onViewS3(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "dynamodb" && onViewDynamoDB && (
+                                            <IconButton
+                                              icon="lucide:eye"
+                                              label="Browse DynamoDB table"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onViewDynamoDB(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "secretsmanager" && onViewSecretsManager && (
+                                            <IconButton
+                                              icon="lucide:eye"
+                                              label="View secret"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onViewSecretsManager(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "ssm" && onEditSSM && (
+                                            <IconButton
+                                              icon="lucide:pencil"
+                                              label="Edit parameter"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onEditSSM(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "lambda" && onViewLambdaCode && (
+                                            <IconButton
+                                              icon="lucide:code"
+                                              label="View code"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onViewLambdaCode(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "iam" && onViewIAMRole && (
+                                            <IconButton
+                                              icon="lucide:shield-check"
+                                              label="View role policies"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onViewIAMRole(resource.name)}
+                                            />
+                                          )}
+                                          {resource.type === "apigateway" && onConfigureAPIGateway && (
+                                            <IconButton
+                                              icon="lucide:settings"
+                                              label="Configure API"
+                                              variant="ghost"
+                                              size="sm"
+                                              onClick={() => onConfigureAPIGateway(getApiId(resource), resource.name)}
+                                            />
+                                          )}
+                                        </>
+                                      )}
+                                      <IconButton
+                                        icon={showDetails === resource.id ? "lucide:chevron-up" : "lucide:chevron-down"}
+                                        label="Toggle details"
+                                        variant="ghost"
+                                        size="sm"
+                                        onClick={() =>
+                                          setShowDetails(showDetails === resource.id ? null : resource.id)
+                                        }
+                                      />
+                                    </div>
+                                  </div>
+
+                                  {/* Resource details */}
+                                  <AnimatePresence initial={false}>
+                                    {showDetails === resource.id && (
+                                      <motion.div
+                                        layout
+                                        initial={{ opacity: 0, height: 0 }}
+                                        animate={{ opacity: 1, height: "auto" }}
+                                        exit={{ opacity: 0, height: 0 }}
+                                        transition={listTransition}
+                                        className="mt-3 pl-6 border-l-2 border-divider overflow-hidden"
+                                      >
+                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+                                          <div>
+                                            <dt className="font-medium text-muted text-xs">Resource ID</dt>
+                                            <dd className="text-ink font-mono text-xs break-all">{resource.id}</dd>
+                                          </div>
+                                          <div>
+                                            <dt className="font-medium text-muted text-xs">Created</dt>
+                                            <dd className="text-ink text-xs">
+                                              {new Date(resource.createdAt).toLocaleString()}
+                                            </dd>
+                                          </div>
+
+                                          {resource.type === "secretsmanager" && resource.details && (
+                                            <>
+                                              <div>
+                                                <dt className="font-medium text-muted text-xs">ARN</dt>
+                                                <dd className="text-ink font-mono text-xs break-all">
+                                                  <div className="flex items-center gap-2">
+                                                    <code className="flex-1 min-w-0">{resource.details.arn}</code>
+                                                    <button
+                                                      onClick={() =>
+                                                        resource.details?.arn &&
+                                                        copyArnToClipboard(resource.details.arn)
+                                                      }
+                                                      className="shrink-0 p-1 text-faint hover:text-ink transition-colors cursor-pointer"
+                                                      title="Copy ARN"
+                                                    >
+                                                      <Icon icon="lucide:copy" width={14} />
+                                                    </button>
+                                                  </div>
+                                                  {copiedArn === resource.details.arn && (
+                                                    <p className="text-xs text-success-ink mt-1">Copied to clipboard</p>
+                                                  )}
+                                                </dd>
+                                              </div>
+                                              {resource.details.description && (
+                                                <div>
+                                                  <dt className="font-medium text-muted text-xs">Description</dt>
+                                                  <dd className="text-ink text-xs">{resource.details.description}</dd>
+                                                </div>
+                                              )}
+                                              <div>
+                                                <dt className="font-medium text-muted text-xs">Last Changed</dt>
+                                                <dd className="text-ink text-xs">
+                                                  {new Date(resource.details.lastChangedDate).toLocaleString()}
+                                                </dd>
+                                              </div>
+                                            </>
+                                          )}
+
+                                          {resource.type === "iam" && resource.details && (
+                                            <>
+                                              {resource.details.arn && (
+                                                <div>
+                                                  <dt className="font-medium text-muted text-xs">ARN</dt>
+                                                  <dd className="text-ink font-mono text-xs break-all">
+                                                    <div className="flex items-center gap-2">
+                                                      <code className="flex-1 min-w-0">{resource.details.arn}</code>
+                                                      <button
+                                                        onClick={() =>
+                                                          resource.details?.arn &&
+                                                          copyArnToClipboard(resource.details.arn)
+                                                        }
+                                                        className="shrink-0 p-1 text-faint hover:text-ink transition-colors cursor-pointer"
+                                                        title="Copy ARN"
+                                                      >
+                                                        <Icon icon="lucide:copy" width={14} />
+                                                      </button>
+                                                    </div>
+                                                    {copiedArn === resource.details.arn && (
+                                                      <p className="text-xs text-success-ink mt-1">Copied to clipboard</p>
+                                                    )}
+                                                  </dd>
+                                                </div>
+                                              )}
+                                              {resource.details.trustService && (
+                                                <div>
+                                                  <dt className="font-medium text-muted text-xs">Trusted Service</dt>
+                                                  <dd className="text-ink font-mono text-xs">
+                                                    {resource.details.trustService}.amazonaws.com
+                                                  </dd>
+                                                </div>
+                                              )}
+                                              {resource.details.description && (
+                                                <div>
+                                                  <dt className="font-medium text-muted text-xs">Description</dt>
+                                                  <dd className="text-ink text-xs">{resource.details.description}</dd>
+                                                </div>
+                                              )}
+                                              {resource.details.path && (
+                                                <div>
+                                                  <dt className="font-medium text-muted text-xs">Path</dt>
+                                                  <dd className="text-ink font-mono text-xs">{resource.details.path}</dd>
+                                                </div>
+                                              )}
+                                            </>
+                                          )}
+
+                                          {resource.type !== "secretsmanager" &&
+                                            resource.type !== "iam" &&
+                                            resource.details &&
+                                            Object.entries(resource.details).map(([key, value], detailIdx) => (
+                                              <div key={`${resource.id}-detail-${key}-${detailIdx}`}>
+                                                <dt className="font-medium text-muted text-xs capitalize">
+                                                  {key.replace(/([A-Z])/g, " $1")}
+                                                </dt>
+                                                <dd className="text-ink text-xs">{String(value)}</dd>
+                                              </div>
+                                            ))}
+                                        </div>
+                                      </motion.div>
+                                    )}
+                                  </AnimatePresence>
                                 </motion.div>
-                              )}
+                              ))}
                             </AnimatePresence>
-                          </motion.div>
-                        ))}
-                      </AnimatePresence>
-                    </div>
+                          </div>
+                        </div>
+                      );
+                    })}
                   </motion.div>
                 );
               })}
@@ -771,7 +726,7 @@ export default function ResourceList({
 
             {/* Select All footer */}
             <AnimatePresence initial={false}>
-              {awsResources.length > 0 && (
+              {filteredAwsResources.length > 0 && (
                 <motion.div
                   key="select-all-footer"
                   layout
@@ -779,22 +734,100 @@ export default function ResourceList({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: 6 }}
                   transition={listTransition}
-                  className="px-6 py-3 bg-gray-50 border-t border-gray-200"
+                  className="flex items-center gap-3 px-4 py-2.5 bg-surface-2 border-t border-border"
                 >
-                  <div className="flex items-center space-x-3">
-                    <input
-                      type="checkbox"
-                      checked={selectedResources.length === awsResources.length && awsResources.length > 0}
-                      onChange={handleSelectAll}
-                      className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <span className="text-sm text-gray-700">
-                      Select all ({awsResources.length} resource{awsResources.length !== 1 ? "s" : ""})
-                    </span>
-                  </div>
+                  <input
+                    type="checkbox"
+                    checked={
+                      selectedResources.length === filteredAwsResources.length && filteredAwsResources.length > 0
+                    }
+                    onChange={handleSelectAll}
+                    className="h-3.5 w-3.5 accent-primary border-border-strong rounded"
+                  />
+                  <span className="text-xs text-muted">
+                    {selectedResources.length > 0
+                      ? `${selectedResources.length} selected`
+                      : `Select all (${filteredAwsResources.length} resource${filteredAwsResources.length !== 1 ? "s" : ""})`}
+                  </span>
                 </motion.div>
               )}
             </AnimatePresence>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Resource type picker */}
+      <AnimatePresence>
+        {showTypePicker && (
+          <motion.div
+            key="type-picker-scrim"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-scrim px-6 py-10"
+            onMouseDown={(e) => {
+              if (e.target === e.currentTarget) setShowTypePicker(false);
+            }}
+          >
+            <motion.div
+              ref={pickerRef}
+              initial={{ opacity: 0, y: -8, scale: 0.98 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -8, scale: 0.98 }}
+              transition={{ duration: 0.15 }}
+              className="w-full max-w-md bg-surface border border-border rounded-xl shadow-e3 overflow-hidden"
+            >
+              <div className="flex items-start gap-2.5 px-4 py-3.5 border-b border-divider">
+                <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary-soft text-primary shrink-0">
+                  <Icon icon="lucide:plus" width={17} />
+                </span>
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="text-[15px] font-semibold text-ink">Create resource</span>
+                  <span className="text-[11px] text-muted truncate">
+                    Into <span className="font-mono">{projectName}</span>
+                  </span>
+                </div>
+                <IconButton
+                  icon="lucide:x"
+                  label="Close"
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto shrink-0"
+                  onClick={() => setShowTypePicker(false)}
+                />
+              </div>
+
+              <div className="p-1.5 max-h-[70vh] overflow-y-auto">
+                {AWS_CATEGORIES.map((category) => {
+                  const items = category.types.filter((type) => addHandlers[type]);
+                  if (items.length === 0) return null;
+                  return (
+                    <div key={category.name}>
+                      <div className="px-2.5 pt-2.5 pb-1 text-[10px] font-semibold uppercase tracking-wider text-faint">
+                        {category.name}
+                      </div>
+                      {items.map((type) => (
+                        <button
+                          key={type}
+                          onClick={() => {
+                            addHandlers[type]?.();
+                            setShowTypePicker(false);
+                          }}
+                          className="flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-left hover:bg-surface-3 transition-colors cursor-pointer"
+                        >
+                          <Icon icon={RESOURCE_ICON[type]} width={17} className="shrink-0" />
+                          <span className="flex flex-col gap-0.5 min-w-0">
+                            <span className="text-[13px] font-medium text-ink">{RESOURCE_LABEL[type]}</span>
+                            <span className="text-[11px] text-muted truncate">{RESOURCE_DESCRIPTION[type]}</span>
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            </motion.div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/localcloud-gui/src/components/S3ConfigModal.tsx
+++ b/localcloud-gui/src/components/S3ConfigModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { XMarkIcon, FolderIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { S3BucketConfig } from "@/types";
 import { usePreferences } from "@/context/PreferencesContext";
 import { toast } from "react-hot-toast";
+import { Button, IconButton, Input } from "@/components/ui";
 
 interface S3ConfigModalProps {
   isOpen: boolean;
@@ -119,179 +120,173 @@ export default function S3ConfigModal({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4"
       onMouseDown={handleBackdropMouseDown}
     >
-      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+      <div className="bg-surface border border-border rounded-xl shadow-e3 w-full max-w-md max-h-[90vh] flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <div className="flex items-center space-x-3">
-            <div className="p-2 bg-indigo-50 rounded-lg">
-              <FolderIcon className="h-5 w-5 text-indigo-600" />
-            </div>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary-soft text-primary">
+              <Icon icon="logos:aws-s3" width={18} />
+            </span>
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">Create S3 Bucket</h2>
-              <p className="text-xs text-gray-500">Configure bucket settings</p>
+              <h2 className="text-base font-semibold text-ink">Create S3 bucket</h2>
+              <p className="text-xs text-muted">Configure bucket settings</p>
             </div>
           </div>
-          <button
-            onClick={onClose}
-            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100"
-            aria-label="Close"
-          >
-            <XMarkIcon className="h-5 w-5" />
-          </button>
+          <IconButton icon="lucide:x" label="Close" variant="ghost" onClick={onClose} />
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+        <form onSubmit={handleSubmit} className="flex flex-col overflow-hidden flex-1">
+          <div className="px-6 py-5 space-y-5 overflow-y-auto">
 
-          {/* Saved config pills */}
-          {profile?.active_project_id && projectConfigs.length > 0 && (
-            <div>
-              <p className="text-xs font-medium text-gray-500 mb-2 uppercase tracking-wide">Load saved config</p>
-              <div className="flex flex-wrap gap-2">
-                {projectConfigs.map((cfg) => (
-                  <button
-                    key={cfg.id}
-                    type="button"
-                    onClick={() => {
-                      loadSavedConfig(cfg.config as S3BucketConfig);
-                      toast.success(`Loaded "${cfg.name}"`);
-                    }}
-                    className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-200 rounded-full hover:border-blue-400 hover:text-blue-700 hover:bg-blue-50 transition-colors"
-                  >
-                    {cfg.name}
-                  </button>
-                ))}
+            {/* Saved config pills */}
+            {profile?.active_project_id && projectConfigs.length > 0 && (
+              <div>
+                <p className="text-[11px] font-semibold text-faint mb-2 uppercase tracking-wide">
+                  Load saved config
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {projectConfigs.map((cfg) => (
+                    <button
+                      key={cfg.id}
+                      type="button"
+                      onClick={() => {
+                        loadSavedConfig(cfg.config as S3BucketConfig);
+                        toast.success(`Loaded "${cfg.name}"`);
+                      }}
+                      className="h-[26px] px-2.5 rounded-full border border-border bg-surface text-ink-2 text-xs font-medium cursor-pointer transition-colors hover:border-primary hover:text-primary hover:bg-primary-soft"
+                    >
+                      {cfg.name}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
-
-          {/* Bucket Name */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Bucket Name
-            </label>
-            <input
-              type="text"
-              value={bucketName}
-              onChange={(e) => setBucketName(e.target.value.toLowerCase())}
-              onBlur={() => setTouched((t) => ({ ...t, bucketName: true }))}
-              className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 text-gray-900 ${
-                bucketNameError
-                  ? "border-red-400 focus:ring-red-400 focus:border-red-400 bg-red-50"
-                  : "border-gray-300 focus:ring-blue-500 focus:border-blue-500"
-              }`}
-              placeholder="my-bucket-name"
-            />
-            {bucketNameError ? (
-              <p className="text-xs text-red-600 mt-1">{bucketNameError}</p>
-            ) : (
-              <p className="text-xs text-gray-400 mt-1">
-                Lowercase letters, numbers, and hyphens · 3–63 characters
-              </p>
             )}
-          </div>
 
-          {/* Region */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Region
+            {/* Bucket Name */}
+            <label className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink-2">Bucket name</span>
+              <Input
+                mono
+                type="text"
+                value={bucketName}
+                onChange={(e) => setBucketName(e.target.value.toLowerCase())}
+                onBlur={() => setTouched((t) => ({ ...t, bucketName: true }))}
+                invalid={!!bucketNameError}
+                placeholder="my-bucket-name"
+                className="h-9"
+              />
+              {bucketNameError ? (
+                <p className="text-xs text-danger">{bucketNameError}</p>
+              ) : (
+                <p className="text-xs text-faint">
+                  Lowercase letters, numbers, and hyphens · 3–63 characters
+                </p>
+              )}
             </label>
-            <select
-              value={region}
-              onChange={(e) => setRegion(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
-            >
-              <option value="us-east-1">US East (N. Virginia) — us-east-1</option>
-              <option value="us-west-2">US West (Oregon) — us-west-2</option>
-              <option value="eu-west-1">Europe (Ireland) — eu-west-1</option>
-              <option value="ap-southeast-1">Asia Pacific (Singapore) — ap-southeast-1</option>
-            </select>
-          </div>
 
-          {/* Advanced Options */}
-          <div className="border-t pt-4 space-y-3">
-            <h3 className="text-sm font-semibold text-gray-700">Advanced Options</h3>
-            <label className="flex items-center space-x-3 cursor-pointer text-gray-900">
-              <input
-                type="checkbox"
-                checked={versioning}
-                onChange={(e) => setVersioning(e.target.checked)}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <div>
-                <span className="text-sm font-medium">Enable Versioning</span>
-                <p className="text-xs text-gray-500">Keep multiple versions of objects</p>
-              </div>
+            {/* Region */}
+            <label className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-ink-2">Region</span>
+              <select
+                value={region}
+                onChange={(e) => setRegion(e.target.value)}
+                className="h-9 px-2.5 rounded-lg border border-border-strong bg-surface-2 text-[13px] text-ink outline-none transition-colors focus:bg-surface focus:border-primary focus:ring-3 focus:ring-focus"
+              >
+                <option value="us-east-1">US East (N. Virginia) — us-east-1</option>
+                <option value="us-west-2">US West (Oregon) — us-west-2</option>
+                <option value="eu-west-1">Europe (Ireland) — eu-west-1</option>
+                <option value="ap-southeast-1">Asia Pacific (Singapore) — ap-southeast-1</option>
+              </select>
             </label>
-            <label className="flex items-center space-x-3 cursor-pointer text-gray-900">
-              <input
-                type="checkbox"
-                checked={encryption}
-                onChange={(e) => setEncryption(e.target.checked)}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <div>
-                <span className="text-sm font-medium">Enable Encryption</span>
-                <p className="text-xs text-gray-500">Encrypt objects at rest using AES-256</p>
-              </div>
-            </label>
-          </div>
 
-          {/* Save config toggle */}
-          <div className="border-t pt-4">
-            <label className="flex items-center space-x-3 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={saveConfig_}
-                onChange={(e) => {
-                  setSaveConfig_(e.target.checked);
-                  if (!e.target.checked) setConfigName("");
-                }}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-              <span className="text-sm text-gray-700">Save as config</span>
-            </label>
-            {saveConfig_ && (
-              <div className="mt-3">
+            {/* Advanced Options */}
+            <div className="border-t border-divider pt-4 space-y-2.5">
+              <h3 className="text-xs font-semibold text-ink-2 uppercase tracking-wide">Advanced options</h3>
+              <label className="flex items-start gap-3 p-2.5 rounded-lg border border-border cursor-pointer hover:bg-surface-2 transition-colors">
                 <input
-                  type="text"
-                  value={configName}
-                  onChange={(e) => setConfigName(e.target.value)}
-                  onBlur={() => setTouched((t) => ({ ...t, configName: true }))}
-                  placeholder="e.g. my-app-assets"
-                  className={`w-full px-3 py-2 text-sm border rounded-md focus:outline-none focus:ring-2 text-gray-900 ${
-                    configNameError
-                      ? "border-red-400 focus:ring-red-400 focus:border-red-400 bg-red-50"
-                      : "border-gray-300 focus:ring-blue-500 focus:border-blue-500"
-                  }`}
-                  autoFocus
+                  type="checkbox"
+                  checked={versioning}
+                  onChange={(e) => setVersioning(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 accent-primary shrink-0"
                 />
-                {configNameError && (
-                  <p className="text-xs text-red-600 mt-1">{configNameError}</p>
-                )}
-              </div>
-            )}
+                <span>
+                  <span className="block text-[13px] font-medium text-ink">Enable versioning</span>
+                  <span className="block text-xs text-muted">Keep multiple versions of objects</span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 p-2.5 rounded-lg border border-border cursor-pointer hover:bg-surface-2 transition-colors">
+                <input
+                  type="checkbox"
+                  checked={encryption}
+                  onChange={(e) => setEncryption(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 accent-primary shrink-0"
+                />
+                <span>
+                  <span className="block text-[13px] font-medium text-ink">Enable encryption</span>
+                  <span className="block text-xs text-muted">Encrypt objects at rest using AES-256</span>
+                </span>
+              </label>
+            </div>
+
+            {/* Save config toggle */}
+            <div className="border-t border-divider pt-4">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={saveConfig_}
+                  onChange={(e) => {
+                    setSaveConfig_(e.target.checked);
+                    if (!e.target.checked) setConfigName("");
+                  }}
+                  className="h-4 w-4 accent-primary shrink-0"
+                />
+                <span className="text-[13px] text-ink-2">Save as config for future use</span>
+              </label>
+              {saveConfig_ && (
+                <div className="mt-3">
+                  <Input
+                    type="text"
+                    value={configName}
+                    onChange={(e) => setConfigName(e.target.value)}
+                    onBlur={() => setTouched((t) => ({ ...t, configName: true }))}
+                    placeholder="e.g. my-app-assets"
+                    invalid={!!configNameError}
+                    className="w-full h-9"
+                    autoFocus
+                  />
+                  {configNameError && (
+                    <p className="text-xs text-danger mt-1">{configNameError}</p>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
 
-          {/* Actions */}
-          <div className="flex justify-end space-x-3 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-              disabled={loading}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
-              disabled={loading || (saveConfig_ && !configName.trim())}
-            >
-              {loading ? "Creating..." : "Create Bucket"}
-            </button>
+          {/* Footer */}
+          <div className="flex items-center gap-2 px-6 py-3.5 border-t border-divider bg-surface-2 shrink-0">
+            <span className="flex items-center gap-1.5 text-[11px] text-muted min-w-0">
+              <Icon icon="lucide:terminal" width={13} className="shrink-0" />
+              <span className="truncate">
+                Runs <span className="font-mono">awslocal s3 mb s3://{bucketName || "…"}</span>
+              </span>
+            </span>
+            <div className="flex items-center gap-2.5 ml-auto shrink-0">
+              <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="primary"
+                icon={loading ? undefined : "lucide:plus"}
+                loading={loading}
+                disabled={loading || (saveConfig_ && !configName.trim())}
+              >
+                {loading ? "Creating…" : "Create bucket"}
+              </Button>
+            </div>
           </div>
         </form>
       </div>

--- a/localcloud-gui/src/components/SavedConfigPicker.tsx
+++ b/localcloud-gui/src/components/SavedConfigPicker.tsx
@@ -2,9 +2,10 @@
 
 import { usePreferences } from "@/context/PreferencesContext";
 import { SavedConfig } from "@/types";
-import { BookmarkIcon, CheckIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { useState } from "react";
 import { toast } from "react-hot-toast";
+import { Button, Input } from "./ui";
 
 interface SavedConfigPickerProps {
   resourceType: "s3" | "dynamodb" | "secrets" | "iam";
@@ -51,59 +52,62 @@ export default function SavedConfigPicker({
   if (!profile?.active_project_id) return null;
 
   return (
-    <div className="mb-5 p-4 bg-gray-50 rounded-lg border border-gray-200">
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center space-x-2">
-          <BookmarkIcon className="h-4 w-4 text-gray-500" />
-          <span className="text-sm font-medium text-gray-700">Saved configs</span>
-          <span className="text-xs text-gray-400">({profile.active_project_label})</span>
-        </div>
+    <div className="flex flex-col gap-1.5 p-3 border border-border rounded-lg bg-surface-2">
+      <div className="flex items-center gap-1.5">
+        <Icon icon="lucide:bookmark" width={13} className="text-muted" />
+        <span className="text-xs font-medium text-ink-2">Saved configs</span>
+        <span className="text-[11px] text-faint">{profile.active_project_label}</span>
         {!hideSave && (
           <button
             type="button"
             onClick={() => setShowSaveInput((v) => !v)}
-            className="text-xs text-blue-600 hover:text-blue-800 font-medium"
+            className="ml-auto text-[11px] font-medium text-primary hover:text-primary-hover cursor-pointer"
           >
             {showSaveInput ? "Cancel" : `Save ${configLabel}`}
           </button>
         )}
       </div>
 
-      {/* Save input */}
       {!hideSave && showSaveInput && (
-        <div className="flex items-center space-x-2 mb-3">
-          <input
-            type="text"
-            placeholder={`Name this ${configLabel.toLowerCase()} config...`}
+        <div className="flex items-center gap-1.5">
+          <Input
+            placeholder={`Name this ${configLabel.toLowerCase()} config…`}
             value={saveName}
             onChange={(e) => setSaveName(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleSave(); } }}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 text-gray-900"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleSave();
+              }
+            }}
+            className="flex-1"
             autoFocus
           />
-          <button
-            type="button"
+          <Button
+            variant="primary"
+            size="sm"
+            icon="lucide:check"
             onClick={handleSave}
             disabled={!saveName.trim() || saving}
-            className="p-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
-          >
-            <CheckIcon className="h-4 w-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => { setShowSaveInput(false); setSaveName(""); }}
-            className="p-1.5 text-gray-400 hover:text-gray-600 border border-gray-200 rounded-md"
-          >
-            <XMarkIcon className="h-4 w-4" />
-          </button>
+            aria-label="Save config"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            icon="lucide:x"
+            onClick={() => {
+              setShowSaveInput(false);
+              setSaveName("");
+            }}
+            aria-label="Cancel"
+          />
         </div>
       )}
 
-      {/* Saved config list */}
       {projectConfigs.length === 0 ? (
-        <p className="text-xs text-gray-400 italic">No saved configs yet for this project.</p>
+        <p className="text-[11px] text-faint italic">No saved configs yet for this project.</p>
       ) : (
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-1.5">
           {projectConfigs.map((cfg) => (
             <button
               key={cfg.id}
@@ -112,7 +116,7 @@ export default function SavedConfigPicker({
                 onLoad(cfg.config);
                 toast.success(`Loaded "${cfg.name}"`);
               }}
-              className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-200 rounded-full hover:border-blue-400 hover:text-blue-700 hover:bg-blue-50 transition-colors"
+              className="h-[26px] px-2.5 rounded-full border border-border bg-surface text-ink-2 text-xs font-medium cursor-pointer transition-colors hover:border-primary hover:text-primary hover:bg-primary-soft"
             >
               {cfg.name}
             </button>

--- a/localcloud-gui/src/components/ServiceStatusBadge.tsx
+++ b/localcloud-gui/src/components/ServiceStatusBadge.tsx
@@ -9,6 +9,7 @@ import {
   keycloakApi,
   posthogApi,
 } from "@/services/api";
+import { StatusDot, type StatusTone } from "./ui";
 
 export type ServiceKey =
   | "aws-emulator"
@@ -76,22 +77,31 @@ async function fetchStatus(service: ServiceKey): Promise<StatusState> {
   }
 }
 
-const dotClass: Record<StatusLevel, string> = {
-  running: "bg-green-500 animate-pulse",
-  degraded: "bg-yellow-500 animate-pulse",
-  starting: "bg-yellow-400 animate-pulse",
-  stopped: "bg-gray-400",
-  failed: "bg-red-500",
-  unknown: "bg-gray-400",
+const levelTone: Record<StatusLevel, StatusTone> = {
+  running: "success",
+  degraded: "warn",
+  starting: "warn",
+  stopped: "neutral",
+  failed: "danger",
+  unknown: "neutral",
 };
 
-const badgeClass: Record<StatusLevel, string> = {
-  running: "bg-green-100 text-green-800",
-  degraded: "bg-yellow-100 text-yellow-800",
-  starting: "bg-yellow-100 text-yellow-700",
-  stopped: "bg-gray-100 text-gray-600",
-  failed: "bg-red-100 text-red-800",
-  unknown: "bg-gray-100 text-gray-600",
+const levelPulse: Record<StatusLevel, boolean> = {
+  running: false,
+  degraded: true,
+  starting: true,
+  stopped: false,
+  failed: false,
+  unknown: false,
+};
+
+const levelTextTone: Record<StatusLevel, string> = {
+  running: "text-ink-2",
+  degraded: "text-warn-ink",
+  starting: "text-warn-ink",
+  stopped: "text-muted",
+  failed: "text-danger-ink",
+  unknown: "text-muted",
 };
 
 interface ServiceStatusBadgeProps {
@@ -127,14 +137,10 @@ export default function ServiceStatusBadge({
   }, [service, refreshMs]);
 
   return (
-    <div className="flex items-center space-x-2 px-3 py-1.5 bg-gray-50 border border-gray-200 rounded-full">
-      <span
-        className={`h-2 w-2 rounded-full shrink-0 ${dotClass[status.level]}`}
-      />
-      <span className="text-xs font-medium text-gray-600">{name}</span>
-      <span
-        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold ${badgeClass[status.level]}`}
-      >
+    <div className="inline-flex items-center gap-2 h-8 px-3 bg-surface border border-border rounded-full">
+      <StatusDot tone={levelTone[status.level]} pulse={levelPulse[status.level]} />
+      <span className="text-xs font-medium text-ink-2">{name}</span>
+      <span className={`text-xs font-semibold ${levelTextTone[status.level]}`}>
         {status.label}
       </span>
     </div>

--- a/localcloud-gui/src/components/StatusCard.tsx
+++ b/localcloud-gui/src/components/StatusCard.tsx
@@ -1,94 +1,64 @@
 import { EmulatorStatus } from "@/types";
-import {
-  CheckCircleIcon,
-  XCircleIcon,
-  QuestionMarkCircleIcon,
-  ClockIcon,
-} from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
+import { Card, Badge } from "./ui";
+import type { StatusTone } from "./ui";
 
 interface StatusCardProps {
   status: EmulatorStatus;
 }
 
 export default function StatusCard({ status }: StatusCardProps) {
-  const getStatusIcon = () => {
-    switch (status.health) {
-      case "healthy":
-        return <CheckCircleIcon className="h-6 w-6 text-green-500" />;
-      case "unhealthy":
-        return <XCircleIcon className="h-6 w-6 text-red-500" />;
-      default:
-        return <QuestionMarkCircleIcon className="h-6 w-6 text-gray-400" />;
-    }
-  };
+  const tone: StatusTone =
+    status.health === "healthy"
+      ? "success"
+      : status.health === "unhealthy"
+        ? "danger"
+        : "neutral";
 
-  const getStatusColor = () => {
-    switch (status.health) {
-      case "healthy":
-        return "text-green-600 bg-green-50 border-green-200";
-      case "unhealthy":
-        return "text-red-600 bg-red-50 border-red-200";
-      default:
-        return "text-gray-600 bg-gray-50 border-gray-200";
-    }
-  };
-
-  const getStatusText = () => {
-    if (!status.running) return "Stopped";
-    switch (status.health) {
-      case "healthy":
-        return "Running";
-      case "unhealthy":
-        return "Unhealthy";
-      default:
-        return "Unknown";
-    }
-  };
+  const statusText = !status.running
+    ? "Stopped"
+    : status.health === "healthy"
+      ? "Running"
+      : status.health === "unhealthy"
+        ? "Unhealthy"
+        : "Unknown";
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          {getStatusIcon()}
+    <Card className="p-6">
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div className="flex items-center gap-4">
+          <span className="flex items-center justify-center w-11 h-11 rounded-lg bg-primary-soft text-primary">
+            <Icon icon="lucide:server" width={22} />
+          </span>
           <div>
-            <h3 className="text-lg font-medium text-gray-900">AWS Emulator</h3>
-            <p className="text-sm text-gray-500">{status.endpoint}</p>
+            <h3 className="text-base font-semibold text-ink">AWS Emulator</h3>
+            <p className="text-sm text-muted font-mono">{status.endpoint}</p>
           </div>
         </div>
-        <div className="text-right">
-          <span
-            className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${getStatusColor()}`}
-          >
-            {getStatusText()}
-          </span>
-        </div>
+        <Badge tone={tone}>{statusText}</Badge>
       </div>
 
       {status.running && status.uptime && (
-        <div className="mt-4 flex items-center text-sm text-gray-500">
-          <ClockIcon className="h-4 w-4 mr-2" />
+        <div className="mt-4 flex items-center gap-2 text-sm text-muted">
+          <Icon icon="lucide:clock" width={15} />
           Uptime: {status.uptime}
         </div>
       )}
 
       <div className="mt-4 grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
-          <dt className="text-sm font-medium text-gray-500">Status</dt>
-          <dd className="mt-1 text-sm text-gray-900">{getStatusText()}</dd>
+          <dt className="text-xs font-medium text-muted">Status</dt>
+          <dd className="mt-1 text-sm text-ink">{statusText}</dd>
         </div>
         <div>
-          <dt className="text-sm font-medium text-gray-500">Health</dt>
-          <dd className="mt-1 text-sm text-gray-900 capitalize">
-            {status.health}
-          </dd>
+          <dt className="text-xs font-medium text-muted">Health</dt>
+          <dd className="mt-1 text-sm text-ink capitalize">{status.health}</dd>
         </div>
         <div>
-          <dt className="text-sm font-medium text-gray-500">Endpoint</dt>
-          <dd className="mt-1 text-sm text-gray-900 font-mono">
-            {status.endpoint}
-          </dd>
+          <dt className="text-xs font-medium text-muted">Endpoint</dt>
+          <dd className="mt-1 text-sm text-ink font-mono">{status.endpoint}</dd>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/localcloud-gui/src/components/ThemeableCodeBlock.tsx
+++ b/localcloud-gui/src/components/ThemeableCodeBlock.tsx
@@ -5,8 +5,8 @@ import hljs from "highlight.js";
 import { highlightThemes, HighlightTheme } from "./highlightThemes";
 import { usePreferences } from "@/context/PreferencesContext";
 import type { HighlightTheme as ProfileHighlightTheme } from "@/types";
-import { ClipboardDocumentIcon } from "@heroicons/react/24/outline";
 import { toast } from "react-hot-toast";
+import { IconButton } from "./ui";
 
 import "highlight.js/lib/languages/javascript";
 import "highlight.js/lib/languages/typescript";
@@ -94,7 +94,7 @@ export default function ThemeableCodeBlock({
           <>
             <label
               htmlFor="samples-theme-select"
-              className="text-xs font-medium text-gray-600"
+              className="text-xs font-medium text-muted"
             >
               Theme:
             </label>
@@ -106,7 +106,7 @@ export default function ThemeableCodeBlock({
                 setSelectedTheme(theme);
                 updateProfile({ highlight_theme: theme as ProfileHighlightTheme }).catch(() => {});
               }}
-              className="text-sm border border-gray-300 rounded px-2 py-1 bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="text-xs border border-border-strong rounded-md px-2 py-1 bg-surface text-ink outline-none focus:border-primary focus:ring-3 focus:ring-focus"
             >
               {Object.keys(highlightThemes).map((key) => (
                 <option key={key} value={key}>
@@ -117,13 +117,7 @@ export default function ThemeableCodeBlock({
           </>
         )}
         {showCopyButton && (
-        <button
-          onClick={copy}
-          className="p-1.5 rounded text-gray-500 hover:text-gray-700 hover:bg-gray-100"
-          title="Copy"
-        >
-          <ClipboardDocumentIcon className="h-4 w-4" />
-        </button>
+          <IconButton icon="lucide:copy" variant="outline" size="sm" label="Copy" onClick={copy} />
         )}
       </div>
       )}

--- a/localcloud-gui/src/components/ThemeableCodeBlock.tsx
+++ b/localcloud-gui/src/components/ThemeableCodeBlock.tsx
@@ -13,6 +13,8 @@ import "highlight.js/lib/languages/typescript";
 import "highlight.js/lib/languages/python";
 import "highlight.js/lib/languages/bash";
 import "highlight.js/lib/languages/php";
+import "highlight.js/lib/languages/go";
+import "highlight.js/lib/languages/java";
 
 const THEME_LINK_ID = "hljs-theme-docs";
 
@@ -29,6 +31,8 @@ const languageMap: Record<string, string> = {
   laravel: "php",
   django: "python",
   flask: "python",
+  go: "go",
+  java: "java",
 };
 
 interface ThemeableCodeBlockProps {

--- a/localcloud-gui/src/components/UploadFileModal.tsx
+++ b/localcloud-gui/src/components/UploadFileModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { XMarkIcon, DocumentIcon } from "@heroicons/react/24/outline";
+import { Icon } from "@iconify/react";
 import { s3Api } from "@/services/api";
 import { toast } from "react-hot-toast";
+import { Button, IconButton } from "@/components/ui";
 
 interface UploadFileModalProps {
   isOpen: boolean;
@@ -125,87 +126,83 @@ export default function UploadFileModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-60">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-scrim p-4">
+      <div className="bg-surface border border-border rounded-xl shadow-e3 w-full max-w-2xl max-h-[90vh] flex flex-col overflow-hidden">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <div className="flex items-center space-x-3">
-            <DocumentIcon className="h-6 w-6 text-blue-500" />
-            <h2 className="text-xl font-bold text-gray-900">
-              Upload File to {bucketName}
-            </h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-divider shrink-0">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center justify-center w-9 h-9 rounded-lg bg-primary-soft text-primary">
+              <Icon icon="lucide:upload" width={17} />
+            </span>
+            <div>
+              <h2 className="text-base font-semibold text-ink">Upload file</h2>
+              <p className="text-xs text-muted font-mono">{bucketName}</p>
+            </div>
           </div>
-          <button
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600"
-            aria-label="Close"
-          >
-            <XMarkIcon className="h-6 w-6" />
-          </button>
+          <IconButton icon="lucide:x" label="Close" variant="ghost" onClick={onClose} />
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-4">
+        <div className="p-6 space-y-4 overflow-y-auto">
           {/* File Upload */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              Upload File
+            <label className="block text-xs font-medium text-ink-2 mb-1.5">
+              Choose file
             </label>
             <input
               type="file"
               onChange={handleFileUpload}
-              className="block w-full text-sm text-gray-900 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+              className="block w-full text-sm text-ink-2 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border-0 file:text-xs file:font-medium file:bg-primary-soft file:text-primary-ink hover:file:bg-primary-soft/80 cursor-pointer"
             />
           </div>
 
           {/* Object Key */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              File Name (Object Key)
+            <label className="block text-xs font-medium text-ink-2 mb-1.5">
+              File name (object key)
             </label>
             <input
               type="text"
               value={objectKey}
               onChange={(e) => setObjectKey(e.target.value)}
-              placeholder="Enter file name (e.g., myfile.txt)"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 placeholder-gray-500"
+              placeholder="e.g. seed/users.json"
+              className="w-full h-9 px-3 rounded-lg border border-border-strong bg-surface-2 font-mono text-[13px] text-ink outline-none transition-colors placeholder:text-faint focus:bg-surface focus:border-primary focus:ring-3 focus:ring-focus"
             />
           </div>
 
           {/* Content */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              File Content
+            <label className="block text-xs font-medium text-ink-2 mb-1.5">
+              File content
             </label>
             <textarea
               value={content}
               onChange={(e) => setContent(e.target.value)}
-              placeholder="Enter file content..."
+              placeholder="Enter file content…"
               rows={10}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm text-gray-900 placeholder-gray-500"
+              className="w-full px-3 py-2 rounded-lg border border-border-strong bg-surface-2 font-mono text-[13px] leading-relaxed text-ink outline-none transition-colors placeholder:text-faint focus:bg-surface focus:border-primary focus:ring-3 focus:ring-focus resize-vertical"
             />
           </div>
         </div>
 
         {/* Footer */}
-        <div className="flex items-center justify-end space-x-3 p-6 border-t border-gray-200">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
+        <div className="flex items-center justify-end gap-2.5 px-6 py-4 border-t border-divider shrink-0">
+          <Button variant="secondary" onClick={onClose} disabled={uploading}>
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            icon={uploading ? undefined : "lucide:upload"}
+            loading={uploading}
             onClick={handleUpload}
             disabled={
               uploading ||
               !objectKey.trim() ||
               (!selectedFile && !content.trim())
             }
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {uploading ? "Uploading..." : "Upload File"}
-          </button>
+            {uploading ? "Uploading…" : "Upload file"}
+          </Button>
         </div>
       </div>
     </div>

--- a/localcloud-gui/src/components/ui/Badge.tsx
+++ b/localcloud-gui/src/components/ui/Badge.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+import { cn } from "./cn";
+import { StatusDot, type StatusTone } from "./StatusDot";
+
+const toneClasses: Record<StatusTone, string> = {
+  success: "bg-success-soft text-success-ink",
+  danger: "bg-danger-soft text-danger-ink",
+  warn: "bg-warn-soft text-warn-ink",
+  neutral: "bg-surface-3 text-muted",
+};
+
+export function Badge({
+  tone,
+  pulse = false,
+  children,
+  className,
+}: {
+  tone: StatusTone;
+  pulse?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-semibold whitespace-nowrap",
+        toneClasses[tone],
+        className
+      )}
+    >
+      <StatusDot tone={tone} pulse={pulse} />
+      {children}
+    </span>
+  );
+}

--- a/localcloud-gui/src/components/ui/Button.tsx
+++ b/localcloud-gui/src/components/ui/Button.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { Icon } from "@iconify/react";
+import { cn } from "./cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
+export type ButtonSize = "sm" | "md";
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-primary text-white hover:bg-primary-hover disabled:hover:bg-primary",
+  secondary:
+    "border border-border-strong bg-surface text-ink-2 hover:bg-surface-2 disabled:hover:bg-surface",
+  ghost:
+    "text-muted hover:bg-surface-3 hover:text-ink disabled:hover:bg-transparent disabled:hover:text-muted",
+  danger: "bg-danger text-white hover:bg-danger-hover disabled:hover:bg-danger",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "h-7 px-2.5 text-xs gap-1.5",
+  md: "h-8 px-3.5 text-[13px] gap-1.5",
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  icon?: string;
+  loading?: boolean;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = "secondary",
+      size = "md",
+      icon,
+      loading = false,
+      disabled,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <button
+        ref={ref}
+        disabled={disabled || loading}
+        className={cn(
+          "inline-flex items-center justify-center rounded-lg font-sans font-medium whitespace-nowrap transition-colors cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      >
+        {loading ? (
+          <Icon icon="lucide:loader-2" width={size === "sm" ? 13 : 15} className="animate-spin" />
+        ) : icon ? (
+          <Icon icon={icon} width={size === "sm" ? 13 : 15} />
+        ) : null}
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/localcloud-gui/src/components/ui/Card.tsx
+++ b/localcloud-gui/src/components/ui/Card.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "bg-surface border border-border rounded-xl shadow-e1 overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/localcloud-gui/src/components/ui/IconButton.tsx
+++ b/localcloud-gui/src/components/ui/IconButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { Icon } from "@iconify/react";
+import { cn } from "./cn";
+
+export type IconButtonVariant = "outline" | "ghost";
+export type IconButtonSize = "sm" | "md";
+
+const variantClasses: Record<IconButtonVariant, string> = {
+  outline:
+    "border border-border-strong bg-surface text-ink-2 hover:bg-surface-2",
+  ghost: "text-faint hover:bg-surface-3 hover:text-ink",
+};
+
+const sizeClasses: Record<IconButtonSize, string> = {
+  sm: "w-7 h-7 rounded-md",
+  md: "w-8 h-8 rounded-lg",
+};
+
+export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: string;
+  variant?: IconButtonVariant;
+  size?: IconButtonSize;
+  label: string;
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ icon, variant = "outline", size = "md", label, className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        aria-label={label}
+        title={label}
+        className={cn(
+          "inline-flex items-center justify-center cursor-pointer transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        {...props}
+      >
+        <Icon icon={icon} width={size === "sm" ? 13 : 15} />
+      </button>
+    );
+  }
+);
+
+IconButton.displayName = "IconButton";

--- a/localcloud-gui/src/components/ui/Input.tsx
+++ b/localcloud-gui/src/components/ui/Input.tsx
@@ -1,0 +1,29 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "./cn";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  mono?: boolean;
+  invalid?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ mono = false, invalid = false, className, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={cn(
+          "h-8 px-2.5 rounded-lg border bg-surface-2 text-[13px] text-ink outline-none transition-colors placeholder:text-faint",
+          "focus:bg-surface focus:ring-3 focus:ring-focus",
+          mono && "font-mono",
+          invalid
+            ? "border-danger focus:border-danger"
+            : "border-border-strong focus:border-primary",
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = "Input";

--- a/localcloud-gui/src/components/ui/SearchInput.tsx
+++ b/localcloud-gui/src/components/ui/SearchInput.tsx
@@ -1,0 +1,27 @@
+import type { InputHTMLAttributes } from "react";
+import { Icon } from "@iconify/react";
+import { cn } from "./cn";
+
+export function SearchInput({
+  className,
+  containerClassName,
+  ...props
+}: InputHTMLAttributes<HTMLInputElement> & { containerClassName?: string }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1.5 h-8 px-2.5 rounded-lg border border-border-strong bg-surface-2 min-w-[160px]",
+        containerClassName
+      )}
+    >
+      <Icon icon="lucide:search" width={14} className="text-faint shrink-0" />
+      <input
+        className={cn(
+          "flex-1 min-w-0 border-none bg-transparent text-[13px] text-ink outline-none placeholder:text-faint",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/ui/SegmentedControl.tsx
+++ b/localcloud-gui/src/components/ui/SegmentedControl.tsx
@@ -1,0 +1,43 @@
+import { cn } from "./cn";
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export function SegmentedControl<T extends string>({
+  options,
+  value,
+  onChange,
+  className,
+}: {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "inline-flex p-0.5 gap-0.5 bg-surface-3 rounded-lg w-fit",
+        className
+      )}
+    >
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+          className={cn(
+            "h-[26px] px-3 rounded-md text-xs font-medium font-sans cursor-pointer transition-colors",
+            value === option.value
+              ? "bg-surface text-ink shadow-e1"
+              : "bg-transparent text-muted hover:text-ink"
+          )}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/localcloud-gui/src/components/ui/StatusDot.tsx
+++ b/localcloud-gui/src/components/ui/StatusDot.tsx
@@ -1,0 +1,31 @@
+import { cn } from "./cn";
+
+export type StatusTone = "success" | "danger" | "warn" | "neutral";
+
+const toneClasses: Record<StatusTone, string> = {
+  success: "bg-success",
+  danger: "bg-danger",
+  warn: "bg-warn",
+  neutral: "bg-faint",
+};
+
+export function StatusDot({
+  tone,
+  pulse = false,
+  className,
+}: {
+  tone: StatusTone;
+  pulse?: boolean;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-block w-1.5 h-1.5 rounded-full",
+        toneClasses[tone],
+        pulse && "animate-pulse",
+        className
+      )}
+    />
+  );
+}

--- a/localcloud-gui/src/components/ui/cn.ts
+++ b/localcloud-gui/src/components/ui/cn.ts
@@ -1,0 +1,5 @@
+import { clsx, type ClassValue } from "clsx";
+
+export function cn(...inputs: ClassValue[]) {
+  return clsx(inputs);
+}

--- a/localcloud-gui/src/components/ui/index.ts
+++ b/localcloud-gui/src/components/ui/index.ts
@@ -1,0 +1,9 @@
+export { cn } from "./cn";
+export { Button, type ButtonProps, type ButtonVariant, type ButtonSize } from "./Button";
+export { IconButton, type IconButtonProps, type IconButtonVariant, type IconButtonSize } from "./IconButton";
+export { StatusDot, type StatusTone } from "./StatusDot";
+export { Badge } from "./Badge";
+export { Input, type InputProps } from "./Input";
+export { SearchInput } from "./SearchInput";
+export { Card } from "./Card";
+export { SegmentedControl, type SegmentedOption } from "./SegmentedControl";

--- a/localcloud-gui/src/context/PreferencesContext.tsx
+++ b/localcloud-gui/src/context/PreferencesContext.tsx
@@ -57,6 +57,14 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     loadAll();
   }, [loadAll]);
 
+  useEffect(() => {
+    if (!profile?.theme || profile.theme === "auto") {
+      document.documentElement.removeAttribute("data-theme");
+    } else {
+      document.documentElement.setAttribute("data-theme", profile.theme);
+    }
+  }, [profile?.theme]);
+
   const updateProfile = useCallback(async (data: Partial<UserProfile>) => {
     const updated = await profileApi.update(data);
     setProfile(updated);

--- a/localcloud-gui/src/types/index.ts
+++ b/localcloud-gui/src/types/index.ts
@@ -201,6 +201,8 @@ export type HighlightTheme =
   | "atom-one-dark"
   | "atom-one-light";
 
+export type ThemePreference = "auto" | "light" | "dark";
+
 export interface Project {
   id: number;
   name: string;
@@ -213,6 +215,7 @@ export interface UserProfile {
   id: number;
   preferred_language: PreferredLanguage;
   highlight_theme: HighlightTheme;
+  theme: ThemePreference;
   display_name: string;
   active_project_id: number | null;
   active_project_name: string | null;

--- a/localcloud-gui/tailwind.config.js
+++ b/localcloud-gui/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: [
+          "var(--font-plex-sans)",
           "system-ui",
           "-apple-system",
           "BlinkMacSystemFont",
@@ -14,6 +15,7 @@ module.exports = {
           "sans-serif",
         ],
         mono: [
+          "var(--font-plex-mono)",
           "SF Mono",
           "Monaco",
           "Inconsolata",


### PR DESCRIPTION
## Summary

- **Design System**: Implemented IBM Plex Sans/Mono typography, indigo-accent design tokens with light/dark palettes, and a shared UI component library (Button, IconButton, Badge, Input, SearchInput, Card, SegmentedControl, StatusDot)
- **Dark Mode Support**: Added automatic theme detection and manual light/dark/auto preference toggle in profile settings
- **Component Migration**: Refactored 15+ components to use new UI primitives and design tokens, replacing hardcoded Tailwind classes and Heroicons with Iconify icons
- **Token System**: Centralized color, spacing, and typography via CSS custom properties in `globals.css` for consistent theming across light and dark modes

## Type of change

- [x] `feat` — new feature
- [x] `refactor` — code restructure, no behavior change
- [x] `build` / `chore` — infra, deps, tooling

## Details

### Design System & Tokens
- Added comprehensive CSS custom properties (`--bg`, `--surface`, `--ink`, `--primary`, `--danger`, `--success`, `--warn`, etc.) with light/dark variants
- Created reusable UI component library in `src/components/ui/`:
  - `Button.tsx` — primary/secondary/ghost/danger variants with icon support
  - `IconButton.tsx` — outline/ghost variants for icon-only actions
  - `Badge.tsx` — status badges with tone-based styling (success/danger/warn/neutral)
  - `Input.tsx` — text input with optional mono font and invalid state
  - `SearchInput.tsx` — search field with magnifying glass icon
  - `Card.tsx` — surface container with border and shadow
  - `SegmentedControl.tsx` — tab-like control for option selection
  - `StatusDot.tsx` — colored indicator dot for status visualization
  - `cn.ts` — utility for conditional class merging (clsx wrapper)

### Theme Support
- Added `ThemePreference` type (`"auto" | "light" | "dark"`) to profile schema
- Updated `PreferencesContext` to apply theme class to `<html>` element and respect `prefers-color-scheme`
- Added theme toggle in `DashboardNavBar` with SegmentedControl
- Profile API now persists theme preference in database

### Component Migrations
Refactored the following components to use new UI primitives and design tokens:
- `ResourceList.tsx` — replaced Heroicons with Iconify, uses new Badge/Button/SearchInput
- `DashboardNavBar.tsx` — migrated to SegmentedControl for theme/language selection, uses new UI components
- `DynamoDBViewer.tsx` — updated modal styling, replaced hardcoded colors with tokens
- `DynamoDBConfigModal.tsx` — uses new Button/IconButton/Input/SegmentedControl
- `S3ConfigModal.tsx` — migrated to new UI components and design tokens
- `BucketViewer.tsx` — uses new Button/IconButton components
- `DynamoDBAddItemModal.tsx` — added TypeSelect component with new styling
- `DynamoDBItemDetailPanel.tsx` — refactored layout with new token colors
- `CliPlaybookSection.tsx` — uses Badge with StatusTone for recipe source labels
- `ConnectionGuide.tsx` — replaced CodeBlock with ThemeableCodeBlock, uses new Button/IconButton
- `FileViewerModal.tsx` — uses new Button/IconButton
- `UploadFileModal.tsx` — migrated to new UI components
- `SavedConfigPicker.tsx` — uses new Button/Input
- `StatusCard.tsx` — uses new Card/Badge/StatusDot
- `RedisModal.tsx` — uses new Badge/IconButton
- `ServiceStatusBadge.tsx` — uses new StatusDot component
- `Dashboard.tsx` — uses new Button/StatusDot
- `ManageS3Page.tsx` — added file type detection with Iconify icons, uses new Button/Card/SearchInput
- `ManageDynamoDBPage.tsx` — uses new Button/IconButton
- `

https://claude.ai/code/session_01LsbimvP238CKcDVMuWK49Z